### PR TITLE
Add SHA-256 integrity verification for plugins and auto-sync config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Enforce LF line endings for files involved in hash-based integrity verification.
+# Hashes are computed on raw bytes (shasum in CI, TextEncoder in browser);
+# CRLF vs LF differences would cause spurious mismatches.
+*.js text eol=lf
+*.sh text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/update-plugin-hashes.yml
+++ b/.github/workflows/update-plugin-hashes.yml
@@ -11,7 +11,7 @@ jobs:
   update-hashes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Compute plugin hashes
         run: ./dev/utils/compute-hashes.sh

--- a/.github/workflows/update-plugin-hashes.yml
+++ b/.github/workflows/update-plugin-hashes.yml
@@ -1,0 +1,26 @@
+name: Update plugin hashes
+
+on:
+  push:
+    branches-ignore: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  update-hashes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute plugin hashes
+        run: ./dev/utils/compute-hashes.sh
+
+      - name: Commit updated hashes
+        run: |
+          git diff --quiet archetypes.json && echo "No hash changes" && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add archetypes.json
+          git commit -m "CI: update plugin hashes"
+          git push

--- a/.github/workflows/update-plugin-hashes.yml
+++ b/.github/workflows/update-plugin-hashes.yml
@@ -3,6 +3,10 @@ name: Update plugin hashes
 on:
   push:
     branches-ignore: [main]
+    paths:
+      - 'plugins/**'
+      - 'archetypes.json'
+      - 'dev/utils/compute-hashes.sh'
 
 permissions:
   contents: write

--- a/.github/workflows/verify-main-branch-config-pr.yml
+++ b/.github/workflows/verify-main-branch-config-pr.yml
@@ -1,0 +1,34 @@
+name: Sync main branch config (PR)
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-branch-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Sync fleet.user.js for main
+        run: |
+          ./dev/utils/sync-branch-config.sh -m
+
+          if git diff --quiet fleet.user.js; then
+            echo "fleet.user.js is already configured for main."
+            exit 0
+          fi
+
+          echo "fleet.user.js was not synced for main. Committing fix."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add fleet.user.js
+          git commit -m "CI: sync branch config for main"
+          git push

--- a/.github/workflows/verify-main-branch-config-pr.yml
+++ b/.github/workflows/verify-main-branch-config-pr.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   sync-branch-config:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/verify-plugin-hashes-pr.yml
+++ b/.github/workflows/verify-plugin-hashes-pr.yml
@@ -6,25 +6,108 @@ on:
     types: [opened, synchronize]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   verify-hashes:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Compute plugin hashes
-        run: ./dev/utils/compute-hashes.sh
-
-      - name: Commit updated hashes
+      - name: Verify plugin hashes
+        shell: bash
         run: |
