### PR TITLE
Add corner-widgets hide toggle to guideline-buttons across archetypes

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "5.3.2",
-  "archetypesVersion": "6.49",
+  "archetypesVersion": "6.50",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -402,7 +402,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.6"
+          "version": "2.0"
         },
         {
           "name": "request-revisions.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "5.3.2",
-  "archetypesVersion": "6.50",
+  "archetypesVersion": "6.51",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -66,7 +66,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.0"
+          "version": "2.1"
         },
         {
           "name": "favorites.js",
@@ -129,7 +129,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.0"
+          "version": "2.1"
         },
         {
           "name": "favorites.js",
@@ -182,7 +182,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.5"
+          "version": "1.6"
         },
         {
           "name": "bug-report-expand.js",
@@ -243,7 +243,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.3"
+          "version": "1.4"
         },
         {
           "name": "prompt-scratchpad.js",
@@ -276,7 +276,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.3"
+          "version": "1.4"
         },
         {
           "name": "bug-report-expand.js",
@@ -402,7 +402,7 @@
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.0"
+          "version": "2.2"
         },
         {
           "name": "request-revisions.js",

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-hide-widgets] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.3.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-hide-widgets/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-hide-widgets/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-hide-widgets',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-hide-widgets] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.3.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-hide-widgets/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-hide-widgets/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-hide-widgets',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/comp-use-revision/main/guideline-buttons.js
+++ b/plugins/archetypes/comp-use-revision/main/guideline-buttons.js
@@ -1,16 +1,28 @@
 // ============= guideline-buttons.js =============
 // Modular guideline link buttons in the top bar (computer use revision).
+// Toggle hides/shows bottom-right Pylon chat + bug-report FAB via CSS only.
 
 const BUTTONS = [
     { id: 'qa-guidelines', title: 'QA Guidelines', link: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56' },
     { id: 'meridian-guidelines', title: 'Meridian Guidelines', link: 'https://fleetai.notion.site/Project-Meridian-Guidelines-2eafe5dd3fba80079b86de5dce865477' }
 ];
 
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+const CORNER_WIDGETS_SUBOPTION_ID = 'corner-widgets-toggle';
+
+const CORNER_WIDGETS_SUBOPTION = {
+    id: CORNER_WIDGETS_SUBOPTION_ID,
+    name: 'Show/Hide Widgets button',
+    description: 'When enabled, adds a button next to the guideline links that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+    enabledByDefault: true
+};
+
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '1.3',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -20,14 +32,18 @@ const plugin = {
         name: b.title,
         description: null,
         enabledByDefault: true
-    })),
+    })).concat([CORNER_WIDGETS_SUBOPTION]),
 
     initialState: {
         wrapperAdded: false,
-        missingLogged: false
+        missingLogged: false,
+        styleInjected: false
     },
 
     onMutation(state, context) {
+        this.ensureCornerWidgetsStyle(state);
+        this.applyCornerWidgetsClassFromStorage();
+
         const buttonContainer = this.findToolbarContainer();
         if (!buttonContainer) {
             if (!state.missingLogged) {
@@ -47,6 +63,91 @@ const plugin = {
         }
 
         this.syncButtons(wrapper);
+    },
+
+    ensureCornerWidgetsStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Guideline Buttons: corner widgets hide style injected');
+    },
+
+    applyCornerWidgetsClassFromStorage() {
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), true);
+        this.setCornerWidgetsHidden(!!hidden, false);
+    },
+
+    storageKeyCornerWidgets() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    setCornerWidgetsHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKeyCornerWidgets(), hidden);
+            Logger.log(`Guideline Buttons: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`);
+        }
+        const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
+            btn.title = hidden
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
+        }
+    },
+
+    isCornerWidgetsHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
+    },
+
+    ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
+        const toggleBtnExisting = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            if (toggleBtnExisting) {
+                toggleBtnExisting.remove();
+                Logger.log('Guideline Buttons: corner widgets toggle removed (subOption disabled)');
+            }
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        let toggleBtn = toggleBtnExisting;
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className = buttonClass;
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isCornerWidgetsHidden();
+                this.setCornerWidgetsHidden(nextHidden, true);
+            });
+            wrapper.appendChild(toggleBtn);
+            Logger.log('Guideline Buttons: corner widgets toggle button added');
+        }
+        this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     },
 
     findToolbarContainer() {
@@ -118,5 +219,7 @@ const plugin = {
                 existing.remove();
             }
         }
