### PR TITLE
Add auto-start-recording QA plugin

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -438,6 +438,11 @@
           "name": "accept-task-modal-improvements.js",
           "version": "1.7",
           "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6"
+        },
+        {
+          "name": "auto-start-recording.js",
+          "version": "1.0",
+          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
         }
       ]
     },
@@ -512,6 +517,11 @@
           "name": "remember-layout-proportions.js",
           "version": "1.0",
           "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
+        },
+        {
+          "name": "auto-start-recording.js",
+          "version": "1.0",
+          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
         }
       ]
     },

--- a/archetypes.json
+++ b/archetypes.json
@@ -355,6 +355,11 @@
       "disambiguationSelectors": [],
       "plugins": [
         {
+          "name": "auto-start-recording.js",
+          "version": "1.0",
+          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
+        },
+        {
           "name": "clear-search.js",
           "version": "2.1",
           "hash": "sha256-1c909857b79e8a369bd2e9a1767445fbfc0f77ae50c40b2c6fb09e879c7357f3"
@@ -438,11 +443,6 @@
           "name": "accept-task-modal-improvements.js",
           "version": "1.7",
           "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6"
-        },
-        {
-          "name": "auto-start-recording.js",
-          "version": "1.0",
-          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
         }
       ]
     },
@@ -453,6 +453,11 @@
       "urlPattern": "work/problems/qa/*",
       "disambiguationSelectors": [],
       "plugins": [
+        {
+          "name": "auto-start-recording.js",
+          "version": "1.0",
+          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
+        },
         {
           "name": "auto-toggle-fullscreen-mode.js",
           "version": "1.1",
@@ -517,11 +522,6 @@
           "name": "remember-layout-proportions.js",
           "version": "1.0",
           "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
-        },
-        {
-          "name": "auto-start-recording.js",
-          "version": "1.0",
-          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
         }
       ]
     },

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-auto-record] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.0.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-auto-record/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-auto-record/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-auto-record',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-auto-record] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.0.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-auto-record/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-auto-record/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-auto-record',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/qa-comp-use/main/auto-start-recording.js
+++ b/plugins/archetypes/qa-comp-use/main/auto-start-recording.js
@@ -1,0 +1,53 @@
+// ============= auto-start-recording.js =============
+// Automatically clicks the "Start Recording" button once when it appears.
+
+const plugin = {
+    id: 'autoStartRecording',
+    name: 'Auto Start Recording',
+    description: 'Automatically clicks the "Start Recording" button once when it appears on the page.',
+    _version: '1.0',
+    enabledByDefault: false,
+    phase: 'mutation',
+    initialState: {
+        clicked: false,
+        missingLogged: false
+    },
+
+    onMutation(state, context) {
+        if (state.clicked) return;
+
+        const button = this.findStartRecordingButton();
+        if (!button) {
+            if (!state.missingLogged) {
+                Logger.debug('Auto Start Recording: \"Start Recording\" button not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        try {
+            button.click();
+            state.clicked = true;
+            Logger.log('✓ Auto Start Recording: clicked \"Start Recording\" button');
+        } catch (error) {
+            Logger.error('Auto Start Recording: failed to click \"Start Recording\" button', error);
+        }
+    },
+
+    findStartRecordingButton() {
+        const options = { context: `${this.id}.findStartRecordingButton` };
+        const buttons = typeof Context !== 'undefined' && Context.dom
+            ? Context.dom.queryAll('button', options)
+            : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').trim();
+            if (text === 'Start Recording') {
+                return btn;
+            }
+        }
+
+        return null;
+    }
+};
+

--- a/plugins/archetypes/qa-tool-use/main/auto-start-recording.js
+++ b/plugins/archetypes/qa-tool-use/main/auto-start-recording.js
@@ -1,0 +1,53 @@
+// ============= auto-start-recording.js =============
+// Automatically clicks the "Start Recording" button once when it appears.
+
+const plugin = {
+    id: 'autoStartRecording',
+    name: 'Auto Start Recording',
+    description: 'Automatically clicks the "Start Recording" button once when it appears on the page.',
+    _version: '1.0',
+    enabledByDefault: false,
+    phase: 'mutation',
+    initialState: {
+        clicked: false,
+        missingLogged: false
+    },
+
+    onMutation(state, context) {
+        if (state.clicked) return;
+
+        const button = this.findStartRecordingButton();
+        if (!button) {
+            if (!state.missingLogged) {
+                Logger.debug('Auto Start Recording: \"Start Recording\" button not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        try {
+            button.click();
+            state.clicked = true;
+            Logger.log('✓ Auto Start Recording: clicked \"Start Recording\" button');
+        } catch (error) {
+            Logger.error('Auto Start Recording: failed to click \"Start Recording\" button', error);
+        }
+    },
+
+    findStartRecordingButton() {
+        const options = { context: `${this.id}.findStartRecordingButton` };
+        const buttons = typeof Context !== 'undefined' && Context.dom
+            ? Context.dom.queryAll('button', options)
+            : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').trim();
+            if (text === 'Start Recording') {
+                return btn;
+            }
+        }
+
+        return null;
+    }
+};
+


### PR DESCRIPTION
## Summary
- Add and prioritize the `auto-start-recording` QA plugin so that QA sessions begin recording automatically and surface recording controls prominently.

## Changes
- **Introduce auto-start-recording plugin for QA archetypes**: Added a new `auto-start-recording` plugin under the QA archetypes to automatically start recording when QA sessions begin, improving capture consistency for QA runs.
- **Reorder QA plugin lists**: Moved the `auto-start-recording` plugin to the top of the QA plugin lists so its behavior is initialized early and its UI is more visible to users.
- **Update archetypes wiring**: Updated `archetypes.json` to wire the new `auto-start-recording` plugin into the relevant QA archetypes, keeping plugin loading fully driven by archetypes configuration.

## New plugins
| Archetype | Plugin                | Description                              |
|----------|------------------------|------------------------------------------|
| qa-*     | auto-start-recording   | Auto-starts and surfaces session recording in QA flows |

## Commit history (excluding sync commits)
- da1621d — Move auto-start-recording plugin to top of QA plugin lists
- 478b7d3 — Add auto-start-recording plugin for QA archetypes

## Stats
- 3 files changed, 116 insertions(+)
