### PR TITLE
Enhance dispute-detail archetype with layout fixes and new features

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "5.1.0",
-  "archetypesVersion": "6.2",
+  "archetypesVersion": "6.3",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -397,7 +397,7 @@
         },
         {
           "name": "dispute-content-layout-fixes.js",
-          "version": "1.0"
+          "version": "1.1"
         },
         {
           "name": "clear-search.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "5.1.0",
-  "archetypesVersion": "6.3",
+  "archetypesVersion": "6.4",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -396,8 +396,12 @@
           "version": "1.0"
         },
         {
+          "name": "dispute-detail-task-id.js",
+          "version": "1.0"
+        },
+        {
           "name": "dispute-content-layout-fixes.js",
-          "version": "1.1"
+          "version": "1.2"
         },
         {
           "name": "clear-search.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "5.1.0",
-  "archetypesVersion": "6.1",
+  "archetypesVersion": "6.2",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -381,6 +381,47 @@
         {
           "name": "dispute-ids-enhancer.js",
           "version": "2.3"
+        }
+      ]
+    },
+    {
+      "id": "dispute-detail",
+      "name": "Dispute Detail Page",
+      "description": "Page for reviewing a single writer dispute",
+      "urlPattern": "work/problems/disputes/*",
+      "disambiguationSelectors": [],
+      "plugins": [
+        {
+          "name": "env-load-gate.js",
+          "version": "1.0"
+        },
+        {
+          "name": "dispute-content-layout-fixes.js",
+          "version": "1.0"
+        },
+        {
+          "name": "clear-search.js",
+          "version": "1.0"
+        },
+        {
+          "name": "favorites.js",
+          "version": "1.0"
+        },
+        {
+          "name": "execute-to-current-tool.js",
+          "version": "1.0"
+        },
+        {
+          "name": "toggle-tool-parameters.js",
+          "version": "1.0"
+        },
+        {
+          "name": "tool-results-resize-handle.js",
+          "version": "1.0"
+        },
+        {
+          "name": "tool-description-truncate.js",
+          "version": "1.0"
         }
       ]
     }

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [dev] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.1.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/dev/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/dev/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'dev',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/clear-search.js
+++ b/plugins/archetypes/dispute-detail/main/clear-search.js
@@ -1,0 +1,105 @@
+// ============= clear-search.js =============
+// Adds an X-in-circle button to the tool search input that clears the search when clicked.
+
+const plugin = {
+    id: 'disputeDetailClearSearch',
+    name: 'Clear Tool Search',
+    description: 'Adds a clear `X` button to the tool search box when it has text',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, envWaitingLogged: false },
+
+    selectors: {
+        searchInput: '[data-ui="tools-search"]',
+        searchInputFallback: 'input[placeholder="Search tools, descriptions, parameters..."]'
+    },
+
+    onMutation(state) {
+        if (!this.isToolEnvReady()) {
+            if (!state.envWaitingLogged) {
+                Logger.debug('Dispute clear-search: waiting for tool environment');
+                state.envWaitingLogged = true;
+            }
+            return;
+        }
+        state.envWaitingLogged = false;
+
+        const searchInput = document.querySelector(this.selectors.searchInput) || Context.dom.query(this.selectors.searchInputFallback, { context: `${this.id}.searchInput` });
+        if (!searchInput) {
+            if (!state.missingLogged) {
+                Logger.debug('Search input not found for clear-search');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        if (searchInput.hasAttribute('data-wf-clear-search-added')) {
+            return;
+        }
+
+        const wrapper = searchInput.closest('.relative');
+        if (!wrapper) {
+            Logger.warn('Clear search: wrapper .relative not found for search input');
+            return;
+        }
+
+        const rightDiv = wrapper.querySelector('div.absolute.right-2');
+        if (!rightDiv) {
+            Logger.warn('Clear search: right div (absolute right-2) not found');
+            return;
+        }
+
+        const clearBtn = document.createElement('button');
+        clearBtn.type = 'button';
+        clearBtn.setAttribute('aria-label', 'Clear search');
+        clearBtn.title = 'Clear search';
+        clearBtn.className = 'wf-clear-search-btn flex items-center justify-center size-6 rounded-full border-0 bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring cursor-pointer ml-1 flex-shrink-0';
+        clearBtn.innerHTML = `
+            <svg class="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+        `;
+        clearBtn.style.display = 'none';
+
+        const updateVisibility = () => {
+            const hasText = (searchInput.value || '').trim().length > 0;
+            clearBtn.style.display = hasText ? 'flex' : 'none';
+        };
+
+        clearBtn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+                window.HTMLInputElement.prototype,
+                'value'
+            )?.set;
+            if (nativeInputValueSetter) {
+                nativeInputValueSetter.call(searchInput, '');
+            } else {
+                searchInput.value = '';
+            }
+            searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+            searchInput.dispatchEvent(new Event('change', { bubbles: true }));
+            searchInput.focus();
+            updateVisibility();
+            Logger.debug('Tool search cleared');
+        });
+
+        searchInput.addEventListener('input', updateVisibility);
+        searchInput.addEventListener('keyup', updateVisibility);
+        updateVisibility();
+
+        rightDiv.style.display = 'flex';
+        rightDiv.style.alignItems = 'center';
+        rightDiv.style.gap = '4px';
+        rightDiv.insertBefore(clearBtn, rightDiv.firstChild);
+        searchInput.setAttribute('data-wf-clear-search-added', 'true');
+
+        Logger.log('✓ Clear search button added to tool search');
+    },
+
+    isToolEnvReady() {
+        return document.documentElement.getAttribute('data-fleet-dispute-tool-env-ready') === '1';
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/dispute-content-layout-fixes.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-content-layout-fixes.js
@@ -1,0 +1,64 @@
+// ============= dispute-content-layout-fixes.js =============
+// Targeted layout fixes for dispute detail text blocks and action buttons.
+
+const STYLE_ID = 'fleet-dispute-detail-layout-fixes-style';
+
+const plugin = {
+    id: 'disputeContentLayoutFixes',
+    name: 'Dispute Content Layout Fixes',
+    description: 'Fixes text whitespace handling and action button visibility in dispute detail panel',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        appliedLogged: false
+    },
+
+    onMutation(state) {
+        this.ensureStyle();
+        if (!state.appliedLogged) {
+            Logger.log('Dispute Content Layout Fixes: styles applied');
+            state.appliedLogged = true;
+        }
+    },
+
+    ensureStyle() {
+        let style = document.getElementById(STYLE_ID);
+        if (!style) {
+            style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.setAttribute('data-fleet-plugin', this.id);
+            document.head.appendChild(style);
+        }
+
+        style.textContent = `
+            /* Preserve whitespace/newlines in disputed QA feedback text */
+            [data-state="open"] .rounded-lg.border.bg-muted\\/50 .space-y-2.text-sm > p,
+            [data-state="open"] .rounded-lg.border.bg-muted\\/50 .space-y-2.text-sm > div {
+                white-space: pre-wrap !important;
+                overflow-wrap: anywhere !important;
+                word-break: break-word !important;
+            }
+
+            /* Keep dispute action bar visible and usable in constrained sizes */
+            .border-t.pt-4 > .flex.items-center.justify-end.gap-2.mt-4 {
+                flex-wrap: nowrap !important;
+                overflow-x: auto !important;
+                overflow-y: hidden !important;
+                padding-bottom: 4px !important;
+                scrollbar-width: thin;
+            }
+
+            .border-t.pt-4 > .flex.items-center.justify-end.gap-2.mt-4 > button {
+                flex: 0 0 auto !important;
+            }
+
+            .border-t.pt-4 {
+                position: sticky;
+                bottom: 0;
+                z-index: 10;
+                background: var(--background, inherit);
+            }
+        `;
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/dispute-content-layout-fixes.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-content-layout-fixes.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'disputeContentLayoutFixes',
     name: 'Dispute Content Layout Fixes',
     description: 'Fixes text whitespace handling and action button visibility in dispute detail panel',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -40,13 +40,11 @@ const plugin = {
                 word-break: break-word !important;
             }
 
-            /* Keep dispute action bar visible and usable in constrained sizes */
+            /* Keep dispute action bar visible: wrap buttons when panel is too narrow */
             .border-t.pt-4 > .flex.items-center.justify-end.gap-2.mt-4 {
-                flex-wrap: nowrap !important;
-                overflow-x: auto !important;
-                overflow-y: hidden !important;
-                padding-bottom: 4px !important;
-                scrollbar-width: thin;
+                flex-wrap: wrap !important;
+                gap: 0.5rem !important;
+                min-width: 0 !important;
             }
 
             .border-t.pt-4 > .flex.items-center.justify-end.gap-2.mt-4 > button {

--- a/plugins/archetypes/dispute-detail/main/dispute-content-layout-fixes.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-content-layout-fixes.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'disputeContentLayoutFixes',
     name: 'Dispute Content Layout Fixes',
     description: 'Fixes text whitespace handling and action button visibility in dispute detail panel',
-    _version: '1.1',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -32,6 +32,17 @@ const plugin = {
         }
 
         style.textContent = `
+            /* Dispute detail header row: wrap when panel is narrow so nothing goes off screen */
+            .p-4 > .flex.items-center.justify-between.mb-2 {
+                flex-wrap: wrap !important;
+                gap: 0.5rem !important;
+                min-width: 0 !important;
+            }
+            .p-4 > .flex.items-center.justify-between.mb-2 > .flex.items-center.gap-2 {
+                flex-wrap: wrap !important;
+                min-width: 0 !important;
+            }
+
             /* Preserve whitespace/newlines in disputed QA feedback text */
             [data-state="open"] .rounded-lg.border.bg-muted\\/50 .space-y-2.text-sm > p,
             [data-state="open"] .rounded-lg.border.bg-muted\\/50 .space-y-2.text-sm > div {

--- a/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
@@ -1,0 +1,94 @@
+// ============= dispute-detail-task-id.js =============
+// Injects a copyable Task ID button in the dispute detail header (from View Task link).
+
+const VIEW_TASK_PATH_PREFIX = '/work/problems/view-task/';
+const COPY_STYLE_ID = 'fleet-dispute-detail-task-id-copy-style';
+const COPY_BTN_CLASS = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-7 rounded-sm pl-2 pr-2 text-xs font-mono';
+
+const plugin = {
+    id: 'disputeDetailTaskId',
+    name: 'Dispute Detail Task ID',
+    description: 'Shows a copyable Task ID in the dispute detail header from the View Task link',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        injectedLogged: false,
+        missingLogged: false
+    },
+
+    onMutation(state) {
+        if (document.querySelector('[data-fleet-dispute-detail-task-id-injected]')) {
+            return;
+        }
+        const viewTaskLink = document.querySelector(`a[href*="${VIEW_TASK_PATH_PREFIX}"]`);
+        if (!viewTaskLink) {
+            if (!state.missingLogged) {
+                Logger.debug('Dispute Detail Task ID: View Task link not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        const taskId = this.getTaskIdFromHref(viewTaskLink.getAttribute('href') || '');
+        if (!taskId) {
+            Logger.debug('Dispute Detail Task ID: could not parse task ID from href');
+            return;
+        }
+        const rightGroup = viewTaskLink.closest('.flex.items-center.gap-2');
+        if (!rightGroup || !rightGroup.parentElement) {
+            Logger.warn('Dispute Detail Task ID: right header group not found');
+            return;
+        }
+        this.ensureCopyStyle();
+        const label = document.createElement('span');
+        label.className = 'text-xs text-muted-foreground font-medium';
+        label.textContent = 'Task:';
+        const copyBtn = this.buildCopyButton(taskId);
+        rightGroup.insertBefore(copyBtn, rightGroup.firstChild);
+        rightGroup.insertBefore(label, rightGroup.firstChild);
+        rightGroup.setAttribute('data-fleet-dispute-detail-task-id-injected', '1');
+        state.missingLogged = false;
+        if (!state.injectedLogged) {
+            Logger.log('Dispute Detail Task ID: injected copyable task ID in header');
+            state.injectedLogged = true;
+        }
+    },
+
+    getTaskIdFromHref(href) {
+        if (!href || typeof href !== 'string') return '';
+        const idx = href.indexOf(VIEW_TASK_PATH_PREFIX);
+        if (idx === -1) return '';
+        const start = idx + VIEW_TASK_PATH_PREFIX.length;
+        const rest = href.slice(start);
+        const end = rest.indexOf('/');
+        const id = end === -1 ? rest : rest.slice(0, end);
+        return id ? id.trim() : '';
+    },
+
+    ensureCopyStyle() {
+        if (document.getElementById(COPY_STYLE_ID)) return;
+        const style = document.createElement('style');
+        style.id = COPY_STYLE_ID;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = '.fleet-dispute-id-copied { background-color: rgb(22 163 74) !important; color: white !important; border-color: rgb(22 163 74) !important; }';
+        (document.head || document.documentElement).appendChild(style);
+    },
+
+    buildCopyButton(taskId) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = COPY_BTN_CLASS;
+        btn.textContent = taskId;
+        btn.title = 'Copy Task ID';
+        btn.addEventListener('click', () => {
+            navigator.clipboard.writeText(taskId).then(() => {
+                btn.classList.add('fleet-dispute-id-copied');
+                Logger.log('Dispute Detail Task ID: copied to clipboard');
+                setTimeout(() => btn.classList.remove('fleet-dispute-id-copied'), 3000);
+            }).catch((err) => {
+                Logger.error('Dispute Detail Task ID: failed to copy', err);
+            });
+        });
+        return btn;
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/env-load-gate.js
+++ b/plugins/archetypes/dispute-detail/main/env-load-gate.js
@@ -1,0 +1,84 @@
+// ============= env-load-gate.js =============
+// Tracks when a dispute detail page has loaded a tool environment.
+
+const plugin = {
+    id: 'disputeToolEnvGate',
+    name: 'Dispute Tool Environment Gate',
+    description: 'Detects tool environment readiness for dispute detail pages',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        observerAttached: false,
+        readyLogged: false,
+        waitingLogged: false
+    },
+
+    selectors: {
+        createInstanceButtonText: 'Create Instance',
+        toolsSearch: '[data-ui="tools-search"]',
+        toolsPanel: '[data-ui="tools-panel"]',
+        workflowPanel: '[data-ui="workflow-panel"]'
+    },
+
+    onMutation(state) {
+        if (!state.observerAttached) {
+            this.installObserver(state);
+            state.observerAttached = true;
+        }
+        this.updateReadyState(state);
+    },
+
+    installObserver(state) {
+        const observer = new MutationObserver(() => {
+            this.updateReadyState(state);
+        });
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true
+        });
+        CleanupRegistry.registerObserver(observer);
+        Logger.log('Dispute Tool Environment Gate: observer installed');
+    },
+
+    updateReadyState(state) {
+        const ready = this.isToolEnvironmentReady();
+        const root = document.documentElement;
+
+        if (ready) {
+            root.setAttribute('data-fleet-dispute-tool-env-ready', '1');
+            window.__fleetDisputeToolEnvReady = true;
+            if (!state.readyLogged) {
+                Logger.info('Dispute Tool Environment Gate: tool environment detected and marked ready');
+                state.readyLogged = true;
+            }
+            return;
+        }
+
+        root.removeAttribute('data-fleet-dispute-tool-env-ready');
+        window.__fleetDisputeToolEnvReady = false;
+
+        if (!state.waitingLogged) {
+            const createInstanceButton = this.findCreateInstanceButton();
+            if (createInstanceButton) {
+                Logger.log('Dispute Tool Environment Gate: waiting for tool environment load');
+            } else {
+                Logger.debug('Dispute Tool Environment Gate: create-instance button not detected yet');
+            }
+            state.waitingLogged = true;
+        }
+    },
+
+    findCreateInstanceButton() {
+        const buttons = Array.from(document.querySelectorAll('button'));
+        return buttons.find((btn) => (btn.textContent || '').trim() === this.selectors.createInstanceButtonText) || null;
+    },
+
+    isToolEnvironmentReady() {
+        const hasToolsSearch = !!document.querySelector(this.selectors.toolsSearch);
+        const hasToolsPanel = !!document.querySelector(this.selectors.toolsPanel);
+        const hasWorkflowPanel = !!document.querySelector(this.selectors.workflowPanel);
+        return hasToolsSearch && hasToolsPanel && hasWorkflowPanel;
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/execute-to-current-tool.js
+++ b/plugins/archetypes/dispute-detail/main/execute-to-current-tool.js
@@ -1,0 +1,209 @@
+// ============= execute-to-current-tool.js =============
+const plugin = {
+    id: 'disputeDetailExecuteToCurrentTool',
+    name: 'Execute to Current Tool',
+    description: 'Adds button to execute all tools from the beginning up to and including the current tool',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, panelId: null, lastToolsContainerMissingLogAt: 0, envWaitingLogged: false },
+
+    selectors: {
+        toolHeader: '[data-ui="step-header"]',
+        toolHeaderFallback: 'div.flex.items-center.gap-3.p-3.cursor-pointer.hover\\:bg-muted\\/30',
+        toolCard: '[data-ui="workflow-step"]',
+        toolCardFallback: 'div.rounded-lg.border.transition-colors'
+    },
+
+    onMutation(state) {
+        if (!this.isToolEnvReady()) {
+            if (!state.envWaitingLogged) {
+                Logger.debug('Execute-to-current: waiting for tool environment');
+                state.envWaitingLogged = true;
+            }
+            return;
+        }
+        state.envWaitingLogged = false;
+
+        const panel = this.findWorkflowPanel();
+        if (!panel) {
+            if (!state.missingLogged) {
+                Logger.log('⚠ Workflow panel not found for execute-to-current-tool');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        const currentPanelId = panel.getAttribute('data-panel-id');
+        if (state.panelId !== currentPanelId) {
+            state.panelId = currentPanelId;
+            state.missingLogged = false;
+        }
+
+        const toolsContainer = this.findToolsArea(panel);
+        if (!toolsContainer) {
+            const now = Date.now();
+            const rateLimitMs = 10000;
+            if (now - state.lastToolsContainerMissingLogAt >= rateLimitMs) {
+                Logger.log('⚠ Tools container not found for execute-to-current-tool');
+                state.lastToolsContainerMissingLogAt = now;
+            }
+            return;
+        }
+
+        const toolCardsByDataUi = toolsContainer.querySelectorAll(this.selectors.toolCard);
+        const toolCards = toolCardsByDataUi.length
+            ? Array.from(toolCardsByDataUi)
+            : Context.dom.queryAll(this.selectors.toolCardFallback, { root: toolsContainer, context: `${this.id}.toolCards` });
+        let buttonsAdded = 0;
+
+        toolCards.forEach(card => {
+            const collapsibleRoot = Context.dom.query('div[data-state]', { root: card, context: `${this.id}.collapsibleRoot` });
+            if (!collapsibleRoot) return;
+            const header = card.querySelector(this.selectors.toolHeader) || Context.dom.query(this.selectors.toolHeaderFallback, { root: card, context: `${this.id}.toolHeader` });
+            if (!header) return;
+            const buttonContainer = Context.dom.query('div.flex.items-center.gap-1', { root: header, context: `${this.id}.buttonContainer` });
+            if (!buttonContainer) return;
+
+            let execToCurrentBtn = Context.dom.query('.wf-execute-to-current-btn', { root: buttonContainer, context: `${this.id}.execToCurrentBtn` });
+            if (!execToCurrentBtn) {
+                execToCurrentBtn = document.createElement('button');
+                execToCurrentBtn.className = 'wf-execute-to-current-btn inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 transition-colors hover:bg-accent hover:text-accent-foreground rounded-sm size-7 h-7 w-7 text-muted-foreground hover:text-accent-foreground';
+                execToCurrentBtn.title = 'Execute to current tool';
+                execToCurrentBtn.innerHTML = `<svg width="42.24" height="31.68" viewBox="0 0 35.2 26.4" fill="none" xmlns="http://www.w3.org/2000/svg" class="stroke-current size-4"><path d="M 12.9 2.2 A 11 11 0 0 0 3.9 13.2 A 11 11 0 0 0 14.9 24.2" stroke-width="2"/><circle cx="22" cy="13.2" r="11" stroke-width="2"/><path d="M20.933 9.5172C20.5939 9.30526 20.1665 9.29404 19.8167 9.4879C19.467 9.68174 19.25 10.0501 19.25 10.45V16.05C19.25 16.4499 19.467 16.8183 19.8167 17.0121C20.1665 17.206 20.5939 17.1947 20.933 16.9828L25.333 14.1328C25.6546 13.9318 25.85 13.5793 25.85 13.2C25.85 12.8207 25.6546 12.4682 25.333 12.2672L20.933 9.5172Z" stroke-width="2" stroke-linejoin="round" fill="none"/></svg>`;
+                execToCurrentBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.executeToCurrentTool(card, header, toolsContainer);
+                });
+                buttonContainer.insertBefore(execToCurrentBtn, buttonContainer.firstChild);
+                buttonsAdded++;
+            }
+            execToCurrentBtn.style.display = 'inline-flex';
+        });
+
+        if (buttonsAdded > 0) {
+            Logger.log(`✓ Added ${buttonsAdded} execute-to-current button(s)`);
+        }
+    },
+
+    findWorkflowPanel() {
+        const byDataUi = document.querySelector('[data-ui="workflow-panel"]');
+        if (byDataUi) return byDataUi;
+        const panels = Context.dom.queryAll('[data-panel-id][data-panel]', { context: `${this.id}.panels` });
+        for (const candidate of panels) {
+            const toolbar = candidate.querySelector('[data-ui="workflow-toolbar"]') || candidate.querySelector('.border-b.h-9');
+            if (!toolbar) continue;
+            const workflowText = Array.from(toolbar.querySelectorAll('span')).find(span => span.textContent.trim() === 'Workflow');
+            if (workflowText) return candidate;
+        }
+        return null;
+    },
+
+    findToolsArea(panel) {
+        if (!panel) return null;
+        const stepsContainer = panel.querySelector('[data-ui="workflow-steps-container"]');
+        if (stepsContainer) return stepsContainer;
+        const scrollable = panel.querySelector('.overflow-y-auto');
+        if (!scrollable) return null;
+        return scrollable.querySelector('.space-y-3');
+    },
+
+    async executeToCurrentTool(currentCard, currentHeader, toolsContainer) {
+        Logger.log('Execute to current tool triggered');
+        const cardsByDataUi = toolsContainer.querySelectorAll(this.selectors.toolCard);
+        const allToolCards = cardsByDataUi.length ? Array.from(cardsByDataUi) : Context.dom.queryAll(this.selectors.toolCardFallback, { root: toolsContainer, context: `${this.id}.allToolCards` });
+        const currentIndex = allToolCards.indexOf(currentCard);
+        if (currentIndex === -1) {
+            Logger.warn('Unable to find current tool in tools list');
+            return;
+        }
+        const toolsToExecute = allToolCards.slice(0, currentIndex + 1);
+        Logger.log(`Executing ${toolsToExecute.length} tool(s) from beginning to current tool`);
+
+        for (let i = 0; i < toolsToExecute.length; i++) {
+            const card = toolsToExecute[i];
+            const header = card.querySelector(this.selectors.toolHeader) || Context.dom.query(this.selectors.toolHeaderFallback, { root: card, context: `${this.id}.toolHeaderForExec` });
+            if (!header) {
+                Logger.warn(`Tool ${i + 1} header not found, skipping`);
+                continue;
+            }
+            Logger.log(`Executing tool ${i + 1} of ${toolsToExecute.length}`);
+            const success = await this.executeTool(card, header);
+            if (!success) {
+                Logger.log(`Tool ${i + 1} execution failed, stopping`);
+                return;
+            }
+        }
+        Logger.log('All tools executed successfully');
+    },
+
+    async executeTool(card, header) {
+        return new Promise((resolve) => {
+            const collapsibleRoot = Context.dom.query('div[data-state]', { root: card, context: `${this.id}.collapsibleRoot` });
+            if (!collapsibleRoot) return resolve(false);
+            const isCollapsed = collapsibleRoot.getAttribute('data-state') === 'closed';
+
+            const findAndClickExecute = () => {
+                const collapsibleContent = Context.dom.query('div[data-state="open"] > div[id^="radix-"][data-state="open"]', { root: card, context: `${this.id}.collapsibleContent` });
+                if (!collapsibleContent) return false;
+                let executeBtn = collapsibleContent.querySelector('[data-ui="step-execute"]');
+                if (!executeBtn) {
+                    const buttons = Context.dom.queryAll('div.px-3.pb-3.space-y-3 > button', { root: collapsibleContent, context: `${this.id}.executeButtons` });
+                    buttons.forEach(btn => {
+                        const btnText = btn.textContent.trim();
+                        if ((btnText === 'Execute' || btnText === 'Re-execute') && !executeBtn) executeBtn = btn;
+                    });
+                }
+                if (executeBtn) {
+                    executeBtn.click();
+                    return true;
+                }
+                return false;
+            };
+
+            if (isCollapsed) {
+                header.click();
+                const buttonObserver = new MutationObserver((mutations, obs) => {
+                    if (findAndClickExecute()) {
+                        obs.disconnect();
+                        this.watchForToolCompletion(card, header, resolve);
+                    }
+                });
+                buttonObserver.observe(card, { childList: true, subtree: true, attributes: true, attributeFilter: ['hidden', 'data-state'] });
+                setTimeout(() => {
+                    buttonObserver.disconnect();
+                    if (!findAndClickExecute()) resolve(false);
+                }, 5000);
+            } else if (findAndClickExecute()) {
+                this.watchForToolCompletion(card, header, resolve);
+            } else {
+                resolve(false);
+            }
+        });
+    },
+
+    watchForToolCompletion(card, header, resolve) {
+        const completionObserver = new MutationObserver((mutations, obs) => {
+            const hasSuccess = card.classList.contains('border-emerald-500/50');
+            const hasError = card.classList.contains('border-red-500/50');
+            if (!hasSuccess && !hasError) return;
+            obs.disconnect();
+            const success = hasSuccess && !hasError;
+            const collapsibleRoot = Context.dom.query('div[data-state]', { root: card, context: `${this.id}.collapsibleRoot` });
+            if (collapsibleRoot && collapsibleRoot.getAttribute('data-state') === 'open') {
+                header.click();
+            }
+            resolve(success);
+        });
+        completionObserver.observe(card, { attributes: true, attributeFilter: ['class'] });
+        setTimeout(() => {
+            completionObserver.disconnect();
+            resolve(false);
+        }, 60000);
+    },
+
+    isToolEnvReady() {
+        return document.documentElement.getAttribute('data-fleet-dispute-tool-env-ready') === '1';
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/favorites.js
+++ b/plugins/archetypes/dispute-detail/main/favorites.js
@@ -1,0 +1,188 @@
+// ============= favorites.js =============
+
+const plugin = {
+    id: 'disputeDetailFavorites',
+    name: 'Tool Favorites',
+    description: 'Add favorite stars to tools list',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, envWaitingLogged: false, stylesInjected: false },
+
+    selectors: {
+        searchInput: '[data-ui="tools-search"]',
+        searchInputFallback: 'input[placeholder="Search tools, descriptions, parameters..."]',
+        toolButton: '[data-ui="tool-item"]',
+        toolButtonFallback: 'button.group\\/tool',
+        toolTitleSpan: 'span.text-xs.font-medium.text-foreground'
+    },
+
+    onMutation(state) {
+        if (!this.isToolEnvReady()) {
+            if (!state.envWaitingLogged) {
+                Logger.debug('Dispute favorites: waiting for tool environment');
+                state.envWaitingLogged = true;
+            }
+            return;
+        }
+        state.envWaitingLogged = false;
+
+        if (!state.stylesInjected) {
+            this.injectStyles();
+            state.stylesInjected = true;
+        }
+
+        let toolsContainer = this.findToolsContainer();
+        if (!toolsContainer) {
+            if (!state.missingLogged) {
+                Logger.debug('Tools container not found for favorites');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        const favoriteTools = new Set(Storage.get(Context.storageKeys.favoriteTools, []));
+        let toolButtons = toolsContainer.querySelectorAll(this.selectors.toolButton);
+        if (toolButtons.length === 0) {
+            toolButtons = Context.dom.queryAll(this.selectors.toolButtonFallback, { root: toolsContainer, context: `${this.id}.toolButtons` });
+        } else {
+            toolButtons = Array.from(toolButtons);
+        }
+
+        toolButtons.forEach(button => {
+            if (Context.dom.query('.favorite-star', { root: button, context: `${this.id}.favoriteStar` })) return;
+            const toolName = this.getToolNameFromButton(button);
+            if (!toolName) return;
+
+            const star = this.createStarElement(toolName, favoriteTools);
+            star.onclick = (e) => {
+                e.stopPropagation();
+                this.toggleFavorite(toolName, favoriteTools, toolsContainer);
+            };
+
+            const titleSpan = Context.dom.query(this.selectors.toolTitleSpan, { root: button, context: `${this.id}.toolTitleSpan` });
+            if (titleSpan) {
+                const innerSpan = this.getToolNameSpanFromTitle(titleSpan);
+                if (innerSpan) {
+                    star.style.marginRight = '6px';
+                    titleSpan.insertBefore(star, innerSpan);
+                    titleSpan.style.display = 'inline-flex';
+                    titleSpan.style.alignItems = 'center';
+                    titleSpan.style.gap = '6px';
+                    return;
+                }
+            }
+
+            const firstSpan = button.querySelector('span:not(.favorite-star)');
+            if (firstSpan?.parentElement) {
+                firstSpan.parentElement.insertBefore(star, firstSpan);
+            } else {
+                button.insertBefore(star, button.firstChild);
+            }
+        });
+    },
+
+    injectStyles() {
+        const style = document.createElement('style');
+        style.textContent = `
+            .favorite-star { cursor:pointer; margin-right:3px; transition:all .2s; display:inline-flex; align-items:center; justify-content:center; width:14px; height:14px; flex:0 0 14px; opacity:.7; }
+            .favorite-star.inline { margin-right:6px; width:14px; height:14px; flex:0 0 14px; display:inline-flex; align-items:center; }
+            .favorite-star svg { width:14px; height:14px; display:block; }
+            .favorite-star:hover { opacity:1; transform:scale(1.2); }
+            .favorite-star.favorited { color:gold; opacity:1; }
+        `;
+        document.head.appendChild(style);
+        Logger.log('✓ Favorites styles injected');
+    },
+
+    findToolsContainer() {
+        const searchInput = document.querySelector(this.selectors.searchInput) || Context.dom.query(this.selectors.searchInputFallback, { context: `${this.id}.searchInput` });
+        if (searchInput) {
+            let container = searchInput.closest('.border-b')?.nextElementSibling;
+            if (container && container.classList.contains('flex-1') && container.classList.contains('overflow-y-auto')) {
+                const toolsList = container.querySelector('[data-ui="tools-list"]');
+                if (toolsList) return toolsList;
+            }
+            const toolsPanel = searchInput.closest('[data-ui="tools-panel"]');
+            if (toolsPanel) {
+                const toolsList = toolsPanel.querySelector('[data-ui="tools-list"]');
+                if (toolsList) return toolsList;
+            }
+        }
+        return null;
+    },
+
+    getToolNameFromButton(button) {
+        const dataName = button.getAttribute && button.getAttribute('data-ui-name');
+        if (dataName) return (dataName || '').trim();
+        const titleSpan = Context.dom.query(this.selectors.toolTitleSpan, { root: button, context: `${this.id}.toolTitleSpan` });
+        if (titleSpan) {
+            const nameSpan = this.getToolNameSpanFromTitle(titleSpan);
+            const text = nameSpan?.textContent?.trim();
+            if (text) return text;
+        }
+        return null;
+    },
+
+    getToolNameSpanFromTitle(titleSpan) {
+        return titleSpan.querySelector('span span:nth-child(2) span')
+            || titleSpan.querySelector('span span span')
+            || titleSpan.querySelector('span span')
+            || titleSpan.querySelector('span');
+    },
+
+    createStarElement(toolName, favoriteTools, { inline = false, tagName = 'span' } = {}) {
+        const star = document.createElement(tagName);
+        star.className = inline ? 'favorite-star inline' : 'favorite-star';
+        this.updateStarElement(star, favoriteTools.has(toolName));
+        return star;
+    },
+
+    createStarSvg(isFavorite) {
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('width', '14');
+        svg.setAttribute('height', '14');
+        svg.setAttribute('fill', isFavorite ? '#FFD700' : 'none');
+        svg.setAttribute('stroke', isFavorite ? '#FFD700' : 'currentColor');
+        svg.setAttribute('stroke-width', '1.5');
+        svg.setAttribute('stroke-linecap', 'round');
+        svg.setAttribute('stroke-linejoin', 'round');
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', 'M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z');
+        svg.appendChild(path);
+        return svg;
+    },
+
+    updateStarElement(starEl, isFavorite) {
+        starEl.innerHTML = '';
+        starEl.appendChild(this.createStarSvg(isFavorite));
+        starEl.classList.toggle('favorited', isFavorite);
+    },
+
+    toggleFavorite(toolName, favoriteTools, toolsContainer) {
+        if (favoriteTools.has(toolName)) {
+            favoriteTools.delete(toolName);
+            Logger.log(`Removed favorite: ${toolName}`);
+        } else {
+            favoriteTools.add(toolName);
+            Logger.log(`Added favorite: ${toolName}`);
+        }
+        Storage.set(Context.storageKeys.favoriteTools, Array.from(favoriteTools));
+        this.syncToolListStars(toolsContainer, favoriteTools);
+    },
+
+    syncToolListStars(toolsContainer, favoriteTools) {
+        const toolButtons = Context.dom.queryAll(this.selectors.toolButton, { root: toolsContainer, context: `${this.id}.toolButtons` });
+        toolButtons.forEach(button => {
+            const toolName = this.getToolNameFromButton(button);
+            const star = button.querySelector('.favorite-star');
+            if (!toolName || !star) return;
+            this.updateStarElement(star, favoriteTools.has(toolName));
+        });
+    },
+
+    isToolEnvReady() {
+        return document.documentElement.getAttribute('data-fleet-dispute-tool-env-ready') === '1';
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/toggle-tool-parameters.js
+++ b/plugins/archetypes/dispute-detail/main/toggle-tool-parameters.js
@@ -1,0 +1,195 @@
+// ============= toggle-tool-parameters.js =============
+const plugin = {
+    id: 'disputeDetailToggleToolParameters',
+    name: 'Toggle Tool Parameters',
+    description: 'Adds a toggle to each tool header to hide/show its parameters section',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { panelId: null, missingLogged: false, envWaitingLogged: false },
+
+    subOptions: [
+        {
+            id: 'auto-collapse-on-execute',
+            name: 'Auto-collapse parameters on execute',
+            description: 'When a tool is executed, collapse its parameters section if it is open',
+            enabledByDefault: true
+        }
+    ],
+
+    paramSectionBtnClass: 'wf-param-section-btn inline-flex items-center gap-1 justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground rounded-sm text-xs py-1.5 pl-2 pr-2',
+
+    selectors: {
+        workflowPanel: '[data-ui="workflow-panel"]',
+        workflowStepsContainer: '[data-ui="workflow-steps-container"]',
+        workflowStep: '[data-ui="workflow-step"]',
+        stepHeader: '[data-ui="step-header"]',
+        stepParameters: '[data-ui="step-parameters"]',
+        toolHeaderFallback: 'div.flex.items-center.gap-3.p-3.cursor-pointer.hover\\:bg-muted\\/30',
+        toolCardFallback: 'div.rounded-lg.border.transition-colors'
+    },
+
+    onMutation(state) {
+        if (!this.isToolEnvReady()) {
+            if (!state.envWaitingLogged) {
+                Logger.debug('Toggle-tool-parameters: waiting for tool environment');
+                state.envWaitingLogged = true;
+            }
+            return;
+        }
+        state.envWaitingLogged = false;
+
+        const panel = this.findWorkflowPanel();
+        if (!panel) {
+            if (!state.missingLogged) {
+                Logger.log('⚠ Workflow panel not found for toggle-tool-parameters');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        const currentPanelId = panel.getAttribute('data-panel-id');
+        if (state.panelId !== currentPanelId) {
+            state.panelId = currentPanelId;
+            state.missingLogged = false;
+        }
+
+        const toolsContainer = this.findToolsArea(panel);
+        if (!toolsContainer) return;
+        this.ensureExecuteClickDelegate(toolsContainer);
+
+        let toolCards = Context.dom.queryAll(this.selectors.workflowStep, { root: toolsContainer, context: `${this.id}.toolCards` });
+        if (!toolCards.length) toolCards = Context.dom.queryAll(this.selectors.toolCardFallback, { root: toolsContainer, context: `${this.id}.toolCards` });
+
+        toolCards.forEach(card => {
+            const collapsibleRoot = Context.dom.query('div[data-state]', { root: card, context: `${this.id}.collapsibleRoot` });
+            if (!collapsibleRoot) return;
+
+            const header = Context.dom.query(this.selectors.stepHeader, { root: card, context: `${this.id}.toolHeader` })
+                || Context.dom.query(this.selectors.toolHeaderFallback, { root: card, context: `${this.id}.toolHeader` });
+            if (!header) return;
+
+            const buttonContainer = Context.dom.query('div.flex.items-center.gap-1', { root: header, context: `${this.id}.buttonContainer` });
+            if (!buttonContainer) return;
+
+            let toggleBtn = Context.dom.query('.wf-param-toggle-btn', { root: buttonContainer, context: `${this.id}.toggleBtn` });
+            const isCollapsed = collapsibleRoot.getAttribute('data-state') === 'closed';
+
+            if (!toggleBtn) {
+                toggleBtn = document.createElement('button');
+                toggleBtn.className = 'wf-param-toggle-btn inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 transition-colors hover:bg-accent hover:text-accent-foreground rounded-sm size-7 h-7 w-7';
+                toggleBtn.title = 'Hide parameters';
+                toggleBtn.dataset.paramVisible = 'true';
+                toggleBtn.innerHTML = this.renderSwitch(true);
+                toggleBtn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.handleToggle(card, toggleBtn);
+                });
+                const execBtn = buttonContainer.querySelector('.wf-execute-to-current-btn');
+                buttonContainer.insertBefore(toggleBtn, execBtn || buttonContainer.firstChild);
+            }
+
+            toggleBtn.style.display = 'none';
+
+            const paramsDiv = this.findParametersDiv(card);
+            if (!paramsDiv) return;
+
+            let expandLink = card.querySelector('.wf-param-expand-link');
+            if (!expandLink) {
+                expandLink = document.createElement('button');
+                expandLink.className = 'wf-param-expand-link ' + this.paramSectionBtnClass;
+                expandLink.type = 'button';
+                expandLink.textContent = 'Show Parameters';
+                expandLink.title = 'Show parameters';
+                expandLink.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    this.handleToggle(card, toggleBtn);
+                });
+                paramsDiv.parentNode.insertBefore(expandLink, paramsDiv.nextSibling);
+            }
+            expandLink.style.display = (!isCollapsed && toggleBtn.dataset.paramVisible === 'false') ? 'inline-flex' : 'none';
+
+            const labelEl = paramsDiv.firstElementChild;
+            if (labelEl && !labelEl.hasAttribute('data-wf-param-label')) {
+                const labelText = labelEl.textContent.trim();
+                if (labelText === 'Parameters' || labelText === 'PARAMETERS') {
+                    labelEl.setAttribute('data-wf-param-label', '1');
+                    labelEl.className = this.paramSectionBtnClass;
+                    labelEl.textContent = 'Hide Parameters';
+                    labelEl.setAttribute('role', 'button');
+                    labelEl.setAttribute('tabindex', '0');
+                    labelEl.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        this.handleToggle(card, toggleBtn);
+                    });
+                }
+            }
+        });
+    },
+
+    renderSwitch(isOn) {
+        const trackColor = isOn ? 'var(--brand, #6366f1)' : 'var(--muted-foreground, #6b7280)';
+        const thumbPos = isOn ? '12px' : '1px';
+        return `<div class="wf-toggle-track" style="width:22px;height:11px;border-radius:5.5px;background-color:${trackColor};transition:background-color 0.15s;position:relative;"><div class="wf-toggle-thumb" style="width:9px;height:9px;border-radius:50%;background:white;position:absolute;top:1px;left:${thumbPos};transition:left 0.15s;box-shadow:0 0.5px 1.5px rgba(0,0,0,0.25);"></div></div>`;
+    },
+
+    handleToggle(card, toggleBtn) {
+        const nowVisible = toggleBtn.dataset.paramVisible === 'false';
+        toggleBtn.dataset.paramVisible = nowVisible ? 'true' : 'false';
+        const paramsDiv = this.findParametersDiv(card);
+        if (paramsDiv) paramsDiv.style.display = nowVisible ? '' : 'none';
+        const expandLink = card.querySelector('.wf-param-expand-link');
+        if (expandLink) expandLink.style.display = nowVisible ? 'none' : 'inline-flex';
+    },
+
+    findParametersDiv(card) {
+        const byDataUi = card.querySelector(this.selectors.stepParameters);
+        if (byDataUi) return byDataUi;
+        const candidates = card.querySelectorAll('div.space-y-3');
+        for (const div of candidates) {
+            const firstChild = div.firstElementChild;
+            if (!firstChild) continue;
+            if (firstChild.textContent.trim() === 'Parameters' || firstChild.getAttribute('data-wf-param-label') === '1') return div;
+        }
+        return null;
+    },
+
+    findWorkflowPanel() {
+        return document.querySelector(this.selectors.workflowPanel);
+    },
+
+    findToolsArea(panel) {
+        if (!panel) return null;
+        const container = panel.querySelector(this.selectors.workflowStepsContainer);
+        if (container) {
+            const spaceY3 = container.querySelector(':scope > .space-y-3');
+            return spaceY3 || container;
+        }
+        return null;
+    },
+
+    ensureExecuteClickDelegate(toolsContainer) {
+        if (toolsContainer.dataset.wfAutoCollapseDelegate === '1') return;
+        toolsContainer.dataset.wfAutoCollapseDelegate = '1';
+        toolsContainer.addEventListener('click', (e) => {
+            const btn = e.target?.closest?.('button');
+            if (!btn) return;
+            const text = btn.textContent?.trim?.();
+            if (text !== 'Execute' && text !== 'Re-execute') return;
+            const card = btn.closest(this.selectors.workflowStep) || btn.closest(this.selectors.toolCardFallback);
+            if (!card || !toolsContainer.contains(card)) return;
+            if (!Storage.getSubOptionEnabled(this.id, 'auto-collapse-on-execute', true)) return;
+            const toggleBtn = card.querySelector('.wf-param-toggle-btn');
+            if (!toggleBtn || toggleBtn.dataset.paramVisible !== 'true') return;
+            this.handleToggle(card, toggleBtn);
+            Logger.debug('Auto-collapsed parameters after execute');
+        });
+    },
+
+    isToolEnvReady() {
+        return document.documentElement.getAttribute('data-fleet-dispute-tool-env-ready') === '1';
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/tool-description-truncate.js
+++ b/plugins/archetypes/dispute-detail/main/tool-description-truncate.js
@@ -1,0 +1,65 @@
+// ============= tool-description-truncate.js =============
+
+const STYLE_ID = 'fleet-style-dispute-tool-description-truncate';
+
+function getStyleContent(hideWhenCollapsed) {
+    const selector =
+        'div.w-full.space-y-3 > button.group\\/tool:only-child p.text-muted-foreground.font-normal.whitespace-normal';
+    const rule = hideWhenCollapsed
+        ? `${selector}{display:none !important;}`
+        : `${selector}{max-width:100ch;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}`;
+    return rule;
+}
+
+const plugin = {
+    id: 'disputeDetailToolDescriptionTruncate',
+    name: 'Tool Description Truncation',
+    description: 'Limits the length tool descriptions to make the tool picker more manageable',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { envWaitingLogged: false },
+
+    onMutation(state) {
+        if (!this.isToolEnvReady()) {
+            if (!state.envWaitingLogged) {
+                Logger.debug('Tool-description-truncate: waiting for tool environment');
+                state.envWaitingLogged = true;
+            }
+            return;
+        }
+        state.envWaitingLogged = false;
+
+        let style = document.getElementById(STYLE_ID);
+        if (!style) {
+            style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.setAttribute('data-fleet-plugin', this.id);
+            document.head.appendChild(style);
+            Logger.log('Tool description truncate styles injected');
+        }
+        const hideWhenCollapsed = Storage.getSubOptionEnabled(
+            this.id,
+            'hide-description-when-collapsed',
+            false
+        );
+        const css = getStyleContent(hideWhenCollapsed);
+        if (style.textContent !== css) {
+            style.textContent = css;
+        }
+    },
+
+    subOptions: [
+        {
+            id: 'hide-description-when-collapsed',
+            name: 'Hide description when collapsed',
+            description:
+                'When enabled, hide the tool description entirely in the list when the tool is collapsed.',
+            enabledByDefault: false
+        }
+    ],
+
+    isToolEnvReady() {
+        return document.documentElement.getAttribute('data-fleet-dispute-tool-env-ready') === '1';
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/tool-results-resize-handle.js
+++ b/plugins/archetypes/dispute-detail/main/tool-results-resize-handle.js
@@ -1,0 +1,175 @@
+// ============= tool-results-resize-handle.js =============
+// Adds a drag-to-resize handle to the bottom of tool result boxes.
+
+const plugin = {
+    id: 'disputeDetailToolResultsResizeHandle',
+    name: 'Tool Results Resize Handle',
+    description: 'Adds a resize handle to tool result boxes so their height can be adjusted by dragging',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { panelId: null, missingLogged: false, envWaitingLogged: false },
+
+    selectors: {
+        toolCard: '[data-ui="workflow-step"]',
+        toolCardFallback: 'div.rounded-lg.border.transition-colors',
+        stepResult: '[data-ui="step-result"]'
+    },
+
+    onMutation(state) {
+        if (!this.isToolEnvReady()) {
+            if (!state.envWaitingLogged) {
+                Logger.debug('Result-resize-handle: waiting for tool environment');
+                state.envWaitingLogged = true;
+            }
+            return;
+        }
+        state.envWaitingLogged = false;
+
+        const panel = this.findWorkflowPanel();
+        if (!panel) return;
+
+        const currentPanelId = panel.getAttribute('data-panel-id');
+        if (state.panelId !== currentPanelId) {
+            state.panelId = currentPanelId;
+            state.missingLogged = false;
+        }
+
+        const toolsContainer = this.findToolsArea(panel);
+        if (!toolsContainer) return;
+
+        const toolCardsByDataUi = toolsContainer.querySelectorAll(this.selectors.toolCard);
+        const toolCards = toolCardsByDataUi.length ? Array.from(toolCardsByDataUi) : Context.dom.queryAll(this.selectors.toolCardFallback, { root: toolsContainer, context: `${this.id}.toolCards` });
+
+        toolCards.forEach(card => {
+            const resultDiv = this.findResultDiv(card);
+            if (!resultDiv) return;
+            if (resultDiv.dataset.wfResultResizeAttached === '1') {
+                const nextEl = resultDiv.nextElementSibling;
+                if (nextEl && nextEl.classList.contains('wf-result-resize-handle')) {
+                    this.ensureResetButton(card, resultDiv);
+                    return;
+                }
+                delete resultDiv.dataset.wfResultResizeAttached;
+            }
+            this.attachResizeHandle(resultDiv);
+            resultDiv.dataset.wfResultResizeAttached = '1';
+            this.ensureResetButton(card, resultDiv);
+        });
+    },
+
+    findResultDiv(card) {
+        const stepResult = card.querySelector(this.selectors.stepResult);
+        if (stepResult) {
+            const box = stepResult.querySelector('div.p-3.rounded-md.border.text-xs.font-mono.whitespace-pre-wrap.overflow-auto');
+            if (box) return box;
+        }
+        return null;
+    },
+
+    attachResizeHandle(resultDiv) {
+        const resizeHandle = document.createElement('div');
+        resizeHandle.className = 'wf-result-resize-handle';
+        Object.assign(resizeHandle.style, {
+            height: '8px',
+            cursor: 'ns-resize',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: '0',
+            transition: 'opacity 0.15s',
+            userSelect: 'none'
+        });
+
+        const handleBar = document.createElement('div');
+        Object.assign(handleBar.style, {
+            width: '40px',
+            height: '3px',
+            borderRadius: '1.5px',
+            backgroundColor: 'currentColor',
+            opacity: '0.3'
+        });
+        resizeHandle.appendChild(handleBar);
+
+        resultDiv.addEventListener('mouseenter', () => { resizeHandle.style.opacity = '1'; });
+        resultDiv.addEventListener('mouseleave', (e) => {
+            if (!e.relatedTarget || !resizeHandle.contains(e.relatedTarget)) resizeHandle.style.opacity = '0';
+        });
+        resizeHandle.addEventListener('mouseenter', () => { resizeHandle.style.opacity = '1'; });
+        resizeHandle.addEventListener('mouseleave', (e) => {
+            if (!e.relatedTarget || !resultDiv.contains(e.relatedTarget)) resizeHandle.style.opacity = '0';
+        });
+
+        resultDiv.insertAdjacentElement('afterend', resizeHandle);
+
+        let isResizing = false;
+        let startY = 0;
+        let startHeight = 0;
+        const minHeight = 40;
+        const handleMouseDown = (e) => {
+            isResizing = true;
+            startY = e.clientY;
+            startHeight = resultDiv.offsetHeight;
+            e.preventDefault();
+            e.stopPropagation();
+            document.addEventListener('mousemove', handleMouseMove);
+            document.addEventListener('mouseup', handleMouseUp);
+            document.body.style.cursor = 'ns-resize';
+            document.body.style.userSelect = 'none';
+        };
+        const handleMouseMove = (e) => {
+            if (!isResizing) return;
+            const delta = e.clientY - startY;
+            const newHeight = Math.max(minHeight, startHeight + delta);
+            resultDiv.style.maxHeight = `${newHeight}px`;
+        };
+        const handleMouseUp = () => {
+            if (!isResizing) return;
+            isResizing = false;
+            document.removeEventListener('mousemove', handleMouseMove);
+            document.removeEventListener('mouseup', handleMouseUp);
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+        };
+
+        resizeHandle.addEventListener('mousedown', handleMouseDown);
+        CleanupRegistry.registerEventListener(resizeHandle, 'mousedown', handleMouseDown);
+    },
+
+    ensureResetButton(card, resultDiv) {
+        const buttonContainer = this.findResultButtonContainer(card);
+        if (!buttonContainer) return;
+        if (buttonContainer.querySelector('.wf-result-reset-btn')) return;
+
+        const resetBtn = document.createElement('button');
+        resetBtn.className = 'wf-result-reset-btn inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        resetBtn.title = 'Reset result box size';
+        resetBtn.innerHTML = '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="fill-current h-3 w-3 text-muted-foreground"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 9C19.5523 9 20 9.44772 20 10C20 10.5523 19.5523 11 19 11H14C13.4477 11 13 10.5523 13 10V5C13 4.44772 13.4477 4 14 4C14.5523 4 15 4.44772 15 5V7.58579L19.2929 3.2929C19.6834 2.9024 20.3166 2.9024 20.7071 3.2929C21.0976 3.6834 21.0976 4.31658 20.7071 4.70711L16.4142 9H19ZM4.70711 20.7071C4.31658 21.0976 3.6834 21.0976 3.2929 20.7071C2.9024 20.3166 2.9024 19.6834 3.2929 19.2929L7.58579 15H5C4.44772 15 4 14.5523 4 14C4 13.4477 4.44772 13 5 13H10C10.5523 13 11 13.4477 11 14V19C11 19.5523 10.5523 20 10 20C9.44772 20 9 19.5523 9 19V16.4142L4.70711 20.7071Z"/></svg>';
+        resetBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            resultDiv.style.maxHeight = '';
+            Logger.log('Result box size reset to default');
+        });
+        buttonContainer.appendChild(resetBtn);
+    },
+
+    findResultButtonContainer(card) {
+        const stepResult = card.querySelector(this.selectors.stepResult);
+        if (!stepResult) return null;
+        return stepResult.querySelector('.flex.items-center.justify-between.gap-2');
+    },
+
+    findWorkflowPanel() {
+        return document.querySelector('[data-ui="workflow-panel"]');
+    },
+
+    findToolsArea(panel) {
+        if (!panel) return null;
+        return panel.querySelector('[data-ui="workflow-steps-container"]');
+    },
+
+    isToolEnvReady() {
+        return document.documentElement.getAttribute('data-fleet-dispute-tool-env-ready') === '1';
+    }
+};


### PR DESCRIPTION
## Dispute Detail archetype + tool-env UX plugins and layout fixes

### Summary

Adds a new **Dispute Detail Page** archetype for `work/problems/disputes/*` and wires in tool-environment–aware UX plugins plus layout fixes. Dev-only script metadata (name prefix, update URLs, branch config) is updated for the dev build.

### Changes

**Archetypes & config**

- **New archetype `dispute-detail`** in `archetypes.json` for URL pattern `work/problems/disputes/*` with 9 plugins (see below). `archetypesVersion` bumped 6.1 → 6.4.
- **`fleet.user.js`** (dev-only): script name prefixed with `[dev]`, `@downloadURL` / `@updateURL` and `GITHUB_CONFIG.branch` set to `dev` so the dev build updates from the dev branch.

**New dispute-detail plugins**

| Plugin | Purpose |
|--------|--------|
| **env-load-gate.js** | Detects when the dispute detail page has a tool environment loaded; sets `data-fleet-dispute-tool-env-ready` on `<html>` so other plugins can gate on it. |
| **dispute-detail-task-id.js** | Adds a copyable Task ID in the dispute header (derived from the “View Task” link). |
| **dispute-content-layout-fixes.js** | Layout fixes: header row wraps when narrow, resolution/action buttons wrap instead of overflowing, and text/whitespace handling in the dispute panel. |
| **clear-search.js** | Adds a clear “X” to the tool search when it has text. |
| **favorites.js** | Adds favorite stars to the tools list. |
| **execute-to-current-tool.js** | Adds a control to run all tools from the start up to and including the current tool (gated on tool env ready). |
| **toggle-tool-parameters.js** | Toggle to show/hide each tool’s parameters; can auto-collapse parameters when a tool is executed. |
| **tool-results-resize-handle.js** | Resize handle on tool result boxes so height can be adjusted by dragging. |
| **tool-description-truncate.js** | Truncates long tool descriptions in the tool picker. |

**Commit history (main → dev)**

- Sync branch config (download/update URLs, branch).
- Add tool-env–gated dispute-detail archetype with ported tool UX plugins and layout fixes.
- Fix resolution buttons wrapping in narrow panel.
- Add copyable Task ID in header and wrap header when narrow.

### Stats

- **11 files changed**, **+1,239 / −6** lines.
- New: 9 plugin files under `plugins/archetypes/dispute-detail/main/`; modified: `archetypes.json`, `fleet.user.js`.

### Testing

- Confirm on a dispute detail page (`work/problems/disputes/*`) that the new archetype loads and all 9 plugins run when the tool environment is present.
- Check header wrap and resolution buttons on narrow viewports.
- Verify Task ID copy, search clear, favorites, execute-to-current, parameter toggles, result resize, and description truncation behave as intended.