-          git diff --quiet archetypes.json && echo "No hash changes" && exit 0
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add archetypes.json
-          git commit -m "CI: update plugin hashes"
-          git push
+          set -e
+
+          archetypes_path="archetypes.json"
+          plugins_dir="plugins"
+
+          compute_hash() {
+            local filepath="$1"
+            if [[ ! -f "$filepath" ]]; then
+              echo ""
+              return
+            fi
+            local hex
+            hex="$(sha256sum "$filepath" | awk '{print $1}')"
+            echo "sha256-${hex}"
+          }
+
+          # Build a JSON object mapping logical keys to hashes.
+          # Keys use prefixes to disambiguate sections (core/, dev/, arch/, devarch/).
+          hashes_json="{"
+          first=true
+
+          # corePlugins → plugins/core/main/<name>
+          while IFS= read -r name; do
+            filepath="$plugins_dir/core/main/$name"
+            hash="$(compute_hash "$filepath")"
+            if [[ -z "$hash" ]]; then
+              echo "::warning::Core plugin file not found: $filepath"
+            fi
+            $first || hashes_json+=","
+            first=false
+            hashes_json+="$(printf '%s' "core/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+          done < <(jq -r '.corePlugins[].name' "$archetypes_path")
+
+          # devPlugins → plugins/core/dev/<name>
+          while IFS= read -r name; do
+            filepath="$plugins_dir/core/dev/$name"
+            hash="$(compute_hash "$filepath")"
+            if [[ -z "$hash" ]]; then
+              echo "::warning::Dev plugin file not found: $filepath"
+            fi
+            $first || hashes_json+=","
+            first=false
+            hashes_json+="$(printf '%s' "dev/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+          done < <(jq -r '.devPlugins[].name' "$archetypes_path")
+
+          # archetypes[].plugins → plugins/archetypes/<id>/main/<name>
+          while IFS=$'\t' read -r aid name; do
+            filepath="$plugins_dir/archetypes/$aid/main/$name"
+            hash="$(compute_hash "$filepath")"
+            if [[ -z "$hash" ]]; then
+              echo "::warning::Archetype plugin file not found: $filepath"
+            fi
+            $first || hashes_json+=","
+            first=false
+            hashes_json+="$(printf '%s' "arch/$aid/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+          done < <(jq -r '.archetypes[] | .id as $aid | .plugins[] | "\($aid)\t\(.name)"' "$archetypes_path")
+
+          # devArchetypes[].plugins → plugins/archetypes/<id>/dev/<name>
+          while IFS=$'\t' read -r aid name; do
+            filepath="$plugins_dir/archetypes/$aid/dev/$name"
+            hash="$(compute_hash "$filepath")"
+            if [[ -z "$hash" ]]; then
+              echo "::warning::Dev archetype plugin file not found: $filepath"
+            fi
+            $first || hashes_json+=","
+            first=false
+            hashes_json+="$(printf '%s' "devarch/$aid/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+          done < <(jq -r '(.devArchetypes // [])[] | .id as $aid | .plugins[] | "\($aid)\t\(.name)"' "$archetypes_path")
+
+          hashes_json+="}"
+
+          # Build expected archetypes.json with computed hashes
+          expected_json="$(mktemp)"
+          trap 'rm -f "$expected_json"' EXIT
+
+          jq -n --slurpfile arch "$archetypes_path" --argjson h "$hashes_json" '
+            ($arch[0]) as $a
+            | $a
+            | .corePlugins |= map(.name as $n | .hash = ($h["core/" + $n] // ""))
+            | .devPlugins |= map(.name as $n | .hash = ($h["dev/" + $n] // ""))
+            | (.archetypes // []) |= map(.id as $aid | .plugins |= map(.name as $n | .hash = ($h["arch/" + $aid + "/" + $n] // "")))
+            | (.devArchetypes // []) |= map(.id as $aid | .plugins |= map(.name as $n | .hash = ($h["devarch/" + $aid + "/" + $n] // "")))
+          ' > "$expected_json"
+
+          if diff -q "$archetypes_path" "$expected_json" > /dev/null 2>&1; then
+            echo "Plugin hashes are up to date."
+          else
+            echo "::error::Plugin hashes are out of date. Run ./dev/utils/compute-hashes.sh locally and commit the updated archetypes.json."
+            echo ""
+            echo "Differences:"
+            diff "$archetypes_path" "$expected_json" || true
+            exit 1
+          fi

--- a/.github/workflows/verify-plugin-hashes-pr.yml
+++ b/.github/workflows/verify-plugin-hashes-pr.yml
@@ -1,0 +1,30 @@
+name: Verify plugin hashes (PR)
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  verify-hashes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Compute plugin hashes
+        run: ./dev/utils/compute-hashes.sh
+
+      - name: Commit updated hashes
+        run: |
+          git diff --quiet archetypes.json && echo "No hash changes" && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add archetypes.json
+          git commit -m "CI: update plugin hashes"
+          git push

--- a/.github/workflows/verify-plugin-hashes-pr.yml
+++ b/.github/workflows/verify-plugin-hashes-pr.yml
@@ -12,7 +12,7 @@ jobs:
   verify-hashes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.0.0",
-  "archetypesVersion": "6.56",
+  "archetypesVersion": "6.57",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -649,13 +649,7 @@
       "description": "Page for reviewing and fixing previously submitted tool use tasks",
       "urlPattern": "work/problems/respond-feedback/edit-tool-use*",
       "disambiguationSelectors": [],
-      "plugins": [
-        {
-          "name": "source-data-explorer.js",
-          "version": "1.2",
-          "hash": ""
-        }
-      ]
+      "plugins": []
     },
     {
       "id": "qa-tool-use",
@@ -686,13 +680,7 @@
       "description": "Page for creating computer use tasks",
       "urlPattern": "work/problems/create*",
       "disambiguationSelectors": [],
-      "plugins": [
-        {
-          "name": "source-data-explorer.js",
-          "version": "1.2",
-          "hash": ""
-        }
-      ]
+      "plugins": []
     },
     {
       "id": "comp-use-revision",
@@ -700,13 +688,7 @@
       "description": "Page for reviewing and fixing previously submitted computer use tasks",
       "urlPattern": "work/problems/respond-feedback/edit*",
       "disambiguationSelectors": [],
-      "plugins": [
-        {
-          "name": "source-data-explorer.js",
-          "version": "1.2",
-          "hash": ""
-        }
-      ]
+      "plugins": []
     },
     {
       "id": "qa-comp-use",

--- a/archetypes.json
+++ b/archetypes.json
@@ -41,7 +41,7 @@
         {
           "name": "feedback-given-stats.js",
           "version": "2.9",
-          "hash": "sha256-3c09a920843a00b381c003472b79588f99d52645386e3ac263878f56121f4a55"
+          "hash": "sha256-3c09a920843a00b382c003472b79588f99d52645386e3ac263878f56121f4a55"
         },
         {
           "name": "task-creation-today-env.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -41,7 +41,7 @@
         {
           "name": "feedback-given-stats.js",
           "version": "2.9",
-          "hash": "sha256-3c09a920843a00b382c003472b79588f99d52645386e3ac263878f56121f4a55"
+          "hash": "sha256-3c09a920843a00b381c003472b79588f99d52645386e3ac263878f56121f4a55"
         },
         {
           "name": "task-creation-today-env.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -4,13 +4,15 @@
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.1"
+      "version": "6.1",
+      "hash": "sha256-b73eddefd35b3053f0256f00f05e664029aced364948f8824836eea0d2566286"
     }
   ],
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.5"
+      "version": "2.5",
+      "hash": "sha256-0590775e6e7436ac9efb9a2d164a4e28689e6ed4d3700f47be41268ec2ce1390"
     }
   ],
   "settingsModalDocs": [
@@ -33,19 +35,23 @@
       "plugins": [
         {
           "name": "progress-prompt-expand.js",
-          "version": "1.7"
+          "version": "1.7",
+          "hash": "sha256-d9c6ec87f1e51d40bc2f8001a81f897a6f392d9a29aa92d12237c8ef00196a89"
         },
         {
           "name": "feedback-given-stats.js",
-          "version": "2.9"
+          "version": "2.9",
+          "hash": "sha256-3c09a920843a00b381c003472b79588f99d52645386e3ac263878f56121f4a55"
         },
         {
           "name": "task-creation-today-env.js",
-          "version": "2.9"
+          "version": "2.9",
+          "hash": "sha256-d2ba0d08ad094416c7fbf930615413b0a6342c2842bd88a2cf052f11797a152f"
         },
         {
           "name": "disputes-reviewed-today.js",
-          "version": "2.9"
+          "version": "2.9",
+          "hash": "sha256-a07092bf7da5ba4c5da458ef482ae98f8a3610b3e72238b0890887cc910b83d0"
         }
       ]
     },
@@ -58,55 +64,68 @@
       "plugins": [
         {
           "name": "clear-search.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-26456ceb6951f47c4ac23fa933c135e110c7506d6b3a0dd4249c3daf26c08063"
         },
         {
           "name": "json-editor-online.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-b1c8988a2a24db1f124045a66e92f8e46e5666409d8f2ac7f3e9f49bf3abef1b"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-22fa7eae954c71a89c0f8dfa3742b0c4b8aa8d0f26d121ffcb610d3387fe84ac"
         },
         {
           "name": "favorites.js",
-          "version": "4.0"
+          "version": "4.0",
+          "hash": "sha256-3d479c21ea95d0b320ed742289f6b716e632c85dbde6b0ca17e9fca518d712af"
         },
         {
           "name": "remove-textarea-gradient.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-4d0f26a20e6ffaf5f943ad07aeafc6e26edeeca0e200198c23b1b88f6ed28c3e"
         },
         {
           "name": "remember-layout-proportions.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-1a76da94eca1432764ddc9de9acadc7aaae19606f54bcb5060a4ab80eb32c200"
         },
         {
           "name": "prompt-and-notes-areas.js",
-          "version": "3.1"
+          "version": "3.1",
+          "hash": "sha256-6139e763f20b96517308fd3c9c2960c92534de686c618a408d205518bdc598ed"
         },
         {
           "name": "execute-to-current-tool.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-c1366496dfa3747ebe7f8f1f82562b1dc79035bcb598f04e2a4f22cc6ee9a2cf"
         },
         {
           "name": "workflow-cache.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-cbe1b187968425d30a2bcd61f80cf187397d43b1e686d4db75c27186ceac19e9"
         },
         {
           "name": "toggle-tool-parameters.js",
-          "version": "2.3"
+          "version": "2.3",
+          "hash": "sha256-91d127b2717d00ac5c0fe82f238d276f81b92e67d97200f560de7afb42c233ae"
         },
         {
           "name": "tool-results-resize-handle.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-c949a14b32c40af22a192941539ae09d36c14a3f908dce61eed13b7bcaa31af0"
         },
         {
           "name": "tool-description-truncate.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-f806767296a5ea148780c47656f14999b8103739363feb9cd1e528e1a4fca27e"
         },
         {
           "name": "text-sanitizer.js",
-          "version": "3.2"
+          "version": "3.2",
+          "hash": "sha256-0f154eb18fb015f999c02faa59011ad4776719c3ac1faa6980dac73c7b408824"
         }
       ]
     },
@@ -121,47 +140,58 @@
       "plugins": [
         {
           "name": "clear-search.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-a3f797c53cbc1b8ecfc5034a73400267987c2a9edc6219e856735e018b5755a5"
         },
         {
           "name": "json-editor-online.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-b1c8988a2a24db1f124045a66e92f8e46e5666409d8f2ac7f3e9f49bf3abef1b"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-22fa7eae954c71a89c0f8dfa3742b0c4b8aa8d0f26d121ffcb610d3387fe84ac"
         },
         {
           "name": "favorites.js",
-          "version": "4.0"
+          "version": "4.0",
+          "hash": "sha256-3d479c21ea95d0b320ed742289f6b716e632c85dbde6b0ca17e9fca518d712af"
         },
         {
           "name": "remove-textarea-gradient.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-4d0f26a20e6ffaf5f943ad07aeafc6e26edeeca0e200198c23b1b88f6ed28c3e"
         },
         {
           "name": "remember-layout-proportions.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-1a76da94eca1432764ddc9de9acadc7aaae19606f54bcb5060a4ab80eb32c200"
         },
         {
           "name": "execute-to-current-tool.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-c1366496dfa3747ebe7f8f1f82562b1dc79035bcb598f04e2a4f22cc6ee9a2cf"
         },
         {
           "name": "workflow-cache.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-46ab5c6741a7d67dad4ef348353d4f1f4cf25d5fb5e746b8759077bdfc30e0bd"
         },
         {
           "name": "toggle-tool-parameters.js",
-          "version": "2.3"
+          "version": "2.3",
+          "hash": "sha256-91d127b2717d00ac5c0fe82f238d276f81b92e67d97200f560de7afb42c233ae"
         },
         {
           "name": "tool-results-resize-handle.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-c949a14b32c40af22a192941539ae09d36c14a3f908dce61eed13b7bcaa31af0"
         },
         {
           "name": "text-sanitizer.js",
-          "version": "3.2"
+          "version": "3.2",
+          "hash": "sha256-0f154eb18fb015f999c02faa59011ad4776719c3ac1faa6980dac73c7b408824"
         }
       ]
     },
@@ -174,51 +204,63 @@
       "plugins": [
         {
           "name": "clear-search.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-1a0622c93b663b7e64b5e3a3c29f0ddd06eb7e464cb655f47c491b5c24a53aed"
         },
         {
           "name": "favorites.js",
-          "version": "5.0"
+          "version": "5.0",
+          "hash": "sha256-e8b53a6643768475e3f975d89805da88cd0fdde8152625003da406e3180d5060"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.6"
+          "version": "1.6",
+          "hash": "sha256-3aefd5135a7621e6c9d63261d46e6d87b91cb455cc1f93f65d9f71dd97525d2a"
         },
         {
           "name": "bug-report-expand.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-0638eeaea59ff4cecffc2ca1a6e19c922e98c974ced1f54c018130313a2771d2"
         },
         {
           "name": "prompt-scratchpad.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-6ab9d874928c74166fd43aadac8c5538a52268aa751acd30020d318ed415d9d9"
         },
         {
           "name": "execute-to-current-tool.js",
-          "version": "3.0"
+          "version": "3.0",
+          "hash": "sha256-ff34686d136205e519afdfc017deb48012e9f2dc116a4d375987a83b36c932a2"
         },
         {
           "name": "workflow-cache.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-3cf51593be8e4acb29476964fd74fa078a937e1bc691d144dacd622dcde39873"
         },
         {
           "name": "toggle-tool-parameters.js",
-          "version": "3.1"
+          "version": "3.1",
+          "hash": "sha256-e842744b2c05fd5d11b3e1fc5f2ecb476fc5deb4dfca2ce7d22acd985d629331"
         },
         {
           "name": "tool-results-resize-handle.js",
-          "version": "3.0"
+          "version": "3.0",
+          "hash": "sha256-052a9388e4afa5d2deb1815cf89bd35bfc4af400def565b18aa60f917a72b5f5"
         },
         {
           "name": "tool-description-truncate.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-53bbb4926e5939a3bfd64152cdeb9ea12689250dbb074e0e79e8ddc22371d60a"
         },
         {
           "name": "text-sanitizer.js",
-          "version": "3.0"
+          "version": "3.0",
+          "hash": "sha256-ce678d871cf2433fbe5d7053403808306ba949239eaab1399ba95baf2e4e15e0"
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "3.2"
+          "version": "3.2",
+          "hash": "sha256-626f4f46d17bd7d2057a09e3cd9bb1c44640ad5ae5548a566fe9b5b30258e282"
         }
       ]
     },
@@ -231,27 +273,33 @@
       "plugins": [
         {
           "name": "auto-toggle-fullscreen-mode.js",
-          "version": "1.1"
+          "version": "1.1",
+          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227"
         },
         {
           "name": "remove-textarea-gradient.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-c4b179cd62b8816a34e00f727d4d3780836bd67cd69441ac5f2f74b0d9656f60"
         },
         {
           "name": "hide-testing-environment-banner.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.4"
+          "version": "1.4",
+          "hash": "sha256-4481551aecbebfdc15450bbad9cedd2d4a3acfc624b64d7796292d90261b4025"
         },
         {
           "name": "prompt-scratchpad.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-f15fc7a63ee2f7fd9219793423b0bc0173b18596ea23570960bdf5a253e528be"
         },
         {
           "name": "remember-layout-proportions.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
         }
       ]
     },
