### PR TITLE
Sync branch configuration and fix development popup

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
-  "version": "5.2.0",
-  "archetypesVersion": "6.21",
+  "version": "5.2.1",
+  "archetypesVersion": "6.22",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,8 +1,8 @@
 
 // ==UserScript==
-// @name         [fix] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      5.2.0
+// @version      5.2.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -28,7 +28,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '5.2.0';
+    const VERSION = '5.2.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [update/remove-metadata-tag-qa-enhancements] Fleet Workflow Builder UX Enhancer
+// @name         [fix] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.2.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'update/remove-metadata-tag-qa-enhancements',
+        branch: 'fix',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',


### PR DESCRIPTION
# Fix dev popup / Restore main config and version bump

## Summary

Restores the main script name and GitHub branch config in `fleet.user.js` and bumps the project and archetypes versions to **5.2.1** and **6.22**.

## Changes

- **fleet.user.js**
  - `@name`: removed branch prefix so it is again `Fleet Workflow Builder UX Enhancer`.
  - `@version` and in-script `VERSION`: **5.2.0** → **5.2.1**.
  - `GITHUB_CONFIG.branch`: set back to `'main'` (from a feature-branch value).

- **archetypes.json**
  - `version`: **5.2.0** → **5.2.1**.
  - `archetypesVersion`: **6.21** → **6.22**.

## New plugins

None.

## Commit history

- `3fac747` Fix dev popup  
- `e36943e` Sync branch config  

## Stats

| File          | Changes   |
|---------------|-----------|
| archetypes.json | 2 lines (±) |
| fleet.user.js   | 4 lines (±) |
| **Total**       | 2 files, +6 −6 |