### PR TITLE
Add version-gated extension ping core plugin

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,11 +1,16 @@
 {
-  "version": "6.0.0",
-  "archetypesVersion": "6.58",
+  "version": "6.1.0",
+  "archetypesVersion": "6.59",
   "corePlugins": [
     {
       "name": "settings-ui.js",
       "version": "6.1",
       "hash": "sha256-b73eddefd35b3053f0256f00f05e664029aced364948f8824836eea0d2566286"
+    },
+    {
+      "name": "extension-ping.js",
+      "version": "1.0",
+      "hash": "sha256-5c1c6509679a1b52b4395297f87d4b048cfae7408e171927827fa013d4f9ac8c"
     }
   ],
   "devPlugins": [

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
-  "version": "6.1.0",
-  "archetypesVersion": "6.60",
+  "version": "6.1.1",
+  "archetypesVersion": "6.61",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.0.0",
-  "archetypesVersion": "6.57",
+  "archetypesVersion": "6.58",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -18,7 +18,7 @@
   "settingsModalDocs": [
     {
       "name": "information-tab.md",
-      "version": "1.8"
+      "version": "1.9"
     },
     {
       "name": "features-tab.md",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
-  "version": "6.1.1",
-  "archetypesVersion": "6.61",
+  "version": "6.1.2",
+  "archetypesVersion": "6.62",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.0",
-  "archetypesVersion": "6.59",
+  "archetypesVersion": "6.60",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -9,8 +9,8 @@
     },
     {
       "name": "extension-ping.js",
-      "version": "1.0",
-      "hash": "sha256-5c1c6509679a1b52b4395297f87d4b048cfae7408e171927827fa013d4f9ac8c"
+      "version": "1.1",
+      "hash": "sha256-faae51a719082c75e025528766152ab23715701ed6f4b029acc717c6fc1b11d3"
     }
   ],
   "devPlugins": [

--- a/dev/utils/vercel-tests/extension-ping-count-get.sh
+++ b/dev/utils/vercel-tests/extension-ping-count-get.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# extension-ping-count-get.sh — Fetch extension ping count
+#
+# Usage:
+#   ./dev/utils/extension-ping-count-get.sh
+#
+
+set -euo pipefail
+
+BASE_URL="https://operations-toolkit-admin.vercel.app"
+ENDPOINT="/api/extension-ping-count"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  cat <<'EOF'
+Usage: extension-ping-count-get.sh
+
+Sends GET https://operations-toolkit-admin.vercel.app/api/extension-ping-count
+EOF
+  exit 0
+fi
+
+echo "[info] GET ${BASE_URL}${ENDPOINT}"
+
+response=$(
+  curl -sS \
+    -w '\nHTTP_STATUS:%{http_code}\n' \
+    -X GET "${BASE_URL}${ENDPOINT}"
+)
+
+status="$(printf '%s' "$response" | awk -F: '/^HTTP_STATUS:/ {print $2}' | tr -d '\r')"
+body="$(printf '%s' "$response" | sed '/^HTTP_STATUS:/d')"
+
+echo "[info] Status: ${status:-unknown}"
+echo "$body"

--- a/dev/utils/vercel-tests/extension-ping-post.sh
+++ b/dev/utils/vercel-tests/extension-ping-post.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# extension-ping-post.sh — Send a test ping to extension-ping endpoint
+#
+# Usage:
+#   ./dev/utils/extension-ping-post.sh [email]
+#
+# Examples:
+#   ./dev/utils/extension-ping-post.sh
+#   ./dev/utils/extension-ping-post.sh maxwellturner@gmail.com
+#
+
+set -euo pipefail
+
+BASE_URL="https://operations-toolkit-admin.vercel.app"
+ENDPOINT="/api/extension-ping"
+EMAIL="${1:-test@example.com}"
+
+if [[ "$EMAIL" == "--help" || "$EMAIL" == "-h" ]]; then
+  cat <<'EOF'
+Usage: extension-ping-post.sh [email]
+
+Sends POST https://operations-toolkit-admin.vercel.app/api/extension-ping
+
+Arguments:
+  email   Optional. Email to send in JSON body.
+          Defaults to test@example.com
+EOF
+  exit 0
+fi
+
+if [[ "$EMAIL" != *"@"* ]]; then
+  echo "[error] Invalid email value: $EMAIL" >&2
+  exit 1
+fi
+
+payload=$(printf '{"email":"%s"}' "$EMAIL")
+
+echo "[info] POST ${BASE_URL}${ENDPOINT}"
+echo "[info] Payload: $payload"
+
+response=$(
+  curl -sS \
+    -w '\nHTTP_STATUS:%{http_code}\n' \
+    -X POST "${BASE_URL}${ENDPOINT}" \
+    -H 'Content-Type: application/json' \
+    -d "$payload"
+)
+
+status="$(printf '%s' "$response" | awk -F: '/^HTTP_STATUS:/ {print $2}' | tr -d '\r')"
+body="$(printf '%s' "$response" | sed '/^HTTP_STATUS:/d')"
+
+echo "[info] Status: ${status:-unknown}"
+echo "$body"

--- a/docs/settings-modal/information-tab.md
+++ b/docs/settings-modal/information-tab.md
@@ -1,8 +1,8 @@
-1.8
+1.9
 ## Information
-
+-> Pro-tip: Use `Ctrl`/`CMD` + `F` to search for names in this table. If you can't find one, please use the `Feedback` tab to notify me!
 #### Environment Codennames
-| Environment Codename       | Real App Name          |
+| Environment Codename      | Real App Name          |
 |---------------------------|------------------------|
 | Agora                     | Reddit                 |
 | Aisle                     | Walmart                |
@@ -12,7 +12,7 @@
 | Crate                     | Instacart              |
 | Docket                    | Dropbox                |
 | Float                     | Ramp                   |
-| Focusign                  | Docusign               |
+| Seal                      | Docusign               |
 | Foundry                   | Github                 |
 | Jetstream                 | Google Flights         |
 | Kernel                    | Jira / RevOps          |
@@ -31,10 +31,6 @@
 | Torch                     | PagerDuty              |
 | Vault                     | Confluence             |
 | Ward                      | Synk                   |
-| Forums Homes              | -                      |
-| FosOperations             | -                      |
-| RevOps                    | -                      |
-| SRE                       | -                      |
 | Docs                      | OpenOffice Writer      |
 | Sheets                    | OpenOffice Calc        |
 | Slides                    | OpenOffice Impress     |

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-ping] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      6.0.0
+// @version      6.1.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -13,6 +13,7 @@
 // @grant        GM_deleteValue
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
+// @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
 // @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-ping/fleet.user.js
 // @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-ping/fleet.user.js
@@ -28,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '6.0.0';
+    const VERSION = '6.1.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-ping] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.0.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -14,8 +14,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-ping/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-ping/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -42,7 +42,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-ping',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1484,6 +1484,7 @@
                     'Logger',
                     'Context',
                     'CleanupRegistry',
+                    'GM_xmlhttpRequest',
                     code + '\n\n// Return the plugin for registration\nreturn plugin;'
                 );
 
@@ -1492,7 +1493,8 @@
                     Storage,
                     moduleLogger,
                     Context,
-                    CleanupRegistry
+                    CleanupRegistry,
+                    GM_xmlhttpRequest
                 );
                 if (useModuleLogger && plugin && plugin.id) {
                     resolvedModuleId = plugin.id;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-ping] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      6.1.0