@@ -264,31 +312,38 @@
       "plugins": [
         {
           "name": "auto-toggle-fullscreen-mode.js",
-          "version": "1.1"
+          "version": "1.1",
+          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227"
         },
         {
           "name": "remove-textarea-gradient.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-c4b179cd62b8816a34e00f727d4d3780836bd67cd69441ac5f2f74b0d9656f60"
         },
         {
           "name": "hide-testing-environment-banner.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "1.4"
+          "version": "1.4",
+          "hash": "sha256-533bd516613590d019c13093f0edd6b30a624e38916573ad29411c8e21cf8f50"
         },
         {
           "name": "bug-report-expand.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-0638eeaea59ff4cecffc2ca1a6e19c922e98c974ced1f54c018130313a2771d2"
         },
         {
           "name": "prompt-scratchpad.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-64f89a9a1b7f2b2fc211a39ca811bff49dd4c2764c320f0a5906f9beb97845e7"
         },
         {
           "name": "remember-layout-proportions.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
         }
       ]
     },
@@ -301,71 +356,88 @@
       "plugins": [
         {
           "name": "clear-search.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-1c909857b79e8a369bd2e9a1767445fbfc0f77ae50c40b2c6fb09e879c7357f3"
         },
         {
           "name": "favorites.js",
-          "version": "4.0"
+          "version": "4.0",
+          "hash": "sha256-dd991aa618b4f49abf7890a69e99a826eaaa897a250bb204d3b54e434382eb53"
         },
         {
           "name": "bug-report-expand.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-ebd685e61af47b6510bb1949d48135a33e9b5dd6e98765f3267e310377239d32"
         },
         {
           "name": "copy-prompt.js",
-          "version": "1.5"
+          "version": "1.5",
+          "hash": "sha256-334230142843259239f5393574d84119b44c237adea0c29c421276a50471ab6e"
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-38f088a48ab0e31419fc943d9cdc6b30130c455a354a3acc3260a5f7888224e9"
         },
         {
           "name": "remember-layout-proportions.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-bc06d024d1e9c6e0c201f511e28feb8db83ee2f561e03624a970614df01e4fd8"
         },
         {
           "name": "qa-scratchpad.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-bc86c47ce2a79a9d662606bb7b198193cd0a1d80cc249d036330795bc1de4e9f"
         },
         {
           "name": "useful-links-buttons.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-50c1f7fc4866dd01e3fd5ffa72affe7ee41fb3b8dcd359c9ae299f42b5a6a0d2"
         },
         {
           "name": "text-sanitizer.js",
-          "version": "2.5"
+          "version": "2.5",
+          "hash": "sha256-a856089dc28fa3cba92d2c554c9f3eb820a3e08a35ea07b96286cda90342c3be"
         },
         {
           "name": "execute-to-current-tool.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-430bec914ed32d755da7477788c34586d55a288d7b30dffdbb19a01ae0e45161"
         },
         {
           "name": "toggle-tool-parameters.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-76c9ebbf39700d8e38758021084cd4cb95a57152e78a980c7897decae767602e"
         },
         {
           "name": "request-revisions.js",
-          "version": "4.4"
+          "version": "4.4",
+          "hash": "sha256-a1cb1bd7c7fb8dd85d9ffe629ddaac8c087d86031fe04b6886500405fe95a66d"
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-a6df47743adaace458ec92b165a498acee5fdaf0ca1365d16b4a314112c4f650"
         },
         {
           "name": "tool-results-resize-handle.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-4222b6ccc3d55b2c996a37010868bd73b34f4b8a26438375a6ff152a89ab194b"
         },
         {
           "name": "tool-description-truncate.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-a9cbab9521fb434443a27faae81d41bf51ff6cfd41feb6e6491de0dbb8edc78b"
         },
         {
           "name": "workflow-cache.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-e8846babc1b9c74a93f4929c69313864d12b0c22f5cb3b36cbea317ddb53823c"
         },
         {
           "name": "accept-task-modal-improvements.js",
-          "version": "1.7"
+          "version": "1.7",
+          "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6"
         }
       ]
     },
@@ -378,55 +450,68 @@
       "plugins": [
         {
           "name": "auto-toggle-fullscreen-mode.js",
-          "version": "1.1"
+          "version": "1.1",
+          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227"
         },
         {
           "name": "hide-testing-environment-banner.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
         },
         {
           "name": "bug-report-expand.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-ebd685e61af47b6510bb1949d48135a33e9b5dd6e98765f3267e310377239d32"
         },
         {
           "name": "copy-prompt.js",
-          "version": "1.4"
+          "version": "1.4",
+          "hash": "sha256-75da918251762019fdf930c02859528f9a5a8cfed62f30e4b47bbf8d47ab5543"
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.2"
+          "version": "1.2",
+          "hash": "sha256-5b231272a0f7829c86f63957244099b6ef187264c377421cd6d5d3ee2d5798d5"
         },
         {
           "name": "copy-result-params.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-f6220beabcf293173f07b6f26b47d453b2a546bfdf615426b628bc2dcf897164"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-5ea99283f4a46c9e9520419e8505a9ecb51f2ed63d54b84c724cf2d899a42500"
         },
         {
           "name": "request-revisions.js",
-          "version": "3.6"
+          "version": "3.6",
+          "hash": "sha256-e42923dc35f3c4bd68844ee1927b15973774651af8c49500bf6ef9494cfd1fc6"
         },
         {
           "name": "qa-scratchpad.js",
-          "version": "1.6"
+          "version": "1.6",
+          "hash": "sha256-b219842987392a09692ea5f093331aef49477b8b25af8faff0272d273431d16a"
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "2.2"
+          "version": "2.2",
+          "hash": "sha256-a6df47743adaace458ec92b165a498acee5fdaf0ca1365d16b4a314112c4f650"
         },
         {
           "name": "verifier-diff-highlight-improved.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-f03f7199c76459273148b308a590bd2b493439d74bad1c396dbcc122711241c1"
         },
         {
           "name": "accept-task-modal-improvements.js",
-          "version": "1.7"
+          "version": "1.7",
+          "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6"
         },
         {
           "name": "remember-layout-proportions.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
         }
       ]
     },