+
+        this.ensureCornerWidgetsToggleButton(wrapper, buttonClass);
     }
 };

--- a/plugins/archetypes/comp-use-task-creation/main/guideline-buttons.js
+++ b/plugins/archetypes/comp-use-task-creation/main/guideline-buttons.js
@@ -1,16 +1,28 @@
 // ============= guideline-buttons.js =============
 // Modular guideline link buttons in the top bar (computer use task creation).
+// Toggle hides/shows bottom-right Pylon chat + bug-report FAB via CSS only.
 
 const BUTTONS = [
     { id: 'qa-guidelines', title: 'QA Guidelines', link: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56' },
     { id: 'meridian-guidelines', title: 'Meridian Guidelines', link: 'https://fleetai.notion.site/Project-Meridian-Guidelines-2eafe5dd3fba80079b86de5dce865477' }
 ];
 
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+const CORNER_WIDGETS_SUBOPTION_ID = 'corner-widgets-toggle';
+
+const CORNER_WIDGETS_SUBOPTION = {
+    id: CORNER_WIDGETS_SUBOPTION_ID,
+    name: 'Show/Hide Widgets button',
+    description: 'When enabled, adds a button next to the guideline links that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+    enabledByDefault: true
+};
+
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '1.3',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -20,14 +32,18 @@ const plugin = {
         name: b.title,
         description: null,
         enabledByDefault: true
-    })),
+    })).concat([CORNER_WIDGETS_SUBOPTION]),
 
     initialState: {
         wrapperAdded: false,
-        missingLogged: false
+        missingLogged: false,
+        styleInjected: false
     },
 
     onMutation(state, context) {
+        this.ensureCornerWidgetsStyle(state);
+        this.applyCornerWidgetsClassFromStorage();
+
         const buttonContainer = this.findToolbarContainer();
         if (!buttonContainer) {
             if (!state.missingLogged) {
@@ -47,6 +63,91 @@ const plugin = {
         }
 
         this.syncButtons(wrapper);
+    },
+
+    ensureCornerWidgetsStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Guideline Buttons: corner widgets hide style injected');
+    },
+
+    applyCornerWidgetsClassFromStorage() {
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), true);
+        this.setCornerWidgetsHidden(!!hidden, false);
+    },
+
+    storageKeyCornerWidgets() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    setCornerWidgetsHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKeyCornerWidgets(), hidden);
+            Logger.log(`Guideline Buttons: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`);
+        }
+        const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
+            btn.title = hidden
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
+        }
+    },
+
+    isCornerWidgetsHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
+    },
+
+    ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
+        const toggleBtnExisting = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            if (toggleBtnExisting) {
+                toggleBtnExisting.remove();
+                Logger.log('Guideline Buttons: corner widgets toggle removed (subOption disabled)');
+            }
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        let toggleBtn = toggleBtnExisting;
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className = buttonClass;
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isCornerWidgetsHidden();
+                this.setCornerWidgetsHidden(nextHidden, true);
+            });
+            wrapper.appendChild(toggleBtn);
+            Logger.log('Guideline Buttons: corner widgets toggle button added');
+        }
+        this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     },
 
     findToolbarContainer() {
@@ -118,5 +219,7 @@ const plugin = {
                 existing.remove();
             }
         }
+
+        this.ensureCornerWidgetsToggleButton(wrapper, buttonClass);
     }
 };

