### PR TITLE
Disable extension for Task Designers and update archetypes version

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
-  "version": "5.2.2",
-  "archetypesVersion": "6.39",
+  "version": "5.3.0",
+  "archetypesVersion": "6.41",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -109,6 +109,16 @@
           "version": "3.2"
         }
       ]
+    },
+    {
+      "id": "tool-use-task-creation-excluded",
+      "name": "Tool Use Task Creation Page (Excluded)",
+      "description": "Task Designers Special Projects variant - extension disabled",
+      "urlPattern": "work/problems/create-tool-use*",
+      "disambiguationSelectors": [
+        "text:Task Designers - Special Projects Tasks"
+      ],
+      "plugins": []
     },
     {
       "id": "tool-use-revision",

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [update-disable-ext-on-claw] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.2.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-disable-ext-on-claw/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-disable-ext-on-claw/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'update-disable-ext-on-claw',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [update-disable-ext-on-claw] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-disable-ext-on-claw/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-disable-ext-on-claw/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'update-disable-ext-on-claw',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [update-disable-ext-on-claw] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      5.2.2
+// @version      5.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -28,7 +28,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '5.2.2';
+    const VERSION = '5.3.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -1021,10 +1021,21 @@
                     }
                     
                     // Check if ALL disambiguation selectors are present
-                    const allPresent = selectors.every(selector => {
-                        const exists = Context.dom.query(selector, {
+                    const selectorMatches = (selector) => {
+                        if (selector.startsWith('text:')) {
+                            const searchText = selector.slice(5);
+                            const elements = document.querySelectorAll('*');
+                            for (const el of elements) {
+                                if (el.children.length === 0 && el.textContent.trim() === searchText) return true;
+                            }
+                            return false;
+                        }
+                        return Context.dom.query(selector, {
                             context: `archetype:${archetype.id}`
                         }) !== null;
+                    };
+                    const allPresent = selectors.every(selector => {
+                        const exists = selectorMatches(selector);
                         Logger.debug(`  [${archetype.id}] Selector "${selector}": ${exists ? '✓' : '✗'}`);
                         return exists;
                     });


### PR DESCRIPTION
## Summary

Disables the extension on the "Task Designers - Special Projects Tasks" variant of the tool-use task creation page by extending the disambiguation system with text-content selectors and adding a zero-plugin exclusion archetype.

## Changes

- **fleet.user.js**: In `_disambiguateWithSelectors`, added support for a `text:` selector prefix. Selectors starting with `text:` are resolved by finding a leaf element whose `textContent.trim()` equals the remainder of the selector (e.g. `text:Task Designers - Special Projects Tasks`). Other selectors continue to use `Context.dom.query`.
- **archetypes.json**: Inserted archetype `tool-use-task-creation-excluded` after `tool-use-task-creation`, with the same URL pattern (`work/problems/create-tool-use*`), disambiguation selector `["text:Task Designers - Special Projects Tasks"]`, and empty `plugins` array. When that badge text is present, disambiguation picks this archetype and no plugins run; otherwise the normal tool-use-task-creation archetype is used. Bumped `archetypesVersion` to 6.40 via `update-versions.sh`.

## Commit history

- `30e6df7` Disable extension on Task Designers - Special Projects page

## Stats

- **Files changed:** 2
- **Insertions:** +27
- **Deletions:** -6