@@ -447,47 +532,58 @@
       "plugins": [
         {
           "name": "env-load-gate.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-84403bd9d0d3278966bc215c3eebec38c222feb277da52c0a7ff3625c2ec3ef3"
         },
         {
           "name": "dispute-detail-task-id.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-b43b20e4851adc3ba3cd079230e08546fd2bede9c0c1f01fb5a24fa0de887c71"
         },
         {
           "name": "dispute-content-layout-fixes.js",
-          "version": "1.2"
+          "version": "1.2",
+          "hash": "sha256-8305f713adae4f30a51538972018542eedec9a7f63d7a4871014fd16ffef1a37"
         },
         {
           "name": "dispute-resolution-widgets-toggle.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-a6cab015e8efca7d041130598d2c551b55ee1a733e0a6eb1810cb01bd2fe96bb"
         },
         {
           "name": "clear-search.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-80b40af93a2889dc851f876b304f8dd015080f0d6c3acd2f3e5bc32a29795e23"
         },
         {
           "name": "favorites.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-1d840f89b2dc12883cc22e15fa620c1141ad53289746d048c5e5fe00ef110af0"
         },
         {
           "name": "execute-to-current-tool.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-edd3970d03416214ee6d948232316accb36d19853199f92ccf233d3bb9d0f80e"
         },
         {
           "name": "toggle-tool-parameters.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-13164379dd18ccc7afad0ce64a0f6be993359d0f1cffc7a0bc65d5bfec40d603"
         },
         {
           "name": "tool-results-resize-handle.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-0f8cfd666edeb33ca97796b097bafbdc1eabcf2a5a1524313edb6f7c259bbd70"
         },
         {
           "name": "tool-description-truncate.js",
-          "version": "1.0"
+          "version": "1.0",
+          "hash": "sha256-0d5430a1eae172431ca9692c3809b478d58d2779ccb30ea4cb277a3845f2d2d1"
         },
         {
           "name": "verifier-diff-highlight-improved.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-0a9c1d87eb11d29d570b8a61d9c0460a7d54b876a0119037e71effc9494ef707"
         }
       ]
     },
@@ -500,7 +596,8 @@
       "plugins": [
         {
           "name": "prompt-diff-highlight.js",
-          "version": "3.2"
+          "version": "3.2",
+          "hash": "sha256-626f4f46d17bd7d2057a09e3cd9bb1c44640ad5ae5548a566fe9b5b30258e282"
         }
       ]
     }
@@ -515,11 +612,13 @@
       "plugins": [
         {
           "name": "source-data-explorer.js",
-          "version": "4.0"
+          "version": "4.0",
+          "hash": "sha256-f8fff3deb0e23fc26053afe83da4da68b2f231f9c3961e1bdfb5ac0caa3a86f0"
         },
         {
           "name": "workflow-integrity-check.js",
-          "version": "2.0"
+          "version": "2.0",
+          "hash": "sha256-73c0cfacead59b2325ac1d937bf27a2c8c07b82331ef9657c5e8003e4f4829f0"
         }
       ]
     },
@@ -534,11 +633,13 @@
       "plugins": [
         {
           "name": "prompt-and-notes-areas.js",
-          "version": "3.1"
+          "version": "3.1",
+          "hash": "sha256-6139e763f20b96517308fd3c9c2960c92534de686c618a408d205518bdc598ed"
         },
         {
           "name": "tool-description-truncate.js",
-          "version": "2.1"
+          "version": "2.1",
+          "hash": "sha256-3062ae5abb6df57a519dc08c43e04db1f852c9f7359304c01eeebece158b14d4"
         }
       ]
     },
@@ -551,7 +652,8 @@
       "plugins": [
         {
           "name": "source-data-explorer.js",
-          "version": "1.2"
+          "version": "1.2",
+          "hash": ""
         }
       ]
     },
@@ -563,15 +665,18 @@
       "plugins": [
         {
           "name": "source-data-explorer.js",
-          "version": "1.3"
+          "version": "1.3",
+          "hash": "sha256-8770f8edc00b55148e48267415c6804339e687dcee1a24f42a901df84eba1095"
         },
         {
           "name": "workflow-integrity-check.js",
-          "version": "1.1"
+          "version": "1.1",
+          "hash": "sha256-3e3478682d1f7379e40d933e399fcb234df7ee1e7dc52305fc61559d08835867"
         },
         {
           "name": "reorganize-request-revisions.js",
-          "version": "1.1"
+          "version": "1.1",
+          "hash": "sha256-1f7708627f64c04c6f92a33c49c783a79ff144ea7485cf4a285d805d758ed72d"
         }
       ]
     },
@@ -584,7 +689,8 @@
       "plugins": [
         {
           "name": "source-data-explorer.js",
-          "version": "1.2"
+          "version": "1.2",
+          "hash": ""
         }
       ]
     },
@@ -597,7 +703,8 @@
       "plugins": [
         {
           "name": "source-data-explorer.js",
-          "version": "1.2"
+          "version": "1.2",
+          "hash": ""
         }
       ]
     },