+// @version      6.1.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '6.1.0';
+    const VERSION = '6.1.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-ping] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      6.1.1
+// @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '6.1.1';
+    const VERSION = '6.1.2';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-ping] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-ping/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-ping/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-ping',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/extension-ping.js
+++ b/plugins/core/main/extension-ping.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'extension-ping',
     name: 'Extension Ping',
     description: 'Pings extension endpoint once per userscript version',
-    _version: '1.0',
+    _version: '1.1',
     phase: 'core',
     enabledByDefault: true,
 
@@ -65,6 +65,11 @@ const plugin = {
     },
 
     _sendPing(email, currentVersion, storageKey) {
+        if (typeof GM_xmlhttpRequest !== 'function') {
+            Logger.error('Extension ping unavailable: GM_xmlhttpRequest is not defined');
+            return;
+        }
+
         const payload = JSON.stringify({ email });
         const url = 'https://operations-toolkit-admin.vercel.app/api/extension-ping';
 

--- a/plugins/core/main/extension-ping.js
+++ b/plugins/core/main/extension-ping.js
@@ -1,0 +1,93 @@
+// extension-ping.js
+// Core plugin that pings extension usage endpoint on script version update.
+
+const plugin = {
+    id: 'extension-ping',
+    name: 'Extension Ping',
+    description: 'Pings extension endpoint once per userscript version',
+    _version: '1.0',
+    phase: 'core',
+    enabledByDefault: true,
+
+    init(state, context) {
+        try {
+            const currentVersion = context && context.version ? context.version : null;
+            if (!currentVersion) {
+                Logger.warn('Extension ping skipped: missing current script version');
+                return;
+            }
+
+            const storageKey = 'extension-ping-last-version';
+            const lastPingedVersion = Storage.get(storageKey, null);
+            if (lastPingedVersion === currentVersion) {
+                Logger.debug(`Extension ping skipped: already pinged for version ${currentVersion}`);
+                return;
+            }
+
+            const email = this._extractEmailFromInlineScripts();
+            if (!email) {
+                Logger.warn('Extension ping skipped: email not found in inline scripts');
+                return;
+            }
+
+            this._sendPing(email, currentVersion, storageKey);
+        } catch (error) {
+            Logger.error('Extension ping init failed:', error);
+        }
+    },
+
+    _extractEmailFromInlineScripts() {
+        const scripts = document.querySelectorAll('script:not([src])');
+        if (!scripts || scripts.length === 0) {
+            Logger.debug('Extension ping email extraction: no inline scripts found');
+            return null;
+        }
+
+        const escapedPattern = /\\"email\\":\\"([^"\\]+@[^"\\]+\.[^"\\]+)\\"/;
+        const plainPattern = /"email":"([^"\\]+@[^"\\]+\.[^"\\]+)"/;
+
+        for (const scriptEl of scripts) {
+            const content = scriptEl && scriptEl.textContent ? scriptEl.textContent : '';
+            if (!content) continue;
+
+            const escapedMatch = content.match(escapedPattern);
+            if (escapedMatch && escapedMatch[1]) {
+                return escapedMatch[1];
+            }
+
+            const plainMatch = content.match(plainPattern);
+            if (plainMatch && plainMatch[1]) {
+                return plainMatch[1];
+            }
+        }
+
+        return null;
+    },
+
+    _sendPing(email, currentVersion, storageKey) {
+        const payload = JSON.stringify({ email });
+        const url = 'https://operations-toolkit-admin.vercel.app/api/extension-ping';
+
+        GM_xmlhttpRequest({
+            method: 'POST',
+            url,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            data: payload,
+            onload: (response) => {
+                const status = response && typeof response.status === 'number' ? response.status : 0;
+                if (status >= 200 && status < 300) {
+                    Storage.set(storageKey, currentVersion);
+                    Logger.info(`Extension ping sent for version ${currentVersion}`);
+                    return;
+                }
+
+                Logger.warn(`Extension ping failed with status ${status}`);
+            },
+            onerror: (error) => {
+                Logger.error('Extension ping network error:', error);
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Add a version-gated core extension ping capability and wire it into the userscript runtime so installs report usage once per release, while aligning docs and version metadata for the new module.

## Changes
- Added a new core plugin `extension-ping.js` that extracts user email from inline page scripts and sends a one-time per-version ping to the Vercel endpoint, with guarded logging and network error handling.
- Updated plugin runtime injection in `fleet.user.js` to pass `GM_xmlhttpRequest` into plugin execution, and added the Vercel host to `@connect` grants so the plugin can send requests.
- Added local verification utilities under `dev/utils/vercel-tests/` for posting test pings and fetching ping counts from the Vercel API.
- Updated docs/settings reference content (including codename corrections) and bumped script/archetype versions to propagate the new plugin and metadata updates.

## New plugins
| Plugin | Archetype | Type | Version | Notes |
|---|---|---|---|---|
| `extension-ping.js` | core | new | `1.1` | Sends one usage ping per userscript version |

## Commit history
- 2652ea7 chore: update fleet.user.js to remove feat-ping branch references and set main as the default branch
- b68c201 chore: update version numbers in archetypes.json and fleet.user.js to 6.1.2
- 6d59c78 chore: update version numbers in archetypes.json and fleet.user.js to 6.1.1
- 27dbf4f fix(core): inject GM_xmlhttpRequest into plugin runtime for extension ping
- 42e2b62 feat(core): add version-gated extension ping module and Vercel connect grant
- aa14cb9 chore(utils): add shell scripts for extension ping endpoint testing
- 1b40210 Update Docusign codename

## Stats
- 6 files changed, 205 insertions(+), 14 deletions(-)
- Files: `archetypes.json`, `fleet.user.js`, `plugins/core/main/extension-ping.js`, `docs/settings-modal/information-tab.md`, `dev/utils/vercel-tests/extension-ping-post.sh`, `dev/utils/vercel-tests/extension-ping-count-get.sh`