--- a/plugins/archetypes/qa-comp-use/main/guideline-buttons.js
+++ b/plugins/archetypes/qa-comp-use/main/guideline-buttons.js
@@ -11,12 +11,20 @@ const BUTTONS = [
 
 const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
 const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+const CORNER_WIDGETS_SUBOPTION_ID = 'corner-widgets-toggle';
+
+const CORNER_WIDGETS_SUBOPTION = {
+    id: CORNER_WIDGETS_SUBOPTION_ID,
+    name: 'Show/Hide Widgets button',
+    description: 'When enabled, adds a button next to the guideline links that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+    enabledByDefault: true
+};
 
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '2.0',
+    _version: '2.2',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -26,7 +34,7 @@ const plugin = {
         name: b.title,
         description: null,
         enabledByDefault: true
-    })),
+    })).concat([CORNER_WIDGETS_SUBOPTION]),
 
     initialState: {
         wrapperAdded: false,
@@ -73,15 +81,19 @@ const plugin = {
         style.id = 'fleet-corner-widgets-toggle-style';
         style.setAttribute('data-fleet-plugin', this.id);
         // CSS only: no DOM removal. visibility + pointer-events so layout/iframes do not "freak out"
+        // Pylon: #pylon-chat / .PylonChat (see .cursor/context/other/pylon-chat.html)
+        // Report a bug FAB: fixed bottom-20 right-4 size-10 rounded-full (see qa.html)
         style.textContent = `
 body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
-body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat-app {
     visibility: hidden !important;
     pointer-events: none !important;
 }
-/* Bug report FAB (qa page): fixed bottom-20 right-4 */
 body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
-body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed,
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.right-4.bottom-20.size-10,
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4.rounded-full {
     visibility: hidden !important;
     pointer-events: none !important;
 }
@@ -92,7 +104,12 @@ body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
     },
 
     applyCornerWidgetsClassFromStorage() {
-        const hidden = Storage.get(this.storageKeyCornerWidgets(), false);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        // Default true = hidden when no prior storage
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), true);
         this.setCornerWidgetsHidden(!!hidden, false);
     },
 
@@ -109,12 +126,10 @@ body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
         }
         const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
         if (btn) {
-            btn.textContent = hidden
-                ? 'Show Bug Report/Chat Widgets'
-                : 'Hide Bug Report/Chat Widgets';
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
             btn.title = hidden
-                ? 'Show Pylon chat and bug report button (bottom right)'
-                : 'Hide Pylon chat and bug report button (bottom right)';
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
         }
     },
 
@@ -185,7 +200,16 @@ body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
     },
 
     ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
-        let toggleBtn = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        const toggleBtnExisting = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            if (toggleBtnExisting) {
+                toggleBtnExisting.remove();
+                Logger.log('Guideline Buttons: corner widgets toggle removed (subOption disabled)');
+            }
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        let toggleBtn = toggleBtnExisting;
         if (!toggleBtn) {
             toggleBtn = document.createElement('button');
             toggleBtn.setAttribute('data-fleet-plugin', this.id);
@@ -199,7 +223,6 @@ body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
             wrapper.appendChild(toggleBtn);
             Logger.log('Guideline Buttons: corner widgets toggle button added');
         }
-        // Sync label from current body class
         this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     }
 };

--- a/plugins/archetypes/qa-comp-use/main/guideline-buttons.js
+++ b/plugins/archetypes/qa-comp-use/main/guideline-buttons.js
@@ -1,5 +1,6 @@
 // ============= guideline-buttons.js =============
 // Modular guideline link buttons below the user prompt. Wraps when panel is narrow.
+// Toggle hides/shows bottom-right Pylon chat + bug-report FAB via CSS only (visibility + pointer-events).
 
 const QA_GUIDELINES_LINK = 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56';
 
@@ -8,11 +9,14 @@ const BUTTONS = [
     { id: 'meridian-guidelines', title: 'Meridian Guidelines', link: 'https://fleetai.notion.site/Project-Meridian-Guidelines-2eafe5dd3fba80079b86de5dce865477' }
 ];
 
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '1.6',
+    _version: '2.0',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -26,10 +30,14 @@ const plugin = {
 
     initialState: {
         wrapperAdded: false,
-        missingLogged: false
+        missingLogged: false,
+        styleInjected: false
     },
 
     onMutation(state, context) {
+        this.ensureCornerWidgetsStyle(state);
+        this.applyCornerWidgetsClassFromStorage();
+
         // Reuse existing wrapper if present (only one insertion per page)
         let wrapper = document.querySelector(`div[data-fleet-plugin="${this.id}"]`);
         if (wrapper) {
@@ -53,6 +61,65 @@ const plugin = {
         Logger.log('✓ Guideline Buttons: wrapper added below user prompt (qa-comp-use)');
 
         this.syncButtons(wrapper);
+    },
+
+    ensureCornerWidgetsStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        // CSS only: no DOM removal. visibility + pointer-events so layout/iframes do not "freak out"
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+/* Bug report FAB (qa page): fixed bottom-20 right-4 */
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Guideline Buttons: corner widgets hide style injected');
+    },
+
+    applyCornerWidgetsClassFromStorage() {
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), false);
+        this.setCornerWidgetsHidden(!!hidden, false);
+    },
+
+    storageKeyCornerWidgets() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    /** @param {boolean} hidden @param {boolean} persist */
+    setCornerWidgetsHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKeyCornerWidgets(), hidden);
+            Logger.log(`Guideline Buttons: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`);
+        }
+        const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden
+                ? 'Show Bug Report/Chat Widgets'
+                : 'Hide Bug Report/Chat Widgets';
+            btn.title = hidden
+                ? 'Show Pylon chat and bug report button (bottom right)'
+                : 'Hide Pylon chat and bug report button (bottom right)';
+        }
+    },
+
+    isCornerWidgetsHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
     },
 
     findPromptSection() {
@@ -113,5 +180,26 @@ const plugin = {
                 existing.remove();
             }
         }
+
+        this.ensureCornerWidgetsToggleButton(wrapper, buttonClass);
+    },
+
+    ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
+        let toggleBtn = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className = buttonClass;
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isCornerWidgetsHidden();
+                this.setCornerWidgetsHidden(nextHidden, true);
+            });
+            wrapper.appendChild(toggleBtn);
+            Logger.log('Guideline Buttons: corner widgets toggle button added');
+        }
+        // Sync label from current body class
+        this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     }
 };

--- a/plugins/archetypes/tool-use-revision/main/guideline-buttons.js
+++ b/plugins/archetypes/tool-use-revision/main/guideline-buttons.js
@@ -1,16 +1,28 @@
 // ============= guideline-buttons.js =============
 // Modular guideline link buttons in the header bar (same spot as task-creation toolbar).
+// Toggle hides/shows bottom-right Pylon chat + bug-report FAB via CSS only.
 
 const BUTTONS = [
     { id: 'qa-guidelines', title: 'QA Guidelines', link: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56' },
     { id: 'kinesis-guidelines', title: 'Kinesis Guidelines', link: 'https://fleetai.notion.site/Project-Kinesis-Guidelines-2d6fe5dd3fba8023aa78e345939dac3d' }
 ];
 
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+const CORNER_WIDGETS_SUBOPTION_ID = 'corner-widgets-toggle';
+
+const CORNER_WIDGETS_SUBOPTION = {
+    id: CORNER_WIDGETS_SUBOPTION_ID,
+    name: 'Show/Hide Widgets button',
+    description: 'When enabled, adds a button next to the guideline links that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+    enabledByDefault: true
+};
+
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '1.5',
+    _version: '1.6',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -20,14 +32,18 @@ const plugin = {
         name: b.title,
         description: null,
         enabledByDefault: true
-    })),
+    })).concat([CORNER_WIDGETS_SUBOPTION]),
 
     initialState: {
         wrapperAdded: false,
-        missingLogged: false
+        missingLogged: false,
+        styleInjected: false
     },
 
     onMutation(state, context) {
+        this.ensureCornerWidgetsStyle(state);
+        this.applyCornerWidgetsClassFromStorage();
+
         const buttonContainer = this.findToolbarContainer();
         if (!buttonContainer) {
             if (!state.missingLogged) {
@@ -47,6 +63,91 @@ const plugin = {
         }
 
         this.syncButtons(wrapper);
+    },
+
+    ensureCornerWidgetsStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Guideline Buttons: corner widgets hide style injected');
+    },
+
+    applyCornerWidgetsClassFromStorage() {
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), true);
+        this.setCornerWidgetsHidden(!!hidden, false);
+    },
+
+    storageKeyCornerWidgets() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    setCornerWidgetsHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKeyCornerWidgets(), hidden);
+            Logger.log(`Guideline Buttons: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`);
+        }
+        const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
+            btn.title = hidden
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
+        }
+    },
+
+    isCornerWidgetsHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
+    },
+
+    ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
+        const toggleBtnExisting = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            if (toggleBtnExisting) {
+                toggleBtnExisting.remove();
+                Logger.log('Guideline Buttons: corner widgets toggle removed (subOption disabled)');
+            }
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        let toggleBtn = toggleBtnExisting;
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className = buttonClass;
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isCornerWidgetsHidden();
+                this.setCornerWidgetsHidden(nextHidden, true);
+            });
+            wrapper.appendChild(toggleBtn);
+            Logger.log('Guideline Buttons: corner widgets toggle button added');
+        }
+        this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     },
 
     findToolbarContainer() {
@@ -127,5 +228,7 @@ const plugin = {
                 existing.remove();
             }
         }
+
+        this.ensureCornerWidgetsToggleButton(wrapper, buttonClass);
     }
 };

--- a/plugins/archetypes/tool-use-task-creation-openclaw/main/guideline-buttons.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/main/guideline-buttons.js
@@ -1,16 +1,28 @@
 // ============= guideline-buttons.js =============
 // Modular guideline link buttons in the toolbar (same spot as JSON Editor).
+// Toggle hides/shows bottom-right Pylon chat + bug-report FAB via CSS only.
 
 const BUTTONS = [
     { id: 'qa-guidelines', title: 'QA Guidelines', link: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56' },
     { id: 'kinesis-guidelines', title: 'Kinesis Guidelines', link: 'https://fleetai.notion.site/Project-Kinesis-Guidelines-2d6fe5dd3fba8023aa78e345939dac3d' }
 ];
 
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+const CORNER_WIDGETS_SUBOPTION_ID = 'corner-widgets-toggle';
+
+const CORNER_WIDGETS_SUBOPTION = {
+    id: CORNER_WIDGETS_SUBOPTION_ID,
+    name: 'Show/Hide Widgets button',
+    description: 'When enabled, adds a button next to the guideline links that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+    enabledByDefault: true
+};
+
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -20,14 +32,18 @@ const plugin = {
         name: b.title,
         description: null,
         enabledByDefault: true
-    })),
+    })).concat([CORNER_WIDGETS_SUBOPTION]),
 
     initialState: {
         wrapperAdded: false,
-        missingLogged: false
+        missingLogged: false,
+        styleInjected: false
     },
 
     onMutation(state, context) {
+        this.ensureCornerWidgetsStyle(state);
+        this.applyCornerWidgetsClassFromStorage();
+
         const buttonContainer = this.findToolbarContainer();
         if (!buttonContainer) {
             if (!state.missingLogged) {
@@ -47,6 +63,91 @@ const plugin = {
         }
 
         this.syncButtons(wrapper);
+    },
+
+    ensureCornerWidgetsStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Guideline Buttons: corner widgets hide style injected');
+    },
+
+    applyCornerWidgetsClassFromStorage() {
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), true);
+        this.setCornerWidgetsHidden(!!hidden, false);
+    },
+
+    storageKeyCornerWidgets() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    setCornerWidgetsHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKeyCornerWidgets(), hidden);
+            Logger.log(`Guideline Buttons: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`);
+        }
+        const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
+            btn.title = hidden
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
+        }
+    },
+
+    isCornerWidgetsHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
+    },
+
+    ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
+        const toggleBtnExisting = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            if (toggleBtnExisting) {
+                toggleBtnExisting.remove();
+                Logger.log('Guideline Buttons: corner widgets toggle removed (subOption disabled)');
+            }
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        let toggleBtn = toggleBtnExisting;
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className = buttonClass;
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isCornerWidgetsHidden();
+                this.setCornerWidgetsHidden(nextHidden, true);
+            });
+            wrapper.appendChild(toggleBtn);
+            Logger.log('Guideline Buttons: corner widgets toggle button added');
+        }
+        this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     },
 
     findToolbarContainer() {
@@ -139,5 +240,7 @@ const plugin = {
                 existing.remove();
             }
         }
+
+        this.ensureCornerWidgetsToggleButton(wrapper, buttonClass);
     }
 };

--- a/plugins/archetypes/tool-use-task-creation/main/guideline-buttons.js
+++ b/plugins/archetypes/tool-use-task-creation/main/guideline-buttons.js
@@ -1,16 +1,28 @@
 // ============= guideline-buttons.js =============
 // Modular guideline link buttons in the toolbar (same spot as JSON Editor).
+// Toggle hides/shows bottom-right Pylon chat + bug-report FAB via CSS only.
 
 const BUTTONS = [
     { id: 'qa-guidelines', title: 'QA Guidelines', link: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56' },
     { id: 'kinesis-guidelines', title: 'Kinesis Guidelines', link: 'https://fleetai.notion.site/Project-Kinesis-Guidelines-2d6fe5dd3fba8023aa78e345939dac3d' }
 ];
 
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+const CORNER_WIDGETS_SUBOPTION_ID = 'corner-widgets-toggle';
+
+const CORNER_WIDGETS_SUBOPTION = {
+    id: CORNER_WIDGETS_SUBOPTION_ID,
+    name: 'Show/Hide Widgets button',
+    description: 'When enabled, adds a button next to the guideline links that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+    enabledByDefault: true
+};
+
 const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -20,14 +32,18 @@ const plugin = {
         name: b.title,
         description: null,
         enabledByDefault: true
-    })),
+    })).concat([CORNER_WIDGETS_SUBOPTION]),
 
     initialState: {
         wrapperAdded: false,
-        missingLogged: false
+        missingLogged: false,
+        styleInjected: false
     },
 
     onMutation(state, context) {
+        this.ensureCornerWidgetsStyle(state);
+        this.applyCornerWidgetsClassFromStorage();
+
         const buttonContainer = this.findToolbarContainer();
         if (!buttonContainer) {
             if (!state.missingLogged) {
@@ -47,6 +63,91 @@ const plugin = {
         }
 
         this.syncButtons(wrapper);
+    },
+
+    ensureCornerWidgetsStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Guideline Buttons: corner widgets hide style injected');
+    },
+
+    applyCornerWidgetsClassFromStorage() {
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        const hidden = Storage.get(this.storageKeyCornerWidgets(), true);
+        this.setCornerWidgetsHidden(!!hidden, false);
+    },
+
+    storageKeyCornerWidgets() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    setCornerWidgetsHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKeyCornerWidgets(), hidden);
+            Logger.log(`Guideline Buttons: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`);
+        }
+        const btn = document.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
+            btn.title = hidden
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
+        }
+    },
+
+    isCornerWidgetsHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
+    },
+
+    ensureCornerWidgetsToggleButton(wrapper, buttonClass) {
+        const toggleBtnExisting = wrapper.querySelector(`button[data-fleet-corner-widgets-toggle="${this.id}"]`);
+        if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
+            if (toggleBtnExisting) {
+                toggleBtnExisting.remove();
+                Logger.log('Guideline Buttons: corner widgets toggle removed (subOption disabled)');
+            }
+            this.setCornerWidgetsHidden(false, false);
+            return;
+        }
+        let toggleBtn = toggleBtnExisting;
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className = buttonClass;
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isCornerWidgetsHidden();
+                this.setCornerWidgetsHidden(nextHidden, true);
+            });
+            wrapper.appendChild(toggleBtn);
+            Logger.log('Guideline Buttons: corner widgets toggle button added');
+        }
+        this.setCornerWidgetsHidden(this.isCornerWidgetsHidden(), false);
     },
 
     findToolbarContainer() {
@@ -139,5 +240,7 @@ const plugin = {
                 existing.remove();
             }
         }
+
+        this.ensureCornerWidgetsToggleButton(wrapper, buttonClass);
     }
 };


### PR DESCRIPTION
## Summary

Adds an optional **Show/Hide Widgets** control next to guideline links that toggles visibility of the bottom-right **Pylon chat** and **Report a bug** FAB using **CSS only** (`visibility` + `pointer-events`), persisted via storage. The behavior was introduced for `qa-comp-use` and then **unified across all archetypes** that ship `guideline-buttons`, with `archetypes.json` bumped accordingly.

## Changes

- **qa-comp-use `guideline-buttons`**: New sub-option and body class (`fleet-hide-corner-widgets`) to hide corner widgets without removing them from the DOM; state persisted so the choice survives reloads.
- **Other archetypes** (`comp-use-revision`, `comp-use-task-creation`, `tool-use-revision`, `tool-use-task-creation`, `tool-use-task-creation-openclaw`): Same toggle and CSS approach applied so the UX is consistent wherever guideline buttons appear.
- **archetypes.json**: Version/metadata updates for the touched `guideline-buttons` modules.

## Commit history

- `99fef4d` — feat(qa-comp-use): toggle to hide/show corner widgets via CSS only
- `7d64f91` — feat(guideline-buttons): unify corner-widgets toggle across all archetypes

*(Sync branch config commits omitted.)*

## Stats

```
 archetypes.json                                    |  14 +--
 .../comp-use-revision/main/guideline-buttons.js    | 109 ++++++++++++++++++-
 .../main/guideline-buttons.js                      | 109 ++++++++++++++++++-
 .../qa-comp-use/main/guideline-buttons.js          | 117 ++++++++++++++++++++-
 .../tool-use-revision/main/guideline-buttons.js    | 109 ++++++++++++++++++-
 .../main/guideline-buttons.js                      | 109 ++++++++++++++++++-
 .../main/guideline-buttons.js                      | 109 ++++++++++++++++++-
 7 files changed, 651 insertions(+), 25 deletions(-)
```