@@ -618,7 +725,8 @@
       "plugins": [
         {
           "name": "dispute-ids-enhancer.js",
-          "version": "3.0"
+          "version": "3.0",
+          "hash": "sha256-bd56d8ced343b95235e7f7f3d4e2977d723afc10aa838e47c7ff7ae66c0ddbf9"
         }
       ]
     }

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
-  "version": "5.3.2",
-  "archetypesVersion": "6.55",
+  "version": "6.0.0",
+  "archetypesVersion": "6.56",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/dev/utils/compute-hashes.sh
+++ b/dev/utils/compute-hashes.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# compute-hashes.sh — Compute SHA-256 hashes for all plugins and update archetypes.json
+#
+# Usage:
+#   ./dev/utils/compute-hashes.sh [--dry-run] [--root DIR] [--archetypes PATH] [--plugins-dir DIR]
+#
+# Options:
+#   --dry-run          Print what would be changed; do not modify archetypes.json.
+#   --root DIR         Repository root (default: derived from git).
+#   --archetypes PATH  Path to archetypes.json (default: <root>/archetypes.json).
+#   --plugins-dir DIR  Plugins directory (default: <root>/plugins).
+#
+# Effects:
+#   1. Reads plugin entries from archetypes.json (corePlugins, devPlugins, archetypes, devArchetypes).
+#   2. Computes SHA-256 hash of each plugin file on disk.
+#   3. Adds or updates the "hash" field on each plugin object in archetypes.json.
+#
+# Prerequisites: jq, shasum (standard on macOS and most Linux).
+
+set -e
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+archetypes_path=""
+plugins_dir=""
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)       dry_run=true; shift ;;
+    --root)          root="$(cd "$2" && pwd)"; shift 2 ;;
+    --archetypes)    archetypes_path="$2"; shift 2 ;;
+    --plugins-dir)   plugins_dir="$2"; shift 2 ;;
+    *)               echo "[error] Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+archetypes_path="${archetypes_path:-$root/archetypes.json}"
+plugins_dir="${plugins_dir:-$root/plugins}"
+
+if ! command -v jq &>/dev/null; then
+  echo "[error] jq is required but not installed." >&2
+  exit 1
+fi
+
+if [[ ! -f "$archetypes_path" ]]; then
+  echo "[error] archetypes.json not found: $archetypes_path" >&2
+  exit 1
+fi
+
+if [[ ! -d "$plugins_dir" ]]; then
+  echo "[error] Plugins directory not found: $plugins_dir" >&2
+  exit 1
+fi
+
+# Returns "sha256-<hex>" for a file, or empty string if the file does not exist.
+compute_hash() {
+  local filepath="$1"
+  if [[ ! -f "$filepath" ]]; then
+    echo ""
+    return
+  fi
+  local hex
+  hex="$(shasum -a 256 "$filepath" | awk '{print $1}')"
+  echo "sha256-${hex}"
+}
+
+# Build a JSON object mapping logical keys to hashes.
+# Keys use prefixes to disambiguate sections (core/, dev/, arch/, devarch/).
+hashes_json="{"
+first=true
+
+# corePlugins → plugins/core/main/<name>
+while IFS= read -r name; do
+  filepath="$plugins_dir/core/main/$name"
+  hash="$(compute_hash "$filepath")"
+  if [[ -z "$hash" ]]; then
+    echo "[warn] Core plugin file not found: $filepath" >&2
+  fi
+  $first || hashes_json+=","
+  first=false
+  hashes_json+="$(printf '%s' "core/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+done < <(jq -r '.corePlugins[].name' "$archetypes_path")
+
+# devPlugins → plugins/core/dev/<name>
+while IFS= read -r name; do
+  filepath="$plugins_dir/core/dev/$name"
+  hash="$(compute_hash "$filepath")"
+  if [[ -z "$hash" ]]; then
+    echo "[warn] Dev plugin file not found: $filepath" >&2
+  fi
+  $first || hashes_json+=","
+  first=false
+  hashes_json+="$(printf '%s' "dev/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+done < <(jq -r '.devPlugins[].name' "$archetypes_path")
+
+# archetypes[].plugins → plugins/archetypes/<id>/main/<name>
+while IFS=$'\t' read -r aid name; do
+  filepath="$plugins_dir/archetypes/$aid/main/$name"
+  hash="$(compute_hash "$filepath")"
+  if [[ -z "$hash" ]]; then
+    echo "[warn] Archetype plugin file not found: $filepath" >&2
+  fi
+  $first || hashes_json+=","
+  first=false
+  hashes_json+="$(printf '%s' "arch/$aid/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+done < <(jq -r '.archetypes[] | .id as $aid | .plugins[] | "\($aid)\t\(.name)"' "$archetypes_path")
+
+# devArchetypes[].plugins → plugins/archetypes/<id>/dev/<name>
+while IFS=$'\t' read -r aid name; do
+  filepath="$plugins_dir/archetypes/$aid/dev/$name"
+  hash="$(compute_hash "$filepath")"
+  if [[ -z "$hash" ]]; then
+    echo "[warn] Dev archetype plugin file not found: $filepath" >&2
+  fi
+  $first || hashes_json+=","
+  first=false
+  hashes_json+="$(printf '%s' "devarch/$aid/$name" | jq -Rs .): $(printf '%s' "$hash" | jq -Rs .)"
+done < <(jq -r '(.devArchetypes // [])[] | .id as $aid | .plugins[] | "\($aid)\t\(.name)"' "$archetypes_path")
+
+hashes_json+="}"
+
+# Update archetypes.json: set .hash on every plugin object
+tmp_json="$(mktemp)"
+trap 'rm -f "$tmp_json"' EXIT
+
+jq -n --slurpfile arch "$archetypes_path" --argjson h "$hashes_json" '
+  ($arch[0]) as $a
+  | $a
+  | .corePlugins |= map(.name as $n | .hash = ($h["core/" + $n] // ""))
+  | .devPlugins |= map(.name as $n | .hash = ($h["dev/" + $n] // ""))
+  | (.archetypes // []) |= map(.id as $aid | .plugins |= map(.name as $n | .hash = ($h["arch/" + $aid + "/" + $n] // "")))
+  | (.devArchetypes // []) |= map(.id as $aid | .plugins |= map(.name as $n | .hash = ($h["devarch/" + $aid + "/" + $n] // "")))
+' > "$tmp_json"
+
+if [[ "$dry_run" == true ]]; then
+  if ! cmp -s "$archetypes_path" "$tmp_json"; then
+    echo "[dry-run] Would update hashes in archetypes.json"
+  else
+    echo "[dry-run] No hash changes in archetypes.json"
+  fi
+  exit 0
+fi
+
+if ! cmp -s "$archetypes_path" "$tmp_json"; then
+  cp "$tmp_json" "$archetypes_path"
+  echo "[info] Updated plugin hashes in archetypes.json"
+else
+  echo "[info] No hash changes in archetypes.json"
+fi
+
+exit 0

--- a/dev/utils/compute-hashes.sh
+++ b/dev/utils/compute-hashes.sh
@@ -44,6 +44,11 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
+if ! command -v shasum &>/dev/null; then
+  echo "[error] shasum is required but not installed. On Linux, install it via the 'perl' package." >&2
+  exit 1
+fi
+
 if [[ ! -f "$archetypes_path" ]]; then
   echo "[error] archetypes.json not found: $archetypes_path" >&2
   exit 1

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-cryptographic-signing] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.0.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-cryptographic-signing/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-cryptographic-signing/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-cryptographic-signing',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-cryptographic-signing] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      5.3.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-cryptographic-signing/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-cryptographic-signing/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-cryptographic-signing',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-cryptographic-signing] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      5.3.2
+// @version      6.0.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -28,7 +28,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '5.3.2';
+    const VERSION = '6.0.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1277,13 +1277,18 @@
         
         /**
          * Compute SHA-256 hash of plugin code, matching the format used by compute-hashes.sh.
+         * Assumes UTF-8 encoding and LF-only line endings (no CRLF normalization).
          * @param {string} code - Plugin source code
          * @returns {Promise<string>} - Hash in "sha256-<hex>" format
          */
         async computeHash(code) {
-            const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(code));
-            const hex = Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, '0')).join('');
-            return 'sha256-' + hex;
+            try {
+                const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(code));
+                const hex = Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+                return 'sha256-' + hex;
+            } catch (err) {
+                throw new Error(`SHA-256 hashing failed for integrity check: ${err.message || err}`);
+            }
         },
 
         /**
@@ -1297,7 +1302,7 @@
             const computed = await this.computeHash(code);
             const valid = computed === expectedHash;
             if (!valid) {
-                Logger.debug(`Hash mismatch for ${filename}: expected ${expectedHash.slice(0, 24)}..., computed ${computed.slice(0, 24)}...`);
+                Logger.warn(`Hash mismatch for ${filename}: expected ${expectedHash.slice(0, 24)}..., computed ${computed.slice(0, 24)}...`);
             }
             return { valid, computed };
         },
@@ -1333,22 +1338,28 @@
             const cached = Storage.getCachedPlugin(pluginKey);
             const isMainLike = MAIN_LIKE_BRANCHES.includes(GITHUB_CONFIG.branch);
 
-            // On production branches, an integrity hash is required
-            if (!expectedHash && isMainLike) {
-                Logger.error(`Plugin ${filename} blocked: no integrity hash in archetypes.json`);
-                throw new Error(`Plugin ${filename} blocked: no integrity hash`);
+            // On main-like branches, an integrity hash is required
+            if ((expectedHash === undefined || expectedHash === '') && isMainLike) {
+                const reason = expectedHash === '' ? 'empty integrity hash' : 'missing integrity hash';
+                Logger.error(`Plugin ${filename} blocked: ${reason} in archetypes.json`);
+                throw new Error(`Plugin ${filename} blocked: ${reason}`);
             }
 
             // --- CACHE PATH ---
             if (cached && cached.version === version) {
                 if (expectedHash) {
-                    const hashResult = await this.verifyPluginHash(cached.code, expectedHash, filename);
-                    if (hashResult.valid) {
-                        Logger.debug(`Using cached plugin ${filename} v${version} (hash verified)`);
-                        this._registerCacheForArchetype(sourcePath, filename);
-                        return cached.code;
+                    try {
+                        const hashResult = await this.verifyPluginHash(cached.code, expectedHash, filename);
+                        if (hashResult.valid) {
+                            Logger.debug(`Using cached plugin ${filename} v${version} (hash verified)`);
+                            this._registerCacheForArchetype(sourcePath, filename);
+                            return cached.code;
+                        }
+                        Logger.warn(`Cached ${filename} v${version} failed hash check. Re-fetching.`);
+                    } catch (hashError) {
+                        Logger.error(`Hash verification failed for ${filename}:`, hashError);
+                        throw new Error(`Plugin ${filename} blocked: hash verification error — ${hashError.message || hashError}`);
                     }
-                    Logger.warn(`Cached ${filename} v${version} failed hash check. Re-fetching.`);
                 } else {
                     Logger.debug(`Using cached plugin ${filename} v${version} (no hash — dev branch)`);
                     this._registerCacheForArchetype(sourcePath, filename);
@@ -1388,8 +1399,7 @@
                         throw new Error(`Plugin ${filename} blocked: integrity hash mismatch`);
                     }
 
-                    Logger.warn(`⚠ Plugin ${filename} hash mismatch (dev branch). Loading anyway.`);
-                    this.cachePluginCode(filename, sourcePath, fetchedCode, version);
+                    Logger.warn(`⚠ Plugin ${filename} hash mismatch (dev branch). Loading anyway (not caching).`);
                     return fetchedCode;
                 }
 
@@ -1436,6 +1446,7 @@
 
             } catch (error) {
                 if (cached) {
+                    Logger.warn(`Fetch failed for ${filename}, falling back to cache:`, error);
                     // On main, even fallback cache must pass integrity check
                     if (expectedHash && isMainLike) {
                         const hashResult = await this.verifyPluginHash(cached.code, expectedHash, filename);
@@ -1648,6 +1659,7 @@
 
             for (const pluginDef of pluginList) {
                 let filename, version, hash;
+                // Backward compat: older archetypes.json entries may be plain strings
                 if (typeof pluginDef === 'string') {
                     filename = pluginDef;
                     version = '1.0';
@@ -1695,6 +1707,7 @@
             
             for (const pluginDef of pluginList) {
                 let filename, version, hash;
+                // Backward compat: older archetypes.json entries may be plain strings
                 if (typeof pluginDef === 'string') {
                     filename = pluginDef;
                     version = '1.0';
@@ -1780,6 +1793,7 @@
             
             for (const pluginDef of pluginList) {
                 let filename, version, hash;
+                // Backward compat: older archetypes.json entries may be plain strings
                 if (typeof pluginDef === 'string') {
                     filename = pluginDef;
                     version = '1.0';
@@ -1876,6 +1890,7 @@
             const expectedFilenames = new Set();
             pluginList.forEach(pluginDef => {
                 let filename;
+                // Backward compat: older archetypes.json entries may be plain strings
                 if (typeof pluginDef === 'string') {
                     filename = pluginDef;
                 } else if (pluginDef && pluginDef.name) {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1276,142 +1276,178 @@
         },
         
         /**
-         * Load plugin code from cache or URL, with version verification
+         * Compute SHA-256 hash of plugin code, matching the format used by compute-hashes.sh.
+         * @param {string} code - Plugin source code
+         * @returns {Promise<string>} - Hash in "sha256-<hex>" format
+         */
+        async computeHash(code) {
+            const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(code));
+            const hex = Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+            return 'sha256-' + hex;
+        },
+
+        /**
+         * Verify plugin code against an expected integrity hash.
+         * @param {string} code - Plugin source code
+         * @param {string} expectedHash - Expected hash from archetypes.json (e.g. "sha256-abc...")
+         * @param {string} filename - Plugin filename (for logging)
+         * @returns {Promise<{valid: boolean, computed: string}>}
+         */
+        async verifyPluginHash(code, expectedHash, filename) {
+            const computed = await this.computeHash(code);
+            const valid = computed === expectedHash;
+            if (!valid) {
+                Logger.debug(`Hash mismatch for ${filename}: expected ${expectedHash.slice(0, 24)}..., computed ${computed.slice(0, 24)}...`);
+            }
+            return { valid, computed };
+        },
+
+        /**
+         * Register archetype plugin in the cache registry (helper to reduce duplication).
+         * @param {string} sourcePath - Plugin source path
+         * @param {string} filename - Plugin filename
+         */
+        _registerCacheForArchetype(sourcePath, filename) {
+            if (sourcePath && sourcePath.startsWith('archetypes/')) {
+                const pathParts = sourcePath.split('/');
+                if (pathParts.length >= 3) {
+                    const archetypeId = pathParts[1];
+                    Storage.registerCachedPlugin(archetypeId, filename);
+                }
+            }
+        },
+
+        /**
+         * Load plugin code from cache or URL, with hash-based integrity verification.
+         * On main-like branches: plugins without a valid hash are blocked.
+         * On dev branches: hash mismatches produce warnings but loading proceeds.
          * @param {string} filename - Plugin filename
          * @param {string} sourcePath - Full path for caching
          * @param {string} version - Required version
          * @param {string} url - URL to fetch from if not cached
+         * @param {string} [expectedHash] - Expected SHA-256 hash from archetypes.json
          * @returns {Promise<string>} - Plugin code
          */
