### PR TITLE
Updates for potential race contditions

### DIFF
--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2009,6 +2009,7 @@
     let mainObserver = null;
     let mutationRafId = null;
     let corePluginsLoaded = false;
+    let navigationHandlerActive = false;
     
     async function initializeCorePlugins() {
         if (corePluginsLoaded) {
@@ -2128,22 +2129,37 @@
             Logger.log('URL is the same, skipping...');
             return;
         }
-        
+
         // Check if task_project_target_id matches - if so, don't reload
         // This prevents reload when only instance_id changes (e.g., backend reset)
         const previousProjectId = getQueryParam(previousUrl, 'task_project_target_id');
         const newProjectId = getQueryParam(newUrl, 'task_project_target_id');
-        
+
         if (previousProjectId && newProjectId && previousProjectId === newProjectId) {
             Logger.log(`Navigation has same task_project_target_id (${newProjectId}), skipping reload...`);
             return;
         }
 
+        // Prevent concurrent invocations from racing each other. A prior call is still
+        // awaiting the GitHub fetch, so drop this one rather than risk a stale reload.
+        if (navigationHandlerActive) {
+            Logger.log('Navigation handler already active, skipping...');
+            return;
+        }
+        navigationHandlerActive = true;
+
         Logger.log('Handling navigation, checking archetype match...');
-        
+
         try {
             await ArchetypeManager.loadArchetypes();
-            
+
+            // If further navigation occurred while we were fetching, the URL we were
+            // called with is now stale. Reloading here would fire on the wrong page.
+            if (window.location.href !== newUrl) {
+                Logger.log('URL changed during archetype fetch, skipping reload...');
+                return;
+            }
+
             const newPath = UrlMatcher.getPathFromUrl(newUrl);
             const matchesArchetype = ArchetypeManager.archetypes.some(archetype => {
                 if (!archetype.urlPattern) {
@@ -2151,7 +2167,7 @@
                 }
                 return UrlMatcher.matches(newPath, archetype.urlPattern);
             });
-            
+
             if (matchesArchetype) {
                 Logger.log('Navigation target matches archetype; refreshing page...');
                 Storage.delete('workflow-cache-latest');
@@ -2161,6 +2177,8 @@
             }
         } catch (error) {
             Logger.error('Failed to check archetype match on navigation:', error);
+        } finally {
+            navigationHandlerActive = false;
         }
         
         Logger.log('Handling navigation, reinitializing...');


### PR DESCRIPTION
Fix: random logouts caused by stale location.reload() in navigation handler

  Problem

  Users are experiencing random logouts that require a page refresh and re-login. The root cause was a race condition in handleNavigation (fleet.user.js). handleNavigation is called on every in-app navigation (pushState / replaceState / popstate). When the destination URL matches an archetype, it calls location.reload() to reinitialize the extension. However, before deciding whether to reload, it first makes an async network request to GitHub to fetch the archetypes config — without a concurrency guard or a staleness check.

This created two failure modes:

---
1. Stale reload fires mid-auth

Many auth flows use replaceState to clean up the URL after processing a login — for example, changing work/create?callbackUrl=... to work/create. The extension's NavigationManager intercepts this replaceState call and kicks off handleNavigation. Because work/create matches the dashboard archetype, a location.reload() will eventually be called — but only after the GitHub fetch completes, which can take anywhere from 200ms to 2s+ depending on network conditions.

If the app is doing any client-side session work during that window (token exchange, writing auth state to storage, initializing in-memory session objects), the reload may occur while that work is incomplete. The page reloads with no valid session, and the user is sent to the login screen.

This is why the issue is random — it's a timing dependency on how long the GitHub fetch takes relative to the app's post-login setup.

2. Concurrent invocations trigger a reload on the wrong page

Auth redirect chains often produce multiple rapid-fire navigation events. For example:

/login  →  pushState  →  /work/create

With no concurrency guard, each navigation event spins up its own handleNavigation call, each independently awaiting a GitHub fetch. If a second navigation fires before the first fetch resolves, both are in-flight simultaneously. Whichever fetch completes first triggers a location.reload() — but by then, window.location.href may have already moved on to a later URL in the redirect chain. The reload fires on the current page (wherever the user ended up), not the page that triggered it. If that page is in the middle of establishing a session, the result is a logout.

  ---
Fix

Two guards added to handleNavigation:

- Concurrency guard — a navigationHandlerActive flag prevents a second invocation from starting while one is already awaiting the GitHub fetch. The flag is released in a finally block, so it's always cleared regardless of how the function exits (normal return, early return, error, or reload).
- Staleness check — after loadArchetypes() resolves, window.location.href is compared against the newUrl captured at call time. If the user has since navigated elsewhere, the reload is skipped rather than firing on the wrong page at the wrong moment.