-        async loadPluginCode(filename, sourcePath, version, url) {
+        async loadPluginCode(filename, sourcePath, version, url, expectedHash) {
             const pluginKey = Storage.getPluginKey(filename, sourcePath);
             const cached = Storage.getCachedPlugin(pluginKey);
-            
-            // Check if we have a cached version that matches
-            if (cached && cached.version === version) {
-                Logger.debug(`Using cached plugin ${filename} v${version}`);
-                // Register in cache registry for archetype plugins (not core/dev)
-                if (sourcePath && sourcePath.startsWith('archetypes/')) {
-                    const pathParts = sourcePath.split('/');
-                    // Format: archetypes/archetypeId/main/filename or archetypes/archetypeId/dev/filename
-                    if (pathParts.length >= 3) {
-                        const archetypeId = pathParts[1];
-                        Storage.registerCachedPlugin(archetypeId, filename);
-                    }
-                }
-                return cached.code;
+            const isMainLike = MAIN_LIKE_BRANCHES.includes(GITHUB_CONFIG.branch);
+
+            // On production branches, an integrity hash is required
+            if (!expectedHash && isMainLike) {
+                Logger.error(`Plugin ${filename} blocked: no integrity hash in archetypes.json`);
+                throw new Error(`Plugin ${filename} blocked: no integrity hash`);
             }
-            
-            // Version mismatch or not cached - try to fetch
+
+            // --- CACHE PATH ---
+            if (cached && cached.version === version) {
+                if (expectedHash) {
+                    const hashResult = await this.verifyPluginHash(cached.code, expectedHash, filename);
+                    if (hashResult.valid) {
+                        Logger.debug(`Using cached plugin ${filename} v${version} (hash verified)`);
+                        this._registerCacheForArchetype(sourcePath, filename);
+                        return cached.code;
+                    }
+                    Logger.warn(`Cached ${filename} v${version} failed hash check. Re-fetching.`);
+                } else {
+                    Logger.debug(`Using cached plugin ${filename} v${version} (no hash — dev branch)`);
+                    this._registerCacheForArchetype(sourcePath, filename);
+                    return cached.code;
+                }
+            }
+
+            // --- FETCH PATH ---
             Logger.log(`Fetching plugin ${filename} v${version}${cached ? ` (cached: v${cached.version})` : ''}`);
-            
+
             try {
                 const result = await this.loadPluginFromUrl(url, filename, sourcePath, version);
                 const fetchedCode = result.code;
                 const trimmed = fetchedCode.trim();
 
-                // If response looks like HTML (error page), don't attempt to parse as JS
                 if (trimmed.startsWith('<')) {
                     Logger.warn(`Fetched content for ${filename} does not look like JavaScript (may be HTML error page). First 150 chars: ${trimmed.slice(0, 150).replace(/\s+/g, ' ')}`);
-                    if (cached) {
-                        Logger.warn(`Using cached v${cached.version} due to non-JS response`);
-                        Context.outdatedPlugins.push({
-                            filename: filename,
-                            sourcePath: sourcePath,
-                            cachedVersion: cached.version,
-                            requiredVersion: version,
-                            nonJsResponse: true
-                        });
+                    if (cached && !isMainLike) {
+                        Logger.warn(`Using cached v${cached.version} due to non-JS response (dev branch)`);
+                        Context.outdatedPlugins.push({ filename, sourcePath, cachedVersion: cached.version, requiredVersion: version, nonJsResponse: true });
                         return cached.code;
                     }
                     throw new Error(`Server returned non-JS content for ${filename} (possible CDN/network issue). Try again later.`);
                 }
 
-                // Verify the fetched version by parsing the plugin
-                // This protects against GitHub CDN cache delays
+                // --- HASH VERIFICATION (when hash is available) ---
+                if (expectedHash) {
+                    const hashResult = await this.verifyPluginHash(fetchedCode, expectedHash, filename);
+                    if (hashResult.valid) {
+                        this.cachePluginCode(filename, sourcePath, fetchedCode, version);
+                        Logger.debug(`Hash verified and cached ${filename} v${version}`);
+                        return fetchedCode;
+                    }
+
+                    if (isMainLike) {
+                        Logger.error(`✗ Plugin ${filename} integrity check failed! Refusing to load.`);
+                        throw new Error(`Plugin ${filename} blocked: integrity hash mismatch`);
+                    }
+
+                    Logger.warn(`⚠ Plugin ${filename} hash mismatch (dev branch). Loading anyway.`);
+                    this.cachePluginCode(filename, sourcePath, fetchedCode, version);
+                    return fetchedCode;
+                }
+
+                // --- NO HASH (dev branch only — main blocked above) ---
+                // Fall back to version-based verification for backward compatibility
                 try {
                     const parsedPlugin = this.parsePluginCode(fetchedCode, filename);
                     const fetchedVersion = parsedPlugin._version || parsedPlugin.version || null;
-                    
+
                     if (fetchedVersion && fetchedVersion !== version) {
-                        // Compare versions to determine if fetched is newer or older
                         const versionComparison = this._compareVersions(fetchedVersion, version);
-                        
+
                         if (versionComparison > 0) {
-                            // Fetched version is NEWER than required - this is good, not outdated
                             Logger.log(`✓ Fetched ${filename} has newer version v${fetchedVersion} (required v${version}). Using newer version.`);
-                            // Cache with the newer fetched version
                             this.cachePluginCode(filename, sourcePath, fetchedCode, fetchedVersion);
-                            Logger.debug(`Verified and cached ${filename} v${fetchedVersion} (newer than required v${version})`);
                             return fetchedCode;
                         } else {
-                            // Fetched version is OLDER than required - GitHub CDN might be stale
                             Logger.warn(`⚠ Fetched ${filename} has version v${fetchedVersion}, expected v${version}. GitHub CDN may be stale.`);
-                            
-                            // Don't cache the wrong version - use old cache if available
                             if (cached) {
                                 Logger.warn(`Using cached v${cached.version} instead of stale fetched version`);
-                                Context.outdatedPlugins.push({
-                                    filename: filename,
-                                    sourcePath: sourcePath,
-                                    cachedVersion: cached.version,
-                                    requiredVersion: version,
-                                    fetchedVersion: fetchedVersion
-                                });
+                                Context.outdatedPlugins.push({ filename, sourcePath, cachedVersion: cached.version, requiredVersion: version, fetchedVersion });
                                 return cached.code;
                             } else {
-                                // No cache available, but version is wrong - use it anyway with warning
                                 Logger.warn(`No cache available, using fetched version v${fetchedVersion} (expected v${version})`);
-                                Context.outdatedPlugins.push({
-                                    filename: filename,
-                                    sourcePath: sourcePath,
-                                    cachedVersion: null,
-                                    requiredVersion: version,
-                                    fetchedVersion: fetchedVersion
-                                });
-                                // Don't cache the wrong version
+                                Context.outdatedPlugins.push({ filename, sourcePath, cachedVersion: null, requiredVersion: version, fetchedVersion });
                                 return fetchedCode;
                             }
                         }
                     }
-                    
-                    // Version matches (or plugin doesn't declare version) - cache it
+
                     this.cachePluginCode(filename, sourcePath, fetchedCode, version);
                     Logger.debug(`Verified and cached ${filename} v${version}`);
                     return fetchedCode;
-                    
+
                 } catch (parseError) {
-                    // Failed to parse - use old cache and surface the actual error for debugging
                     Logger.error(`Failed to parse fetched plugin ${filename} for version verification:`, parseError);
                     if (cached) {
                         Logger.warn(`Using cached v${cached.version} due to parse error`);
-                        Context.outdatedPlugins.push({
-                            filename: filename,
-                            sourcePath: sourcePath,
-                            cachedVersion: cached.version,
-                            requiredVersion: version,
-                            parseError: true,
-                            parseErrorMessage: parseError && parseError.message ? parseError.message : String(parseError)
-                        });
+                        Context.outdatedPlugins.push({ filename, sourcePath, cachedVersion: cached.version, requiredVersion: version, parseError: true, parseErrorMessage: parseError && parseError.message ? parseError.message : String(parseError) });
                         return cached.code;
                     }
-                    // No cache, but can't parse - rethrow
                     throw parseError;
                 }
-                
+
             } catch (error) {
-                // Fetch failed - use cached version if available (with warning)
                 if (cached) {
+                    // On main, even fallback cache must pass integrity check
+                    if (expectedHash && isMainLike) {
+                        const hashResult = await this.verifyPluginHash(cached.code, expectedHash, filename);
+                        if (!hashResult.valid) {
+                            Logger.error(`✗ Fetch failed and cached ${filename} also fails integrity check. Refusing to load.`);
+                            throw new Error(`Plugin ${filename} blocked: fetch failed and cache integrity mismatch`);
+                        }
+                    }
                     Logger.warn(`⚠ Failed to fetch ${filename} v${version}, using cached v${cached.version}`);
-                    Context.outdatedPlugins.push({
-                        filename: filename,
-                        sourcePath: sourcePath,
-                        cachedVersion: cached.version,
-                        requiredVersion: version
-                    });
+                    Context.outdatedPlugins.push({ filename, sourcePath, cachedVersion: cached.version, requiredVersion: version });
                     return cached.code;
                 }
-                // No cache available, rethrow error
                 throw error;
             }
         },
@@ -1457,17 +1493,17 @@
         },
         
         /**
-         * Load a core plugin with versioning support
+         * Load a core plugin with versioning and hash verification
          * @param {string} filename - Plugin filename
          * @param {string} version - Required version
+         * @param {string} [hash] - Expected integrity hash
          * @returns {Promise<Object>} - Plugin object
          */
-        async loadCorePlugin(filename, version) {
+        async loadCorePlugin(filename, version, hash) {
             const sourcePath = `core/main/${filename}`;
             const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
             
-            // Load plugin code with versioning
-            const code = await this.loadPluginCode(filename, sourcePath, version, url);
+            const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: false });
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded core plugin ${filename} v${version}`);
@@ -1475,16 +1511,17 @@
         },
 
         /**
-         * Load a dev plugin with versioning support
+         * Load a dev plugin with versioning and hash verification
          * @param {string} filename - Plugin filename
          * @param {string} version - Required version
+         * @param {string} [hash] - Expected integrity hash
          * @returns {Promise<Object>} - Plugin object
          */
-        async loadDevPlugin(filename, version) {
+        async loadDevPlugin(filename, version, hash) {
             const sourcePath = `core/dev/${filename}`;
             const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
 
-            const code = await this.loadPluginCode(filename, sourcePath, version, url);
+            const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: false });
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded dev plugin ${filename} v${version}`);
@@ -1492,14 +1529,14 @@
         },
         
         /**
-         * Load an archetype plugin with versioning support
+         * Load an archetype plugin with versioning and hash verification
          * @param {string} filename - The plugin filename (e.g., "source-data-explorer.js")
          * @param {string} version - Required version (e.g., "1.0")
          * @param {string} archetypeId - The archetype ID (e.g., "k-taskCreation")
+         * @param {string} [hash] - Expected integrity hash
          * @returns {Promise} - Resolves with the plugin object
          */
-        async loadArchetypePlugin(filename, version, archetypeId) {
-            // Archetype plugins must always live under: plugins/archetypes/<archetypeId>/main/<filename>
+        async loadArchetypePlugin(filename, version, archetypeId, hash) {
             if (filename.includes('/')) {
                 throw new Error(
                     `Invalid archetype plugin name "${filename}". Plugin names must be filenames only (no folder paths).`
@@ -1509,7 +1546,7 @@
             const sourcePath = `archetypes/${archetypeId}/main/${filename}`;
             const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
 
-            const code = await this.loadPluginCode(filename, sourcePath, version, url);
+            const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded ${filename} v${version} from ${sourcePath}`);
@@ -1517,15 +1554,15 @@
         },
         
         /**
-         * Load a dev archetype plugin with versioning support
+         * Load a dev archetype plugin with versioning and hash verification
          * Dev archetype plugins live under: plugins/archetypes/<archetypeId>/dev/<filename>
          * @param {string} filename - The plugin filename (e.g., "source-data-explorer.js")
          * @param {string} version - Required version (e.g., "1.0")
          * @param {string} archetypeId - The archetype ID (e.g., "qa-tool-use")
+         * @param {string} [hash] - Expected integrity hash
          * @returns {Promise} - Resolves with the plugin object
          */
-        async loadDevArchetypePlugin(filename, version, archetypeId) {
-            // Dev archetype plugins must always live under: plugins/archetypes/<archetypeId>/dev/<filename>
+        async loadDevArchetypePlugin(filename, version, archetypeId, hash) {
             if (filename.includes('/')) {
                 throw new Error(
                     `Invalid dev archetype plugin name "${filename}". Plugin names must be filenames only (no folder paths).`
@@ -1535,7 +1572,7 @@
             const sourcePath = `archetypes/${archetypeId}/dev/${filename}`;
             const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
 
-            const code = await this.loadPluginCode(filename, sourcePath, version, url);
+            const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded dev archetype plugin ${filename} v${version} from ${sourcePath}`);
@@ -1610,24 +1647,23 @@
                 : this.loadCorePlugin.bind(this);
 
             for (const pluginDef of pluginList) {
-                // Support both old format (string) and new format (object with name and version)
-                let filename, version;
+                let filename, version, hash;
                 if (typeof pluginDef === 'string') {
-                    // Backward compatibility: if just a string, default to version 1.0
                     filename = pluginDef;
                     version = '1.0';
                 } else if (pluginDef && pluginDef.name && pluginDef.version) {
                     filename = pluginDef.name;
                     version = pluginDef.version;
+                    hash = pluginDef.hash || undefined;
                 } else {
                     Logger.error(`Invalid ${normalizedType} plugin definition:`, pluginDef);
                     continue;
                 }
                 
-                Logger.debug(`🔍 archetypes.json requests ${normalizedType} plugin ${filename} v${version}`);
+                Logger.debug(`🔍 archetypes.json requests ${normalizedType} plugin ${filename} v${version}${hash ? ' (hash present)' : ''}`);
                 
                 try {
-                    const plugin = await loader(filename, version);
+                    const plugin = await loader(filename, version, hash);
                     const loadedVersion = plugin._version || plugin.version || version;
                     plugin._sourceFile = filename;
                     plugin._version = loadedVersion;
@@ -1658,21 +1694,20 @@
             const loadPromises = [];
             
             for (const pluginDef of pluginList) {
-                // Support both old format (string) and new format (object with name and version)
-                let filename, version;
+                let filename, version, hash;
                 if (typeof pluginDef === 'string') {
-                    // Backward compatibility: if just a string, default to version 1.0
                     filename = pluginDef;
                     version = '1.0';
                 } else if (pluginDef && pluginDef.name && pluginDef.version) {
                     filename = pluginDef.name;
                     version = pluginDef.version;
+                    hash = pluginDef.hash || undefined;
                 } else {
                     Logger.error('Invalid plugin definition:', pluginDef);
                     continue;
                 }
 
-                Logger.debug(`🔍 archetypes.json requests archetype plugin ${filename} v${version} for ${archetypeId}`);
+                Logger.debug(`🔍 archetypes.json requests archetype plugin ${filename} v${version} for ${archetypeId}${hash ? ' (hash present)' : ''}`);
 
                 if (filename.includes('/')) {
                     Logger.error(
@@ -1681,7 +1716,6 @@
                     continue;
                 }
                 
-                // Check if already loaded
                 const existingPlugins = PluginManager.getAll();
                 const alreadyLoadedByFile = existingPlugins.some(p => p._sourceFile === filename);
                 
@@ -1694,7 +1728,7 @@
                 }
                 
                 loadPromises.push(
-                    this.loadArchetypePlugin(filename, version, archetypeId)
+                    this.loadArchetypePlugin(filename, version, archetypeId, hash)
                         .then(plugin => {
                             const loadedVersion = plugin._version || plugin.version || version;
                             plugin._sourceFile = filename;
@@ -1745,21 +1779,20 @@
             const loadPromises = [];
             
             for (const pluginDef of pluginList) {
-                // Support both old format (string) and new format (object with name and version)
-                let filename, version;
+                let filename, version, hash;
                 if (typeof pluginDef === 'string') {
-                    // Backward compatibility: if just a string, default to version 1.0
                     filename = pluginDef;
                     version = '1.0';
                 } else if (pluginDef && pluginDef.name && pluginDef.version) {
                     filename = pluginDef.name;
                     version = pluginDef.version;
+                    hash = pluginDef.hash || undefined;
                 } else {
                     Logger.error('Invalid dev archetype plugin definition:', pluginDef);
                     continue;
                 }
 
-                Logger.debug(`🔍 archetypes.json requests dev archetype plugin ${filename} v${version} for ${archetypeId}`);
+                Logger.debug(`🔍 archetypes.json requests dev archetype plugin ${filename} v${version} for ${archetypeId}${hash ? ' (hash present)' : ''}`);
 
                 if (filename.includes('/')) {
                     Logger.error(
@@ -1768,7 +1801,6 @@
                     continue;
                 }
                 
-                // Check if already loaded
                 const existingPlugins = PluginManager.getAll();
                 const alreadyLoadedByFile = existingPlugins.some(p => p._sourceFile === filename && p._isDev);
                 
@@ -1781,7 +1813,7 @@
                 }
                 
                 loadPromises.push(
-                    this.loadDevArchetypePlugin(filename, version, archetypeId)
+                    this.loadDevArchetypePlugin(filename, version, archetypeId, hash)
                         .then(plugin => {
                             const loadedVersion = plugin._version || plugin.version || version;
                             plugin._sourceFile = filename;


### PR DESCRIPTION
## Summary

- Adds SHA-256 hash-based integrity verification for all plugins, enforcing strict checks on production branches (`main`) while allowing permissive warnings on dev branches.
- Introduces a `compute-hashes.sh` utility and three CI workflows to automatically compute, update, and verify plugin hashes.
- Bumps `version` to `6.0.0` and `archetypesVersion` to `6.56` to reflect the new cryptographic signing architecture.

## Test
- I intentionally did not sync the branch config in `fleet.user.js` for this PR to test the `verify-main-branch-config-pr.yml` workflow. This workflow should automatically fix the mismatch when the PR is created.

## Changes

### Plugin Integrity Verification (`fleet.user.js`)
- Added `computeHash()` — computes SHA-256 using the Web Crypto API in `"sha256-<hex>"` format.
- Added `verifyPluginHash()` — compares a plugin's computed hash against the expected value from `archetypes.json`.
- Refactored `loadPluginCode()` to integrate hash-based verification:
  - **Main branches**: plugins without a valid hash are **blocked** from loading; hash mismatches throw errors.
  - **Dev branches**: hash mismatches produce warnings but loading proceeds for development flexibility.
  - Cache hits are re-verified against the expected hash; stale cache entries trigger a re-fetch.
  <img width="445" height="67" alt="Screenshot 2026-03-14 at 21 52 54" src="https://github.com/user-attachments/assets/16adcbd6-44fb-4789-a8e6-199c196cfe00" />

- Extracted `_registerCacheForArchetype()` helper to reduce duplication.

### Hash Computation Utility (`dev/utils/compute-hashes.sh`)
- New shell script that computes SHA-256 hashes for all plugin files across `corePlugins`, `devPlugins`, `archetypes`, and `devArchetypes`.
- Updates `archetypes.json` in-place with `"hash": "sha256-<hex>"` for each plugin entry.
- Supports `--dry-run`, `--root`, `--archetypes`, and `--plugins-dir` options.

### CI Workflows (`.github/workflows/`)
- **`update-plugin-hashes.yml`** — Runs `compute-hashes.sh` on every push to non-main branches; auto-commits hash updates.
  <img width="605" height="275" alt="Screenshot 2026-03-14 at 21 54 29" src="https://github.com/user-attachments/assets/eb5d1756-dff7-4695-93f7-d33076e1092f" />
  <img width="946" height="67" alt="Screenshot 2026-03-14 at 21 55 27" src="https://github.com/user-attachments/assets/f8aee418-5d71-4d85-ab95-f306073fe55c" />


- **`verify-plugin-hashes-pr.yml`** — Re-computes and verifies hashes on PRs to `main`; auto-fixes and commits if stale.
- **`verify-main-branch-config-pr.yml`** — Ensures `fleet.user.js` is synced for `main` on PRs; auto-commits fixes. Uses `actions/checkout@v5` (upgraded from v4 to resolve Node.js 20 deprecation).

### `archetypes.json`
- Every plugin entry (core, dev, archetype, dev-archetype) now includes a `"hash"` field with its SHA-256 digest.
- Version bumped to `6.0.0`, `archetypesVersion` to `6.56`.

## Commit history

| Hash | Message |
|------|---------|
| `ea19bbb` | feat: add SHA-256 hash-based integrity verification for all plugins |
| `f1cc4f6` | fix: upgrade actions/checkout from v4 to v5 to resolve Node.js 20 deprecation warning |
| `4d84743` | feat: auto-sync branch config for main on PRs (#15) |
| `f0c4dbd` | chore: update version numbers in archetypes.json and fleet.user.js to 6.0.0 and 6.56 respectively |
| `0982d47` | test: Input wrong hash for feedback-given-stats.js to test loader handling |
| `f8be849` | CI: update plugin hashes |

## Stats

- **6 files** changed
- **606** insertions, **223** deletions