### PR TITLE
Multiple enhancements, mainly targeting the QA archetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Useful Link Buttons**: Quick links to QA/Kinesis guidelines and JSON Editor Online below the scratchpad
 - **Bug Report Expand**: Click bug reports to expand and view full content with proper whitespace rendering
 - **Remember Layout Proportions**: Persists and restores panel split positions between sessions
-- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open project guidelines (Kinesis / Meridian)
+- **Request Revisions Improvements**: In the Request Revisions modal: **Copy Prompt** and **Copy Verifier Output** buttons; shortcut to open project guidelines (Kinesis / Meridian)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Toggle Tool Parameters**: Collapse/expand tool parameters (with option to auto-collapse on execute)
 - **Tool Results Resize Handle**: Resizable tool results area
@@ -162,7 +162,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Copy verifier output to clipboard
 - **Copy Result Params and Inputs**: Button under Your Answer to copy parameter labels and values to clipboard
 - **Guideline Buttons**: Quick links to guidelines
-- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open Meridian guidelines
+- **Request Revisions Improvements**: In the Request Revisions modal: **Copy Prompt** and **Copy Verifier Output** buttons; shortcut to open Meridian guidelines
 - **QA Scratchpad**: Adjustable-height scratchpad for notes (with option to remember contents)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Metadata Tag QA Enhancements**: Show/hide Writer Metadata section; suggested tag changes as toggles with "Copy Suggested Changes" for feedback

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Useful Link Buttons**: Quick links to QA/Kinesis guidelines and JSON Editor Online below the scratchpad
 - **Bug Report Expand**: Click bug reports to expand and view full content with proper whitespace rendering
 - **Remember Layout Proportions**: Persists and restores panel split positions between sessions
-- **Request Revisions Improvements**: Enhanced workflow with auto-copy workflow to "What did you try?", auto-paste prompt to Task issue, and auto-paste verifier output to Grading issue (with guideline link shortcuts)
+- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open project guidelines (Kinesis / Meridian)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Toggle Tool Parameters**: Collapse/expand tool parameters (with option to auto-collapse on execute)
 - **Tool Results Resize Handle**: Resizable tool results area
@@ -162,7 +162,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Copy verifier output to clipboard
 - **Copy Result Params and Inputs**: Button under Your Answer to copy parameter labels and values to clipboard
 - **Guideline Buttons**: Quick links to guidelines
-- **Request Revisions Improvements**: Enhanced workflow with auto-copy workflow to "What did you try?", auto-paste prompt to Task issue, and auto-paste verifier output to Grading issue
+- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open Meridian guidelines
 - **QA Scratchpad**: Adjustable-height scratchpad for notes (with option to remember contents)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Metadata Tag QA Enhancements**: Show/hide Writer Metadata section; suggested tag changes as toggles with "Copy Suggested Changes" for feedback

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.62",
+  "archetypesVersion": "6.63",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -365,6 +365,11 @@
           "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
         },
         {
+          "name": "hide-grading-autoclick.js",
+          "version": "1.0",
+          "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37"
+        },
+        {
           "name": "clear-search.js",
           "version": "2.1",
           "hash": "sha256-1c909857b79e8a369bd2e9a1767445fbfc0f77ae50c40b2c6fb09e879c7357f3"
@@ -472,6 +477,11 @@
           "name": "hide-testing-environment-banner.js",
           "version": "1.0",
           "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
+        },
+        {
+          "name": "hide-grading-autoclick.js",
+          "version": "1.0",
+          "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37"
         },
         {
           "name": "bug-report-expand.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.67",
+  "archetypesVersion": "6.68",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.7",
-          "hash": "sha256-14f83455fe9e57858c005f0b9cfafe22df060d01bb9cf1e9271396c90a615442"
+          "version": "1.8",
+          "hash": "sha256-5b08a6a2eed71642263da8893128fecc6dc0bfdc950199b3f7b693c2fa3170b9"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.6",
-          "hash": "sha256-1d476fbc88bad77224c4beeb9ad870537dfa16527b2a135a198da4aa643a80b6"
+          "version": "4.7",
+          "hash": "sha256-b9c2229aec44715cdf8168848f144f6c148f43eeb8269045b0b3fe6a020c8d9e"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.6",
-          "hash": "sha256-f1db70a8c8e72cd4b6acbd8d28d39c20cbae36fa8fd61eb84423e1c1b081dbfe"
+          "version": "1.7",
+          "hash": "sha256-f7b8b6afd7ad1461ee213e334244aa28f69183f7071e5fc3bb8acf2ccda95f6f"
         },
         {
           "name": "copy-result-params.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.8",
-          "hash": "sha256-42541801523db2405b971edb13ab34087f71b4f186ee92f4b0363fd899bfe3c8"
+          "version": "3.9",
+          "hash": "sha256-f9ae54084df14447325c004c3e273faa944e9c9d525569ef3a4acfc6d6429940"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.63",
+  "archetypesVersion": "6.64",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.3",
-          "hash": "sha256-38f088a48ab0e31419fc943d9cdc6b30130c455a354a3acc3260a5f7888224e9"
+          "version": "1.4",
+          "hash": "sha256-09018b5f83f71160d4b22dbc41ebaa69b752c02a895c75e56c55c08de39f9bcb"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.4",
-          "hash": "sha256-a1cb1bd7c7fb8dd85d9ffe629ddaac8c087d86031fe04b6886500405fe95a66d"
+          "version": "4.5",
+          "hash": "sha256-ebc6f2a408da911c63363709bef5757fb8dc3676607fc0f33736a7c7f565a587"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.2",
-          "hash": "sha256-5b231272a0f7829c86f63957244099b6ef187264c377421cd6d5d3ee2d5798d5"
+          "version": "1.3",
+          "hash": "sha256-6774a346bf525817c20b97d0f4da56a65e90175088ca170ea231c290d64010b0"
         },
         {
           "name": "copy-result-params.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.6",
-          "hash": "sha256-e42923dc35f3c4bd68844ee1927b15973774651af8c49500bf6ef9494cfd1fc6"
+          "version": "3.7",
+          "hash": "sha256-0f22400e1c2ca2e9e6d6e20ac2de31460f46ef36afdbb4e676f97ca49eef12aa"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.64",
+  "archetypesVersion": "6.65",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.4",
-          "hash": "sha256-09018b5f83f71160d4b22dbc41ebaa69b752c02a895c75e56c55c08de39f9bcb"
+          "version": "1.5",
+          "hash": "sha256-c01c6cb92b4bd003e52803ec9034c814c6ef4d5324c87921bc95c21b78df2aa2"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.3",
-          "hash": "sha256-6774a346bf525817c20b97d0f4da56a65e90175088ca170ea231c290d64010b0"
+          "version": "1.4",
+          "hash": "sha256-8cf5145374bb8c3757254516b632a49e4e94309a689a208bf9c6839dc20e2be2"
         },
         {
           "name": "copy-result-params.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.66",
+  "archetypesVersion": "6.67",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.6",
-          "hash": "sha256-8edd0dffbb9b3248f5c5c03c5c3e32b930a086448c57f652e2fa66e25d727d72"
+          "version": "1.7",
+          "hash": "sha256-14f83455fe9e57858c005f0b9cfafe22df060d01bb9cf1e9271396c90a615442"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.5",
-          "hash": "sha256-ebc6f2a408da911c63363709bef5757fb8dc3676607fc0f33736a7c7f565a587"
+          "version": "4.6",
+          "hash": "sha256-1d476fbc88bad77224c4beeb9ad870537dfa16527b2a135a198da4aa643a80b6"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.5",
-          "hash": "sha256-62907a144e2b94546f5b0f81ab3289eacb9c2df96691982a17c929787138dc95"
+          "version": "1.6",
+          "hash": "sha256-f1db70a8c8e72cd4b6acbd8d28d39c20cbae36fa8fd61eb84423e1c1b081dbfe"
         },
         {
           "name": "copy-result-params.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.7",
-          "hash": "sha256-0f22400e1c2ca2e9e6d6e20ac2de31460f46ef36afdbb4e676f97ca49eef12aa"
+          "version": "3.8",
+          "hash": "sha256-42541801523db2405b971edb13ab34087f71b4f186ee92f4b0363fd899bfe3c8"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.70",
+  "archetypesVersion": "6.71",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.9",
-          "hash": "sha256-325eca433cf9c36d954fdc7b52d116a8c388ec25106834d99cb0037933838d7b"
+          "version": "4.10",
+          "hash": "sha256-9614ac59a4a848005e2dea3cc76577a3be4d322693b37807c5feb07ef78c38b3"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.11",
-          "hash": "sha256-0f22c8cd7865a738a25b68ac060844ea776d29f9d3c0bf727ff6ab65fcf4ce8d"
+          "version": "3.12",
+          "hash": "sha256-7bfb770b878bebe2916e7c7f9bff530027661e8603c824f43513aa8fc4bb309d"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.71",
+  "archetypesVersion": "6.72",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.10",
-          "hash": "sha256-9614ac59a4a848005e2dea3cc76577a3be4d322693b37807c5feb07ef78c38b3"
+          "version": "4.11",
+          "hash": "sha256-5c33b85b9740f8929e841cac7cc5c99ed543f463a8b072d1f3d6cd3510237453"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.12",
-          "hash": "sha256-7bfb770b878bebe2916e7c7f9bff530027661e8603c824f43513aa8fc4bb309d"
+          "version": "3.13",
+          "hash": "sha256-07562095c364495df2737e3d302b83459d2ac002bc75ad7057998c941ff0e052"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.65",
+  "archetypesVersion": "6.66",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.5",
-          "hash": "sha256-c01c6cb92b4bd003e52803ec9034c814c6ef4d5324c87921bc95c21b78df2aa2"
+          "version": "1.6",
+          "hash": "sha256-8edd0dffbb9b3248f5c5c03c5c3e32b930a086448c57f652e2fa66e25d727d72"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.4",
-          "hash": "sha256-8cf5145374bb8c3757254516b632a49e4e94309a689a208bf9c6839dc20e2be2"
+          "version": "1.5",
+          "hash": "sha256-62907a144e2b94546f5b0f81ab3289eacb9c2df96691982a17c929787138dc95"
         },
         {
           "name": "copy-result-params.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.72",
+  "archetypesVersion": "6.74",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -16,8 +16,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.5",
-      "hash": "sha256-0590775e6e7436ac9efb9a2d164a4e28689e6ed4d3700f47be41268ec2ce1390"
+      "version": "2.6",
+      "hash": "sha256-c3ed59d35a36fb23fd7982ed3144a68f1bdd18d05086788fd4c8d249eab2b848"
     }
   ],
   "settingsModalDocs": [
@@ -40,23 +40,23 @@
       "plugins": [
         {
           "name": "progress-prompt-expand.js",
-          "version": "1.7",
-          "hash": "sha256-d9c6ec87f1e51d40bc2f8001a81f897a6f392d9a29aa92d12237c8ef00196a89"
+          "version": "1.8",
+          "hash": "sha256-2d499f17881a9c1335ad4b37ac695ccf19ab37747b02e0bc10fb05e29d8cd0f0"
         },
         {
           "name": "feedback-given-stats.js",
-          "version": "2.9",
-          "hash": "sha256-3c09a920843a00b381c003472b79588f99d52645386e3ac263878f56121f4a55"
+          "version": "3.0",
+          "hash": "sha256-a8043a6868f582525604584b2081ce30cd1d3c6670000a9f51ba886d992343a6"
         },
         {
           "name": "task-creation-today-env.js",
-          "version": "2.9",
-          "hash": "sha256-d2ba0d08ad094416c7fbf930615413b0a6342c2842bd88a2cf052f11797a152f"
+          "version": "3.0",
+          "hash": "sha256-9ab03fd598a5046a1fcee023f30296dc3b11408e96ac64d74c6c08cb09980f53"
         },
         {
           "name": "disputes-reviewed-today.js",
-          "version": "2.9",
-          "hash": "sha256-a07092bf7da5ba4c5da458ef482ae98f8a3610b3e72238b0890887cc910b83d0"
+          "version": "3.0",
+          "hash": "sha256-eece62dc245e0482ca91851b53460142fd5f2bb0dc00d8953ed233c479aff158"
         }
       ]
     },
@@ -74,8 +74,8 @@
         },
         {
           "name": "json-editor-online.js",
-          "version": "2.0",
-          "hash": "sha256-b1c8988a2a24db1f124045a66e92f8e46e5666409d8f2ac7f3e9f49bf3abef1b"
+          "version": "2.1",
+          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180"
         },
         {
           "name": "guideline-buttons.js",
@@ -129,8 +129,8 @@
         },
         {
           "name": "text-sanitizer.js",
-          "version": "3.2",
-          "hash": "sha256-0f154eb18fb015f999c02faa59011ad4776719c3ac1faa6980dac73c7b408824"
+          "version": "3.3",
+          "hash": "sha256-00fb0fa32015a92797b2c70a9e5e00a8a552670addee1aeb9b72cb2ce309a8b4"
         }
       ]
     },
@@ -150,8 +150,8 @@
         },
         {
           "name": "json-editor-online.js",
-          "version": "2.0",
-          "hash": "sha256-b1c8988a2a24db1f124045a66e92f8e46e5666409d8f2ac7f3e9f49bf3abef1b"
+          "version": "2.1",
+          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180"
         },
         {
           "name": "guideline-buttons.js",
@@ -195,8 +195,8 @@
         },
         {
           "name": "text-sanitizer.js",
-          "version": "3.2",
-          "hash": "sha256-0f154eb18fb015f999c02faa59011ad4776719c3ac1faa6980dac73c7b408824"
+          "version": "3.3",
+          "hash": "sha256-00fb0fa32015a92797b2c70a9e5e00a8a552670addee1aeb9b72cb2ce309a8b4"
         }
       ]
     },
@@ -259,13 +259,13 @@
         },
         {
           "name": "text-sanitizer.js",
-          "version": "3.0",
-          "hash": "sha256-ce678d871cf2433fbe5d7053403808306ba949239eaab1399ba95baf2e4e15e0"
+          "version": "3.1",
+          "hash": "sha256-e8d44bc528ecfb602f8b684a52a534ab0eea28ef75f58f3b997db3917f310be9"
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "3.2",
-          "hash": "sha256-626f4f46d17bd7d2057a09e3cd9bb1c44640ad5ae5548a566fe9b5b30258e282"
+          "version": "3.3",
+          "hash": "sha256-d226b94bccd038122217639d34bafc2417f4b573afe3c9b373b63c3bdee8d9af"
         }
       ]
     },
@@ -386,13 +386,13 @@
         },
         {
           "name": "copy-prompt.js",
-          "version": "1.5",
-          "hash": "sha256-334230142843259239f5393574d84119b44c237adea0c29c421276a50471ab6e"
+          "version": "1.6",
+          "hash": "sha256-e9fd5dfa0043ac0249b21407483e0f3985eebcb8c3ac1fed66f10cacc148a650"
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.8",
-          "hash": "sha256-5b08a6a2eed71642263da8893128fecc6dc0bfdc950199b3f7b693c2fa3170b9"
+          "version": "1.9",
+          "hash": "sha256-9e77d8f75789817ee4c43f6d71d1886a75dbb8c69d7e92e1769efe2fc5e6ba50"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -406,13 +406,13 @@
         },
         {
           "name": "useful-links-buttons.js",
-          "version": "2.0",
-          "hash": "sha256-50c1f7fc4866dd01e3fd5ffa72affe7ee41fb3b8dcd359c9ae299f42b5a6a0d2"
+          "version": "2.1",
+          "hash": "sha256-92914ecd1790fa86c7054308c509d23e81defabfd98719f0c7b9720112339ff8"
         },
         {
           "name": "text-sanitizer.js",
-          "version": "2.5",
-          "hash": "sha256-a856089dc28fa3cba92d2c554c9f3eb820a3e08a35ea07b96286cda90342c3be"
+          "version": "2.6",
+          "hash": "sha256-8b6df5ee1457423a55c22cf7beeb5780f23f15531e697bcc487ffde8b6a3be6b"
         },
         {
           "name": "execute-to-current-tool.js",
@@ -426,13 +426,13 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.11",
-          "hash": "sha256-5c33b85b9740f8929e841cac7cc5c99ed543f463a8b072d1f3d6cd3510237453"
+          "version": "5.0",
+          "hash": "sha256-f63146be53b605e34ab08d978abab841d2ddfb7efcb61671a94376406bdc7753"
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "2.2",
-          "hash": "sha256-a6df47743adaace458ec92b165a498acee5fdaf0ca1365d16b4a314112c4f650"
+          "version": "2.3",
+          "hash": "sha256-3f354b0619991574f9718b2a2607278bf2711a354a9f9f24a6cd03a15ebfc4eb"
         },
         {
           "name": "tool-results-resize-handle.js",
@@ -490,28 +490,28 @@
         },
         {
           "name": "copy-prompt.js",
-          "version": "1.4",
-          "hash": "sha256-75da918251762019fdf930c02859528f9a5a8cfed62f30e4b47bbf8d47ab5543"
+          "version": "1.5",
+          "hash": "sha256-78603cee2124738aeb32db0ca503b5e9654d17d1ffdd0e564f626c6e5501f73a"
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.7",
-          "hash": "sha256-f7b8b6afd7ad1461ee213e334244aa28f69183f7071e5fc3bb8acf2ccda95f6f"
+          "version": "1.8",
+          "hash": "sha256-0899b7312a8dc2bcba72aad9d236263c30033589af95407200c33420427fb906"
         },
         {
           "name": "copy-result-params.js",
-          "version": "1.0",
-          "hash": "sha256-f6220beabcf293173f07b6f26b47d453b2a546bfdf615426b628bc2dcf897164"
+          "version": "1.1",
+          "hash": "sha256-10b544d60b4eae9da833035e40ba4f43cc3b04e92d4e5447f463432c5b3e7bac"
         },
         {
           "name": "guideline-buttons.js",
-          "version": "2.2",
-          "hash": "sha256-5ea99283f4a46c9e9520419e8505a9ecb51f2ed63d54b84c724cf2d899a42500"
+          "version": "2.3",
+          "hash": "sha256-038fb5954172425ed0530d776d78fbcb1f9b32f0e6036aaeda1786b2aed2732e"
         },
         {
           "name": "request-revisions.js",
-          "version": "3.13",
-          "hash": "sha256-07562095c364495df2737e3d302b83459d2ac002bc75ad7057998c941ff0e052"
+          "version": "4.0",
+          "hash": "sha256-50f4d804d666c4c19f588cf267d4c0f7c3602acd4f1bae8143a50a217a85bcbc"
         },
         {
           "name": "qa-scratchpad.js",
@@ -520,13 +520,13 @@
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "2.2",
-          "hash": "sha256-a6df47743adaace458ec92b165a498acee5fdaf0ca1365d16b4a314112c4f650"
+          "version": "2.3",
+          "hash": "sha256-3f354b0619991574f9718b2a2607278bf2711a354a9f9f24a6cd03a15ebfc4eb"
         },
         {
           "name": "verifier-diff-highlight-improved.js",
-          "version": "1.3",
-          "hash": "sha256-f03f7199c76459273148b308a590bd2b493439d74bad1c396dbcc122711241c1"
+          "version": "1.4",
+          "hash": "sha256-d8c9f49082a3d7fef6f85daa5e806041fdde49746064f74ff66336772fa91978"
         },
         {
           "name": "accept-task-modal-improvements.js",
@@ -562,8 +562,8 @@
         },
         {
           "name": "dispute-detail-task-id.js",
-          "version": "1.0",
-          "hash": "sha256-b43b20e4851adc3ba3cd079230e08546fd2bede9c0c1f01fb5a24fa0de887c71"
+          "version": "1.1",
+          "hash": "sha256-c5f505ac2b5485867898c9901b8c4faa4420b42da68eda32166bdeed49af58c7"
         },
         {
           "name": "dispute-content-layout-fixes.js",
@@ -607,8 +607,8 @@
         },
         {
           "name": "verifier-diff-highlight-improved.js",
-          "version": "1.3",
-          "hash": "sha256-0a9c1d87eb11d29d570b8a61d9c0460a7d54b876a0119037e71effc9494ef707"
+          "version": "1.4",
+          "hash": "sha256-e0ef7a8f1f8b53aa0ac26661d5d2f0024b3739c43e9f673a6ec982474a8239f8"
         }
       ]
     },
@@ -621,8 +621,8 @@
       "plugins": [
         {
           "name": "prompt-diff-highlight.js",
-          "version": "3.2",
-          "hash": "sha256-626f4f46d17bd7d2057a09e3cd9bb1c44640ad5ae5548a566fe9b5b30258e282"
+          "version": "3.3",
+          "hash": "sha256-d226b94bccd038122217639d34bafc2417f4b573afe3c9b373b63c3bdee8d9af"
         }
       ]
     }
@@ -732,8 +732,8 @@
       "plugins": [
         {
           "name": "dispute-ids-enhancer.js",
-          "version": "3.0",
-          "hash": "sha256-bd56d8ced343b95235e7f7f3d4e2977d723afc10aa838e47c7ff7ae66c0ddbf9"
+          "version": "3.1",
+          "hash": "sha256-4c885d4706a1b1a367213b45dea7842424a124a7db38f457e4d5bad9cc80d1d7"
         }
       ]
     }

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.69",
+  "archetypesVersion": "6.70",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.8",
-          "hash": "sha256-b87590e5fb94b83d34b34629ab1c4fa510c128aa02be544684a760da544256bd"
+          "version": "4.9",
+          "hash": "sha256-325eca433cf9c36d954fdc7b52d116a8c388ec25106834d99cb0037933838d7b"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.10",
-          "hash": "sha256-402a8d5caf06384f749aae3821f96df1fb65a8eeee316592e39f3741f51bedfa"
+          "version": "3.11",
+          "hash": "sha256-0f22c8cd7865a738a25b68ac060844ea776d29f9d3c0bf727ff6ab65fcf4ce8d"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.74",
+  "archetypesVersion": "6.75",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "5.0",
-          "hash": "sha256-f63146be53b605e34ab08d978abab841d2ddfb7efcb61671a94376406bdc7753"
+          "version": "5.1",
+          "hash": "sha256-c83c990f595c20c1e010700077c0d0263da4d9ced46944daa0a8e5697d8cac2e"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.0",
-          "hash": "sha256-50f4d804d666c4c19f588cf267d4c0f7c3602acd4f1bae8143a50a217a85bcbc"
+          "version": "4.1",
+          "hash": "sha256-ca2d864fc92f72f2a481e69fef3dad5ad442a64c72fbdf30a76beb092a41c1ca"
         },
         {
           "name": "qa-scratchpad.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.68",
+  "archetypesVersion": "6.69",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.7",
-          "hash": "sha256-b9c2229aec44715cdf8168848f144f6c148f43eeb8269045b0b3fe6a020c8d9e"
+          "version": "4.8",
+          "hash": "sha256-b87590e5fb94b83d34b34629ab1c4fa510c128aa02be544684a760da544256bd"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "3.9",
-          "hash": "sha256-f9ae54084df14447325c004c3e273faa944e9c9d525569ef3a4acfc6d6429940"
+          "version": "3.10",
+          "hash": "sha256-402a8d5caf06384f749aae3821f96df1fb65a8eeee316592e39f3741f51bedfa"
         },
         {
           "name": "qa-scratchpad.js",

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -75,7 +75,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Useful Link Buttons**: Quick links to QA/Kinesis guidelines and JSON Editor Online below the scratchpad
 - **Bug Report Expand**: Click bug reports to expand and view full content with proper whitespace rendering
 - **Remember Layout Proportions**: Persists and restores panel split positions between sessions
-- **Request Revisions Improvements**: Enhanced workflow with auto-copy workflow to "What did you try?", auto-paste prompt to Task issue, and auto-paste verifier output to Grading issue (with guideline link shortcuts)
+- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open project guidelines (Kinesis / Meridian)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Toggle Tool Parameters**: Collapse/expand tool parameters (with option to auto-collapse on execute)
 - **Tool Results Resize Handle**: Resizable tool results area
@@ -90,7 +90,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Copy verifier output to clipboard
 - **Copy Result Params and Inputs**: Button under Your Answer to copy parameter labels and values to clipboard
 - **Guideline Buttons**: Quick links to guidelines
-- **Request Revisions Improvements**: Enhanced workflow with auto-copy workflow to "What did you try?", auto-paste prompt to Task issue, and auto-paste verifier output to Grading issue
+- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open Meridian guidelines
 - **QA Scratchpad**: Adjustable-height scratchpad for notes (with option to remember contents)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Metadata Tag QA Enhancements**: Show/hide Writer Metadata section; suggested tag changes as toggles with "Copy Suggested Changes" for feedback

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -75,7 +75,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Useful Link Buttons**: Quick links to QA/Kinesis guidelines and JSON Editor Online below the scratchpad
 - **Bug Report Expand**: Click bug reports to expand and view full content with proper whitespace rendering
 - **Remember Layout Proportions**: Persists and restores panel split positions between sessions
-- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open project guidelines (Kinesis / Meridian)
+- **Request Revisions Improvements**: In the Request Revisions modal: **Copy Prompt** and **Copy Verifier Output** buttons; shortcut to open project guidelines (Kinesis / Meridian)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Toggle Tool Parameters**: Collapse/expand tool parameters (with option to auto-collapse on execute)
 - **Tool Results Resize Handle**: Resizable tool results area
@@ -90,7 +90,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Copy verifier output to clipboard
 - **Copy Result Params and Inputs**: Button under Your Answer to copy parameter labels and values to clipboard
 - **Guideline Buttons**: Quick links to guidelines
-- **Request Revisions Improvements**: In the Request Revisions modal: optional auto-paste of the saved prompt into the Task issue box when Task is selected; **Copy Verifier Output** button; shortcut to open Meridian guidelines
+- **Request Revisions Improvements**: In the Request Revisions modal: **Copy Prompt** and **Copy Verifier Output** buttons; shortcut to open Meridian guidelines
 - **QA Scratchpad**: Adjustable-height scratchpad for notes (with option to remember contents)
 - **Prompt Diff Highlighting**: Highlight differences in prompt content when comparing versions
 - **Metadata Tag QA Enhancements**: Show/hide Writer Metadata section; suggested tag changes as toggles with "Copy Suggested Changes" for feedback

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-qa-improvements] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-qa-improvements/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-qa-improvements/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-qa-improvements',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-qa-improvements] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-qa-improvements/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-qa-improvements/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-qa-improvements',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dashboard/deprecated/feedback-given-today-env.js
+++ b/plugins/archetypes/dashboard/deprecated/feedback-given-today-env.js
@@ -4,10 +4,41 @@ const plugin = {
     id: 'feedbackGivenTodayEnv',
     name: 'Daily Feedback Breakdown',
     description: 'Show today\'s feedback count and environment breakdown under the Feedback Given stat, with a warning when list may be incomplete',
-    _version: '2.2',
+    _version: '2.3',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, lastUncertain: false },
+
+    COPY_FEEDBACK_SUCCESS_MS: 1000,
+    COPY_FEEDBACK_FAILURE_MS: 500,
+
+    flashCopyButtonSuccess(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        btn.style.transition = '';
+        btn.style.backgroundColor = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn._wfCopyResetTimeout = null;
+            btn.style.backgroundColor = '';
+            btn.style.color = '';
+        }, this.COPY_FEEDBACK_SUCCESS_MS);
+    },
+
+    flashCopyButtonFailure(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        const prevT = btn.style.transition;
+        btn.style.transition = 'none';
+        btn.style.backgroundColor = 'rgb(239, 68, 68)';
+        btn.style.color = '#ffffff';
+        void btn.offsetHeight;
+        btn.style.transition = `background-color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out, color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out`;
+        btn.style.backgroundColor = '';
+        btn.style.color = '';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn.style.transition = prevT || '';
+            btn._wfCopyResetTimeout = null;
+        }, this.COPY_FEEDBACK_FAILURE_MS);
+    },
 
     /** Month name (3-letter) to 1-based month index. */
     MONTH_INDEX: { Jan: 1, Feb: 2, Mar: 3, Apr: 4, May: 5, Jun: 6, Jul: 7, Aug: 8, Sep: 9, Oct: 10, Nov: 11, Dec: 12 },
@@ -115,7 +146,10 @@ const plugin = {
             if (copyBtn) {
                 copyBtn.addEventListener('click', () => {
                     const text = copyBtn.getAttribute('data-wf-copy-text');
-                    if (!text) return;
+                    if (!text) {
+                        this.flashCopyButtonFailure(copyBtn);
+                        return;
+                    }
                     if (copyBtn.getAttribute('data-wf-copy-uncertain') === 'true') {
                         alert(
                             'Warning:\n\n' +
@@ -123,18 +157,12 @@ const plugin = {
                             'Please scroll down the page so that all of today\'s tasks are visible on the page before copying to ensure accurate results.'
                         );
                     }
-                    if (copyBtn._wfCopyResetTimeout) clearTimeout(copyBtn._wfCopyResetTimeout);
                     navigator.clipboard.writeText(text).then(() => {
                         Logger.log('feedback-given-today-env: copied breakdown to clipboard');
-                        copyBtn.textContent = 'Copied!';
-                        copyBtn.classList.add('text-green-600', 'dark:text-green-400');
-                        copyBtn._wfCopyResetTimeout = setTimeout(() => {
-                            copyBtn._wfCopyResetTimeout = null;
-                            copyBtn.textContent = 'Copy';
-                            copyBtn.classList.remove('text-green-600', 'dark:text-green-400');
-                        }, 5000);
+                        this.flashCopyButtonSuccess(copyBtn);
                     }).catch((err) => {
                         Logger.error('feedback-given-today-env: failed to copy breakdown', err);
+                        this.flashCopyButtonFailure(copyBtn);
                     });
                 });
             }

--- a/plugins/archetypes/dashboard/main/disputes-reviewed-today.js
+++ b/plugins/archetypes/dashboard/main/disputes-reviewed-today.js
@@ -3,10 +3,41 @@ const plugin = {
     id: 'disputesReviewedToday',
     name: 'Disputes Reviewed Today Breakdown',
     description: 'Show today\'s disputes reviewed count and approved/rejected breakdown with copy and scroll warning',
-    _version: '2.9',
+    _version: '3.0',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, lastUncertain: false },
+
+    COPY_FEEDBACK_SUCCESS_MS: 1000,
+    COPY_FEEDBACK_FAILURE_MS: 500,
+
+    flashCopyButtonSuccess(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        btn.style.transition = '';
+        btn.style.backgroundColor = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn._wfCopyResetTimeout = null;
+            btn.style.backgroundColor = '';
+            btn.style.color = '';
+        }, this.COPY_FEEDBACK_SUCCESS_MS);
+    },
+
+    flashCopyButtonFailure(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        const prevT = btn.style.transition;
+        btn.style.transition = 'none';
+        btn.style.backgroundColor = 'rgb(239, 68, 68)';
+        btn.style.color = '#ffffff';
+        void btn.offsetHeight;
+        btn.style.transition = `background-color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out, color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out`;
+        btn.style.backgroundColor = '';
+        btn.style.color = '';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn.style.transition = prevT || '';
+            btn._wfCopyResetTimeout = null;
+        }, this.COPY_FEEDBACK_FAILURE_MS);
+    },
 
     /** Month name (3-letter) to 1-based month index. */
     MONTH_INDEX: { Jan: 1, Feb: 2, Mar: 3, Apr: 4, May: 5, Jun: 6, Jul: 7, Aug: 8, Sep: 9, Oct: 10, Nov: 11, Dec: 12 },
@@ -261,7 +292,10 @@ const plugin = {
             if (copyBtn) {
                 copyBtn.addEventListener('click', () => {
                     const text = copyBtn.getAttribute('data-wf-copy-text');
-                    if (!text) return;
+                    if (!text) {
+                        self.flashCopyButtonFailure(copyBtn);
+                        return;
+                    }
                     if (copyBtn.getAttribute('data-wf-copy-uncertain') === 'true') {
                         const daysAgo = block._wfDaysAgo || 0;
                         alert(
@@ -272,18 +306,12 @@ const plugin = {
                                 : 'Please scroll down the page so that all reviews for that day are visible on the page before copying to ensure accurate results.')
                         );
                     }
-                    if (copyBtn._wfCopyResetTimeout) clearTimeout(copyBtn._wfCopyResetTimeout);
                     navigator.clipboard.writeText(text).then(() => {
                         Logger.log('disputes-reviewed-today: copied breakdown to clipboard', { daysAgo: block._wfDaysAgo || 0 });
-                        copyBtn.textContent = 'Copied!';
-                        copyBtn.classList.add('text-green-600', 'dark:text-green-400');
-                        copyBtn._wfCopyResetTimeout = setTimeout(() => {
-                            copyBtn._wfCopyResetTimeout = null;
-                            copyBtn.textContent = 'Copy Breakdown';
-                            copyBtn.classList.remove('text-green-600', 'dark:text-green-400');
-                        }, 5000);
+                        self.flashCopyButtonSuccess(copyBtn);
                     }).catch((err) => {
                         Logger.error('disputes-reviewed-today: failed to copy breakdown', err);
+                        self.flashCopyButtonFailure(copyBtn);
                     });
                 });
             }

--- a/plugins/archetypes/dashboard/main/feedback-given-stats.js
+++ b/plugins/archetypes/dashboard/main/feedback-given-stats.js
@@ -3,10 +3,41 @@ const plugin = {
     id: 'feedbackGivenStats',
     name: 'Feedback Given Stats',
     description: 'Show overall approval rate, today\'s feedback count and environment breakdown with day and per-env approval rates, plus copy and scroll warning',
-    _version: '2.9',
+    _version: '3.0',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, lastUncertain: false, lastStatsPayload: null },
+
+    COPY_FEEDBACK_SUCCESS_MS: 1000,
+    COPY_FEEDBACK_FAILURE_MS: 500,
+
+    flashCopyButtonSuccess(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        btn.style.transition = '';
+        btn.style.backgroundColor = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn._wfCopyResetTimeout = null;
+            btn.style.backgroundColor = '';
+            btn.style.color = '';
+        }, this.COPY_FEEDBACK_SUCCESS_MS);
+    },
+
+    flashCopyButtonFailure(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        const prevT = btn.style.transition;
+        btn.style.transition = 'none';
+        btn.style.backgroundColor = 'rgb(239, 68, 68)';
+        btn.style.color = '#ffffff';
+        void btn.offsetHeight;
+        btn.style.transition = `background-color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out, color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out`;
+        btn.style.backgroundColor = '';
+        btn.style.color = '';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn.style.transition = prevT || '';
+            btn._wfCopyResetTimeout = null;
+        }, this.COPY_FEEDBACK_FAILURE_MS);
+    },
 
     /** Month name (3-letter) to 1-based month index. */
     MONTH_INDEX: { Jan: 1, Feb: 2, Mar: 3, Apr: 4, May: 5, Jun: 6, Jul: 7, Aug: 8, Sep: 9, Oct: 10, Nov: 11, Dec: 12 },
@@ -324,7 +355,10 @@ const plugin = {
             if (copyBtn) {
                 copyBtn.addEventListener('click', () => {
                     const text = copyBtn.getAttribute('data-wf-copy-text');
-                    if (!text) return;
+                    if (!text) {
+                        self.flashCopyButtonFailure(copyBtn);
+                        return;
+                    }
                     if (copyBtn.getAttribute('data-wf-copy-uncertain') === 'true') {
                         const daysAgo = block._wfDaysAgo || 0;
                         alert(
@@ -335,18 +369,12 @@ const plugin = {
                                 : 'Please scroll down the page so that all submissions for that day are visible on the page before copying to ensure accurate results.')
                         );
                     }
-                    if (copyBtn._wfCopyResetTimeout) clearTimeout(copyBtn._wfCopyResetTimeout);
                     navigator.clipboard.writeText(text).then(() => {
                         Logger.log('feedback-given-stats: copied breakdown to clipboard', { daysAgo: block._wfDaysAgo || 0 });
-                        copyBtn.textContent = 'Copied!';
-                        copyBtn.classList.add('text-green-600', 'dark:text-green-400');
-                        copyBtn._wfCopyResetTimeout = setTimeout(() => {
-                            copyBtn._wfCopyResetTimeout = null;
-                            copyBtn.textContent = 'Copy Breakdown';
-                            copyBtn.classList.remove('text-green-600', 'dark:text-green-400');
-                        }, 5000);
+                        self.flashCopyButtonSuccess(copyBtn);
                     }).catch((err) => {
                         Logger.error('feedback-given-stats: failed to copy breakdown', err);
+                        self.flashCopyButtonFailure(copyBtn);
                     });
                 });
             }

--- a/plugins/archetypes/dashboard/main/progress-prompt-expand.js
+++ b/plugins/archetypes/dashboard/main/progress-prompt-expand.js
@@ -4,7 +4,7 @@ const plugin = {
     id: 'progressPromptExpand',
     name: 'Expanded Submitted Prompts',
     description: 'Hover over task items to expand truncated prompts',
-    _version: '1.7',
+    _version: '1.8',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false },
@@ -94,11 +94,43 @@ const plugin = {
                     e.stopPropagation();
                     if (!Storage.getSubOptionEnabled(pluginId, 'copyOnClick', true)) return;
                     const text = inner.textContent.trim();
-                    if (!text) return;
+                    const flashSuccess = () => {
+                        if (inner._wfPromptCopyT) clearTimeout(inner._wfPromptCopyT);
+                        inner.style.transition = '';
+                        inner.style.backgroundColor = 'rgb(34, 197, 94)';
+                        inner.style.color = '#ffffff';
+                        inner._wfPromptCopyT = setTimeout(() => {
+                            inner.style.backgroundColor = '';
+                            inner.style.color = '';
+                            inner._wfPromptCopyT = null;
+                        }, 1000);
+                    };
+                    const flashFailure = () => {
+                        if (inner._wfPromptCopyT) clearTimeout(inner._wfPromptCopyT);
+                        const prevT = inner.style.transition;
+                        inner.style.transition = 'none';
+                        inner.style.backgroundColor = 'rgb(239, 68, 68)';
+                        inner.style.color = '#ffffff';
+                        void inner.offsetHeight;
+                        inner.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                        inner.style.backgroundColor = '';
+                        inner.style.color = '';
+                        inner._wfPromptCopyT = setTimeout(() => {
+                            inner.style.transition = prevT || '';
+                            inner._wfPromptCopyT = null;
+                        }, 500);
+                    };
+                    if (!text) {
+                        Logger.debug('progress-prompt-expand: no prompt text to copy');
+                        flashFailure();
+                        return;
+                    }
                     navigator.clipboard.writeText(text).then(() => {
                         Logger.log('Prompt copied to clipboard');
+                        flashSuccess();
                     }).catch((err) => {
                         Logger.error('Failed to copy prompt:', err);
+                        flashFailure();
                     });
                 });
             }

--- a/plugins/archetypes/dashboard/main/task-creation-today-env.js
+++ b/plugins/archetypes/dashboard/main/task-creation-today-env.js
@@ -3,10 +3,41 @@ const plugin = {
     id: 'taskCreationTodayEnv',
     name: 'Daily Task Creation Breakdown',
     description: 'Show today\'s task creation count and environment breakdown under the Task Creation stat, with a warning when list may be incomplete',
-    _version: '2.9',
+    _version: '3.0',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, lastUncertain: false },
+
+    COPY_FEEDBACK_SUCCESS_MS: 1000,
+    COPY_FEEDBACK_FAILURE_MS: 500,
+
+    flashCopyButtonSuccess(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        btn.style.transition = '';
+        btn.style.backgroundColor = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn._wfCopyResetTimeout = null;
+            btn.style.backgroundColor = '';
+            btn.style.color = '';
+        }, this.COPY_FEEDBACK_SUCCESS_MS);
+    },
+
+    flashCopyButtonFailure(btn) {
+        if (btn._wfCopyResetTimeout) clearTimeout(btn._wfCopyResetTimeout);
+        const prevT = btn.style.transition;
+        btn.style.transition = 'none';
+        btn.style.backgroundColor = 'rgb(239, 68, 68)';
+        btn.style.color = '#ffffff';
+        void btn.offsetHeight;
+        btn.style.transition = `background-color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out, color ${this.COPY_FEEDBACK_FAILURE_MS}ms ease-out`;
+        btn.style.backgroundColor = '';
+        btn.style.color = '';
+        btn._wfCopyResetTimeout = setTimeout(() => {
+            btn.style.transition = prevT || '';
+            btn._wfCopyResetTimeout = null;
+        }, this.COPY_FEEDBACK_FAILURE_MS);
+    },
 
     /** Month name (3-letter) to 1-based month index. */
     MONTH_INDEX: { Jan: 1, Feb: 2, Mar: 3, Apr: 4, May: 5, Jun: 6, Jul: 7, Aug: 8, Sep: 9, Oct: 10, Nov: 11, Dec: 12 },
@@ -246,7 +277,10 @@ const plugin = {
             if (copyBtn) {
                 copyBtn.addEventListener('click', () => {
                     const text = copyBtn.getAttribute('data-wf-copy-text');
-                    if (!text) return;
+                    if (!text) {
+                        self.flashCopyButtonFailure(copyBtn);
+                        return;
+                    }
                     if (copyBtn.getAttribute('data-wf-copy-uncertain') === 'true') {
                         const daysAgo = block._wfDaysAgo || 0;
                         alert(
@@ -257,18 +291,12 @@ const plugin = {
                                 : 'Please scroll down the page so that all submissions for that day are visible on the page before copying to ensure accurate results.')
                         );
                     }
-                    if (copyBtn._wfCopyResetTimeout) clearTimeout(copyBtn._wfCopyResetTimeout);
                     navigator.clipboard.writeText(text).then(() => {
                         Logger.log('task-creation-today-env: copied breakdown to clipboard', { daysAgo: block._wfDaysAgo || 0 });
-                        copyBtn.textContent = 'Copied!';
-                        copyBtn.classList.add('text-green-600', 'dark:text-green-400');
-                        copyBtn._wfCopyResetTimeout = setTimeout(() => {
-                            copyBtn._wfCopyResetTimeout = null;
-                            copyBtn.textContent = 'Copy Breakdown';
-                            copyBtn.classList.remove('text-green-600', 'dark:text-green-400');
-                        }, 5000);
+                        self.flashCopyButtonSuccess(copyBtn);
                     }).catch((err) => {
                         Logger.error('task-creation-today-env: failed to copy breakdown', err);
+                        self.flashCopyButtonFailure(copyBtn);
                     });
                 });
             }

--- a/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
@@ -9,7 +9,7 @@ const plugin = {
     id: 'disputeDetailTaskId',
     name: 'Dispute Detail Task ID',
     description: 'Shows a copyable Task ID in the dispute detail header from the View Task link',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -82,11 +82,42 @@ const plugin = {
         btn.title = 'Copy Task ID';
         btn.addEventListener('click', () => {
             navigator.clipboard.writeText(taskId).then(() => {
+                if (btn._fleetDisputeCopyFailT) {
+                    clearTimeout(btn._fleetDisputeCopyFailT);
+                    btn._fleetDisputeCopyFailT = null;
+                }
+                btn.style.backgroundColor = '';
+                btn.style.color = '';
+                btn.style.transition = '';
+                btn.classList.remove('fleet-dispute-id-copied');
+                void btn.offsetHeight;
                 btn.classList.add('fleet-dispute-id-copied');
                 Logger.log('Dispute Detail Task ID: copied to clipboard');
-                setTimeout(() => btn.classList.remove('fleet-dispute-id-copied'), 3000);
+                if (btn._fleetDisputeCopyOkT) clearTimeout(btn._fleetDisputeCopyOkT);
+                btn._fleetDisputeCopyOkT = setTimeout(() => {
+                    btn.classList.remove('fleet-dispute-id-copied');
+                    btn._fleetDisputeCopyOkT = null;
+                }, 1000);
             }).catch((err) => {
                 Logger.error('Dispute Detail Task ID: failed to copy', err);
+                if (btn._fleetDisputeCopyOkT) {
+                    clearTimeout(btn._fleetDisputeCopyOkT);
+                    btn._fleetDisputeCopyOkT = null;
+                }
+                btn.classList.remove('fleet-dispute-id-copied');
+                if (btn._fleetDisputeCopyFailT) clearTimeout(btn._fleetDisputeCopyFailT);
+                const prevTransition = btn.style.transition;
+                btn.style.transition = 'none';
+                btn.style.backgroundColor = 'rgb(239, 68, 68)';
+                btn.style.color = '#ffffff';
+                void btn.offsetHeight;
+                btn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                btn.style.backgroundColor = '';
+                btn.style.color = '';
+                btn._fleetDisputeCopyFailT = setTimeout(() => {
+                    btn.style.transition = prevTransition || '';
+                    btn._fleetDisputeCopyFailT = null;
+                }, 500);
             });
         });
         return btn;

--- a/plugins/archetypes/dispute-detail/main/verifier-diff-highlight-improved.js
+++ b/plugins/archetypes/dispute-detail/main/verifier-diff-highlight-improved.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'verifierDiffHighlightImproved',
     name: 'Verifier Diff Highlight (Improved)',
     description: 'Custom side-by-side diff viewer for Expected vs Your Answer in verifier output',
-    _version: '1.3',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -712,16 +712,37 @@ const plugin = {
             Logger.info('Copied Expected and QA answer to clipboard');
             if (button) {
                 if (button._vdhiCopyTimeoutId) clearTimeout(button._vdhiCopyTimeoutId);
+                if (button._vdhiCopyFailTimeoutId) clearTimeout(button._vdhiCopyFailTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
                 button._vdhiCopyTimeoutId = setTimeout(() => {
                     button.style.backgroundColor = '';
                     button.style.color = '';
                     button._vdhiCopyTimeoutId = null;
-                }, 3000);
+                }, 1000);
             }
         }).catch((err) => {
             Logger.error('Failed to copy to clipboard', err);
+            if (button) {
+                if (button._vdhiCopyTimeoutId) {
+                    clearTimeout(button._vdhiCopyTimeoutId);
+                    button._vdhiCopyTimeoutId = null;
+                }
+                if (button._vdhiCopyFailTimeoutId) clearTimeout(button._vdhiCopyFailTimeoutId);
+                const prevTransition = button.style.transition;
+                button.style.transition = 'none';
+                button.style.backgroundColor = 'rgb(239, 68, 68)';
+                button.style.color = '#ffffff';
+                void button.offsetHeight;
+                button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._vdhiCopyFailTimeoutId = setTimeout(() => {
+                    button.style.transition = prevTransition || '';
+                    button._vdhiCopyFailTimeoutId = null;
+                }, 500);
+            }
         });
     },
 

--- a/plugins/archetypes/disputes/dev/dispute-ids-enhancer.js
+++ b/plugins/archetypes/disputes/dev/dispute-ids-enhancer.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'disputeIdsEnhancer',
     name: 'Dispute IDs Enhancer',
     description: 'Surface Dispute and Task IDs at top of dispute cards.',
-    _version: '3.0',
+    _version: '3.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -318,11 +318,42 @@ const plugin = {
         btn.title = `Copy ${value}`;
         btn.addEventListener('click', () => {
             navigator.clipboard.writeText(value).then(() => {
+                if (btn._fleetDisputeCopyFailT) {
+                    clearTimeout(btn._fleetDisputeCopyFailT);
+                    btn._fleetDisputeCopyFailT = null;
+                }
+                btn.style.backgroundColor = '';
+                btn.style.color = '';
+                btn.style.transition = '';
+                btn.classList.remove('fleet-dispute-id-copied');
+                void btn.offsetHeight;
                 btn.classList.add('fleet-dispute-id-copied');
                 Logger.log(`Dispute IDs Enhancer: copied ${label} to clipboard`);
-                setTimeout(() => btn.classList.remove('fleet-dispute-id-copied'), 3000);
+                if (btn._fleetDisputeCopyOkT) clearTimeout(btn._fleetDisputeCopyOkT);
+                btn._fleetDisputeCopyOkT = setTimeout(() => {
+                    btn.classList.remove('fleet-dispute-id-copied');
+                    btn._fleetDisputeCopyOkT = null;
+                }, 1000);
             }).catch((err) => {
                 Logger.error('Dispute IDs Enhancer: failed to copy', err);
+                if (btn._fleetDisputeCopyOkT) {
+                    clearTimeout(btn._fleetDisputeCopyOkT);
+                    btn._fleetDisputeCopyOkT = null;
+                }
+                btn.classList.remove('fleet-dispute-id-copied');
+                if (btn._fleetDisputeCopyFailT) clearTimeout(btn._fleetDisputeCopyFailT);
+                const prevTransition = btn.style.transition;
+                btn.style.transition = 'none';
+                btn.style.backgroundColor = 'rgb(239, 68, 68)';
+                btn.style.color = '#ffffff';
+                void btn.offsetHeight;
+                btn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                btn.style.backgroundColor = '';
+                btn.style.color = '';
+                btn._fleetDisputeCopyFailT = setTimeout(() => {
+                    btn.style.transition = prevTransition || '';
+                    btn._fleetDisputeCopyFailT = null;
+                }, 500);
             });
         });
         return btn;

--- a/plugins/archetypes/qa-comp-use/deprecated/metadata-tag-qa-enhancements.js
+++ b/plugins/archetypes/qa-comp-use/deprecated/metadata-tag-qa-enhancements.js
@@ -10,8 +10,10 @@ const NORMAL_BORDER = '1px solid var(--border, #d4d4d4)';
 const NORMAL_BOX_SHADOW = '0 2px 8px rgba(0, 0, 0, 0.1)';
 const BORDER_SUGGEST_DESELECT = '2px solid rgb(239, 68, 68)';
 const BORDER_SUGGEST_SELECT = '2px solid rgb(34, 197, 94)';
-const COPY_CONFIRMATION_MS = 3000;
+const COPY_CONFIRMATION_MS = 1000;
+const COPY_FAILURE_PULSE_MS = 500;
 const COPY_CONFIRMATION_GREEN_BG = 'rgb(34, 197, 94)';
+const COPY_FAILURE_RED_BG = 'rgb(239, 68, 68)';
 
 const BUTTON_CLASS = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
 const COPY_BTN_DISABLED_CLASSES = ['opacity-50', 'cursor-not-allowed'];
@@ -22,7 +24,7 @@ const plugin = {
     id: 'metadataTagQAEnhancements',
     name: 'Metadata Tag QA Enhancements',
     description: 'Show/hide Writer Metadata section and/or QA suggested tag changes (toggle tags + copy as text feedback)',
-    _version: '2.5',
+    _version: '2.6',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -253,28 +255,45 @@ const plugin = {
 
         btn.addEventListener('click', () => {
             const text = this.buildCopyText(state);
-            const originalText = btn.textContent;
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log('Metadata Tag QA Enhancements: suggested changes copied to clipboard');
-                this.showCopyConfirmation(btn, originalText);
+                this.showCopyConfirmation(btn);
             }).catch((err) => {
                 Logger.error('Metadata Tag QA Enhancements: failed to copy suggested changes', err);
+                this.showCopyFailurePulse(btn);
             });
         });
         return btn;
     },
 
-    showCopyConfirmation(button, originalText) {
-        button.textContent = 'Copied!';
+    showCopyConfirmation(button) {
+        if (button._copyConfirmationTimeout) clearTimeout(button._copyConfirmationTimeout);
+        if (button._copyFailurePulseTimeout) clearTimeout(button._copyFailurePulseTimeout);
+        button.style.transition = '';
         button.style.backgroundColor = COPY_CONFIRMATION_GREEN_BG;
         button.style.color = 'white';
-        if (button._copyConfirmationTimeout) clearTimeout(button._copyConfirmationTimeout);
         button._copyConfirmationTimeout = setTimeout(() => {
-            button.textContent = originalText;
             button.style.backgroundColor = '';
             button.style.color = '';
             button._copyConfirmationTimeout = null;
         }, COPY_CONFIRMATION_MS);
+    },
+
+    showCopyFailurePulse(button) {
+        if (button._copyConfirmationTimeout) clearTimeout(button._copyConfirmationTimeout);
+        if (button._copyFailurePulseTimeout) clearTimeout(button._copyFailurePulseTimeout);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = COPY_FAILURE_RED_BG;
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = `background-color ${COPY_FAILURE_PULSE_MS}ms ease-out, color ${COPY_FAILURE_PULSE_MS}ms ease-out`;
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._copyFailurePulseTimeout = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._copyFailurePulseTimeout = null;
+        }, COPY_FAILURE_PULSE_MS);
     },
 
     buildTagToggles(innerContent, header, state) {
@@ -453,12 +472,12 @@ const plugin = {
         if (!hasAny) btn.classList.add(...COPY_BTN_DISABLED_CLASSES);
         btn.addEventListener('click', () => {
             const text = this.buildCopyText(state);
-            const originalText = btn.textContent;
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log('Metadata Tag QA Enhancements: suggested changes copied to clipboard (modal)');
-                this.showCopyConfirmation(btn, originalText);
+                this.showCopyConfirmation(btn);
             }).catch((err) => {
                 Logger.error('Metadata Tag QA Enhancements: failed to copy suggested changes', err);
+                this.showCopyFailurePulse(btn);
             });
         });
         wrapper.appendChild(btn);

--- a/plugins/archetypes/qa-comp-use/main/copy-prompt.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-prompt.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyPrompt',
     name: 'Copy Prompt',
     description: 'Add a copy button next to the Prompt label. Click copies the prompt text to the clipboard',
-    _version: '1.4',
+    _version: '1.5',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -110,17 +110,34 @@ const plugin = {
         button.appendChild(svg);
 
         let copyFeedbackTimeoutId = null;
+        const pulseFailure = () => {
+            if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            copyFeedbackTimeoutId = setTimeout(() => {
+                button.style.transition = prevT || '';
+                copyFeedbackTimeoutId = null;
+            }, 500);
+        };
         button.addEventListener('click', () => {
             const text = this.getPromptText(promptSection);
             if (!text) {
                 Logger.warn('Copy Prompt: No prompt text to copy');
+                pulseFailure();
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Copy Prompt: Copied ${text.length} chars to clipboard`);
+                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
-                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
                 copyFeedbackTimeoutId = setTimeout(() => {
                     button.style.backgroundColor = '';
                     button.style.color = '';
@@ -128,6 +145,7 @@ const plugin = {
                 }, 1000);
             }).catch((err) => {
                 Logger.error('Copy Prompt: Failed to copy to clipboard', err);
+                pulseFailure();
             });
         });
 

--- a/plugins/archetypes/qa-comp-use/main/copy-result-params.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-result-params.js
@@ -1,16 +1,18 @@
 // ============= copy-result-params.js =============
 // Adds a "Copy Result Params and Inputs" button under the Your Answer title/explanation.
-// Click copies each parameter label and value (e.g. "Total Paid: 0") to the clipboard with green 3s confirmation.
+// Click copies each parameter label and value (e.g. "Total Paid: 0") to the clipboard with green 1s confirmation (label unchanged).
 
 const COPY_RESULT_PARAMS_MARKER = 'data-fleet-copy-result-params';
-const CONFIRMATION_MS = 3000;
+const CONFIRMATION_MS = 1000;
+const FAILURE_PULSE_MS = 500;
 const GREEN_BG = 'rgb(34, 197, 94)';
+const FAILURE_RED_BG = 'rgb(239, 68, 68)';
 
 const plugin = {
     id: 'copyResultParams',
     name: 'Copy Result Params and Inputs',
     description: 'Add a button under Your Answer that copies all parameter labels and values to the clipboard',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -77,17 +79,45 @@ const plugin = {
         return lines.join('\n');
     },
 
-    showCopyConfirmation(button, originalText) {
-        button.textContent = 'Copied!';
+    clearCopyButtonFeedback(button) {
+        if (button._copyResultParamsTimeout) {
+            clearTimeout(button._copyResultParamsTimeout);
+            button._copyResultParamsTimeout = null;
+        }
+        if (button._copyResultParamsFailTimeout) {
+            clearTimeout(button._copyResultParamsFailTimeout);
+            button._copyResultParamsFailTimeout = null;
+        }
+        button.style.transition = '';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+    },
+
+    showCopySuccessFlash(button) {
+        this.clearCopyButtonFeedback(button);
         button.style.backgroundColor = GREEN_BG;
         button.style.color = 'white';
-        if (button._copyResultParamsTimeout) clearTimeout(button._copyResultParamsTimeout);
         button._copyResultParamsTimeout = setTimeout(() => {
-            button.textContent = originalText;
             button.style.backgroundColor = '';
             button.style.color = '';
             button._copyResultParamsTimeout = null;
         }, CONFIRMATION_MS);
+    },
+
+    showCopyFailurePulse(button) {
+        this.clearCopyButtonFeedback(button);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = FAILURE_RED_BG;
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = `background-color ${FAILURE_PULSE_MS}ms ease-out, color ${FAILURE_PULSE_MS}ms ease-out`;
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._copyResultParamsFailTimeout = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._copyResultParamsFailTimeout = null;
+        }, FAILURE_PULSE_MS);
     },
 
     createCopyButton(yourAnswerSection) {
@@ -103,18 +133,19 @@ const plugin = {
         button.textContent = 'Copy Result Params and Inputs';
         button.title = 'Copy parameter labels and values to clipboard';
 
-        const originalText = button.textContent;
         button.addEventListener('click', () => {
             const text = this.getResultParamsText(yourAnswerSection);
             if (!text) {
                 Logger.warn('Copy Result Params: No parameters to copy');
+                this.showCopyFailurePulse(button);
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Copy Result Params: Copied ${text.length} chars to clipboard`);
-                this.showCopyConfirmation(button, originalText);
+                this.showCopySuccessFlash(button);
             }).catch((err) => {
                 Logger.error('Copy Result Params: Failed to copy to clipboard', err);
+                this.showCopyFailurePulse(button);
             });
         });
 

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -1,46 +1,57 @@
 // ============= copy-verifier-output.js =============
-// Adds a copy button after "Stdout" in the Grading/verifier panel. Click copies the verifier output to the clipboard.
+// Adds a copy button in the Grading/verifier panel: after "Stdout" (classic output) or after "Score: #" (checklist verifier). Click copies formatted verifier text to the clipboard.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
 
 const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
-    description: 'Add a copy button after Stdout in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.2',
+    description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
+    _version: '1.3',
     enabledByDefault: true,
     phase: 'mutation',
 
     initialState: {
         buttonAdded: false,
-        stdoutRowMissingLogged: false
+        verifierTargetMissingLogged: false
     },
 
     onMutation(state, context) {
-        const stdoutRow = this.findStdoutRow();
-        if (!stdoutRow) {
-            if (!state.stdoutRowMissingLogged) {
-                Logger.debug('Copy Verifier Output: Stdout row not found');
-                state.stdoutRowMissingLogged = true;
+        const scoreRow = this.findScoreRow();
+        const stdoutRow = scoreRow ? null : this.findStdoutRow();
+        const anchorRow = scoreRow || stdoutRow;
+        if (!anchorRow) {
+            if (!state.verifierTargetMissingLogged) {
+                Logger.debug('Copy Verifier Output: Stdout/Score row not found');
+                state.verifierTargetMissingLogged = true;
             }
             return;
         }
-        state.stdoutRowMissingLogged = false;
+        state.verifierTargetMissingLogged = false;
 
-        if (stdoutRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
+        if (anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
             return;
         }
 
-        const container = stdoutRow.closest('div.text-xs.w-full');
-        if (!container) {
-            Logger.debug('Copy Verifier Output: Stdout container not found');
-            return;
+        let container;
+        if (scoreRow) {
+            container = scoreRow.closest('div.p-3');
+            if (!container) {
+                Logger.debug('Copy Verifier Output: Score card container not found');
+                return;
+            }
+        } else {
+            container = stdoutRow.closest('div.text-xs.w-full');
+            if (!container) {
+                Logger.debug('Copy Verifier Output: Stdout container not found');
+                return;
+            }
         }
 
         const button = this.createCopyButton(container);
-        stdoutRow.appendChild(button);
-        if (!stdoutRow.classList.contains('flex')) {
-            stdoutRow.classList.add('flex', 'items-center', 'gap-2');
+        anchorRow.appendChild(button);
+        if (!anchorRow.classList.contains('flex')) {
+            anchorRow.classList.add('flex', 'items-center', 'gap-2');
         }
         state.buttonAdded = true;
         Logger.log('Copy Verifier Output: Copy button added');
@@ -65,6 +76,22 @@ const plugin = {
         return null;
     },
 
+    findScoreRow() {
+        const gradingPanel = this.getGradingPanelRoot();
+        const roots = gradingPanel ? [gradingPanel, document] : [document];
+        for (const root of roots) {
+            const candidates = root.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+            for (const el of candidates) {
+                for (const s of el.querySelectorAll('span')) {
+                    if (s.textContent.trim() === 'Score:') {
+                        return el;
+                    }
+                }
+            }
+        }
+        return null;
+    },
+
     findStdoutRow() {
         const gradingPanel = this.getGradingPanelRoot();
         const roots = gradingPanel ? [gradingPanel, document] : [document];
@@ -79,9 +106,53 @@ const plugin = {
         return null;
     },
 
+    buildScoreVerifierMarkdown(container) {
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        if (!list) {
+            return null;
+        }
+        const rows = list.querySelectorAll(':scope > div.flex.items-start');
+        const successes = [];
+        const failures = [];
+        for (const row of rows) {
+            const svg = row.querySelector(':scope > svg');
+            if (!svg) continue;
+            const cls = svg.getAttribute('class') || '';
+            const span = row.querySelector(':scope > span');
+            const text = span ? span.textContent.trim() : '';
+            if (!text) continue;
+            if (cls.includes('text-emerald')) {
+                successes.push(text);
+            } else if (cls.includes('text-red')) {
+                failures.push(text);
+            }
+        }
+        if (successes.length === 0 && failures.length === 0) {
+            return null;
+        }
+        const lines = ['## Verifier'];
+        if (successes.length > 0) {
+            lines.push('#### Successes');
+            for (const t of successes) {
+                lines.push(`> ✅ ${t}`);
+            }
+        }
+        if (failures.length > 0) {
+            lines.push('#### Failures');
+            for (const t of failures) {
+                lines.push(`> ❌ ${t}`);
+            }
+        }
+        return lines.join('\n');
+    },
+
     getVerifierOutputText(container) {
+        const scoreMd = this.buildScoreVerifierMarkdown(container);
+        if (scoreMd) {
+            return scoreMd;
+        }
         const pre = container.querySelector('div.overflow-x-auto.bg-background.border.rounded pre');
-        if (pre) {
+        if (pre && pre.textContent.trim()) {
             return pre.textContent.trim();
         }
         return null;

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.5',
+    _version: '1.6',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -107,7 +107,7 @@ const plugin = {
     },
 
     buildScoreVerifierMarkdown(container) {
-        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0\\.5');
         if (!list) {
             return null;
         }

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.3',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -158,22 +158,104 @@ const plugin = {
         return null;
     },
 
+    ensureWindowCopyCapture() {
+        if (this._copyVerifierWindowCaptureInstalled) {
+            return;
+        }
+        this._copyVerifierWindowCaptureInstalled = true;
+        window.addEventListener(
+            'click',
+            (e) => {
+                const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
+                if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
+                    return;
+                }
+                const cont = btn._fleetCopyVerifierContainer;
+                if (!cont) {
+                    return;
+                }
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                e.preventDefault();
+                const text = this.getVerifierOutputText(cont);
+                if (!text) {
+                    Logger.warn('Copy Verifier Output: No verifier output to copy');
+                    return;
+                }
+                this.copyVerifierTextWithFeedback(btn, text);
+            },
+            true
+        );
+    },
+
+    copyVerifierTextWithFeedback(button, text) {
+        const showOk = () => {
+            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            button.style.backgroundColor = 'rgb(34, 197, 94)';
+            button.style.color = 'white';
+            if (button._fleetCopyFeedbackTimeoutId) clearTimeout(button._fleetCopyFeedbackTimeoutId);
+            button._fleetCopyFeedbackTimeoutId = setTimeout(() => {
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._fleetCopyFeedbackTimeoutId = null;
+            }, 1000);
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard
+                .writeText(text)
+                .then(showOk)
+                .catch((err) => {
+                    Logger.warn('Copy Verifier Output: Clipboard API failed, trying fallback', err);
+                    if (this.copyVerifierTextFallback(text)) {
+                        showOk();
+                    } else {
+                        Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
+                    }
+                });
+        } else if (this.copyVerifierTextFallback(text)) {
+            showOk();
+        } else {
+            Logger.error('Copy Verifier Output: Failed to copy to clipboard');
+        }
+    },
+
+    copyVerifierTextFallback(text) {
+        try {
+            const temp = document.createElement('textarea');
+            temp.value = text;
+            temp.style.position = 'fixed';
+            temp.style.top = '-1000px';
+            document.body.appendChild(temp);
+            temp.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(temp);
+            return ok;
+        } catch (e) {
+            return false;
+        }
+    },
+
     createCopyButton(container) {
+        this.ensureWindowCopyCapture();
+
         const button = document.createElement('button');
         button.setAttribute(COPY_BUTTON_MARKER, 'true');
         button.setAttribute('data-fleet-plugin', this.id);
         button.type = 'button';
-        button.className = 'inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        button.className =
+            'relative z-50 inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
         button.setAttribute('data-state', 'closed');
         button.title = 'Copy verifier output to clipboard';
         button.setAttribute('aria-label', 'Copy verifier output to clipboard');
+        button._fleetCopyVerifierContainer = container;
 
         const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         svg.setAttribute('width', '12');
         svg.setAttribute('height', '12');
         svg.setAttribute('viewBox', '0 0 24 24');
         svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-        svg.className = 'fill-current h-3 w-3 text-muted-foreground';
+        svg.className = 'fill-current h-3 w-3 text-muted-foreground pointer-events-none';
         const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path.setAttribute('fill', 'currentColor');
         path.setAttribute('fill-rule', 'evenodd');
@@ -181,28 +263,6 @@ const plugin = {
         path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
         svg.appendChild(path);
         button.appendChild(svg);
-
-        let copyFeedbackTimeoutId = null;
-        button.addEventListener('click', () => {
-            const text = this.getVerifierOutputText(container);
-            if (!text) {
-                Logger.warn('Copy Verifier Output: No verifier output to copy');
-                return;
-            }
-            navigator.clipboard.writeText(text).then(() => {
-                Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
-                button.style.backgroundColor = 'rgb(34, 197, 94)';
-                button.style.color = 'white';
-                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
-                copyFeedbackTimeoutId = setTimeout(() => {
-                    button.style.backgroundColor = '';
-                    button.style.color = '';
-                    copyFeedbackTimeoutId = null;
-                }, 1000);
-            }).catch((err) => {
-                Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
-            });
-        });
 
         return button;
     }

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.4',
+    _version: '1.5',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -163,29 +163,32 @@ const plugin = {
             return;
         }
         this._copyVerifierWindowCaptureInstalled = true;
-        window.addEventListener(
-            'click',
-            (e) => {
-                const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
-                if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
-                    return;
-                }
-                const cont = btn._fleetCopyVerifierContainer;
-                if (!cont) {
-                    return;
-                }
-                e.stopImmediatePropagation();
-                e.stopPropagation();
-                e.preventDefault();
-                const text = this.getVerifierOutputText(cont);
-                if (!text) {
-                    Logger.warn('Copy Verifier Output: No verifier output to copy');
-                    return;
-                }
-                this.copyVerifierTextWithFeedback(btn, text);
-            },
-            true
-        );
+        const win = typeof Context !== 'undefined' && Context.getPageWindow ? Context.getPageWindow() : window;
+        const handler = (e) => {
+            const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
+            if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
+                return;
+            }
+            const cont = btn._fleetCopyVerifierContainer;
+            if (!cont) {
+                return;
+            }
+            if (btn._fleetCopyHandledAt && Date.now() - btn._fleetCopyHandledAt < 150) {
+                return;
+            }
+            btn._fleetCopyHandledAt = Date.now();
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            e.preventDefault();
+            const text = this.getVerifierOutputText(cont);
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No verifier output to copy');
+                return;
+            }
+            this.copyVerifierTextWithFeedback(btn, text);
+        };
+        win.addEventListener('pointerdown', handler, true);
+        win.addEventListener('click', handler, true);
     },
 
     copyVerifierTextWithFeedback(button, text) {
@@ -263,6 +266,31 @@ const plugin = {
         path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
         svg.appendChild(path);
         button.appendChild(svg);
+
+        const doCopy = () => {
+            if (button._fleetCopyHandledAt && Date.now() - button._fleetCopyHandledAt < 200) {
+                return;
+            }
+            button._fleetCopyHandledAt = Date.now();
+            const text = this.getVerifierOutputText(container);
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No verifier output to copy');
+                return;
+            }
+            this.copyVerifierTextWithFeedback(button, text);
+        };
+
+        button.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
 
         return button;
     }

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.7',
+    _version: '1.8',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -184,6 +184,7 @@ const plugin = {
             const text = this.getVerifierOutputText(cont);
             if (!text) {
                 Logger.warn('Copy Verifier Output: No verifier output to copy');
+                this.showVerifierCopyFailurePulse(btn);
                 return;
             }
             this.copyVerifierTextWithFeedback(btn, text);
@@ -192,12 +193,42 @@ const plugin = {
         win.addEventListener('click', handler, true);
     },
 
+    clearVerifierCopyButtonFeedback(button) {
+        if (button._fleetCopyFeedbackTimeoutId) {
+            clearTimeout(button._fleetCopyFeedbackTimeoutId);
+            button._fleetCopyFeedbackTimeoutId = null;
+        }
+        if (button._fleetCopyFailureTimeoutId) {
+            clearTimeout(button._fleetCopyFailureTimeoutId);
+            button._fleetCopyFailureTimeoutId = null;
+        }
+        button.style.transition = '';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+    },
+
+    showVerifierCopyFailurePulse(button) {
+        this.clearVerifierCopyButtonFeedback(button);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = 'rgb(239, 68, 68)';
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._fleetCopyFailureTimeoutId = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._fleetCopyFailureTimeoutId = null;
+        }, 500);
+    },
+
     copyVerifierTextWithFeedback(button, text) {
         const showOk = () => {
             Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            this.clearVerifierCopyButtonFeedback(button);
             button.style.backgroundColor = 'rgb(34, 197, 94)';
             button.style.color = 'white';
-            if (button._fleetCopyFeedbackTimeoutId) clearTimeout(button._fleetCopyFeedbackTimeoutId);
             button._fleetCopyFeedbackTimeoutId = setTimeout(() => {
                 button.style.backgroundColor = '';
                 button.style.color = '';
@@ -215,12 +246,14 @@ const plugin = {
                         showOk();
                     } else {
                         Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
+                        this.showVerifierCopyFailurePulse(button);
                     }
                 });
         } else if (this.copyVerifierTextFallback(text)) {
             showOk();
         } else {
             Logger.error('Copy Verifier Output: Failed to copy to clipboard');
+            this.showVerifierCopyFailurePulse(button);
         }
     },
 
@@ -276,6 +309,7 @@ const plugin = {
             const text = this.getVerifierOutputText(container);
             if (!text) {
                 Logger.warn('Copy Verifier Output: No verifier output to copy');
+                this.showVerifierCopyFailurePulse(button);
                 return;
             }
             this.copyVerifierTextWithFeedback(button, text);

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.6',
+    _version: '1.7',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -138,6 +138,7 @@ const plugin = {
             }
         }
         if (failures.length > 0) {
+            lines.push('');
             lines.push('#### Failures');
             for (const t of failures) {
                 lines.push(`> ❌ ${t}`);

--- a/plugins/archetypes/qa-comp-use/main/guideline-buttons.js
+++ b/plugins/archetypes/qa-comp-use/main/guideline-buttons.js
@@ -24,7 +24,7 @@ const plugin = {
     id: 'guidelineButtons',
     name: 'Guideline Buttons',
     description: 'Add links to the guidelines on the page',
-    _version: '2.2',
+    _version: '2.3',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -40,6 +40,33 @@ const plugin = {
         wrapperAdded: false,
         missingLogged: false,
         styleInjected: false
+    },
+
+    flashClipboardSuccess(btn) {
+        if (btn._fleetClipboardFbT) clearTimeout(btn._fleetClipboardFbT);
+        btn.style.backgroundColor = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._fleetClipboardFbT = setTimeout(() => {
+            btn.style.backgroundColor = '';
+            btn.style.color = '';
+            btn._fleetClipboardFbT = null;
+        }, 1000);
+    },
+
+    flashClipboardFailure(btn) {
+        if (btn._fleetClipboardFbT) clearTimeout(btn._fleetClipboardFbT);
+        const prevT = btn.style.transition;
+        btn.style.transition = 'none';
+        btn.style.backgroundColor = 'rgb(239, 68, 68)';
+        btn.style.color = '#ffffff';
+        void btn.offsetHeight;
+        btn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+        btn.style.backgroundColor = '';
+        btn.style.color = '';
+        btn._fleetClipboardFbT = setTimeout(() => {
+            btn.style.transition = prevT || '';
+            btn._fleetClipboardFbT = null;
+        }, 500);
     },
 
     onMutation(state, context) {
@@ -179,8 +206,10 @@ body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4.rounded-full {
                     btn.addEventListener('click', () => {
                         navigator.clipboard.writeText(b.link).then(() => {
                             Logger.log(`Guideline Buttons: copied QA Guidelines link to clipboard`);
+                            this.flashClipboardSuccess(btn);
                         }).catch((err) => {
                             Logger.error('Guideline Buttons: failed to copy QA Guidelines link', err);
+                            this.flashClipboardFailure(btn);
                         });
                     });
                 } else {

--- a/plugins/archetypes/qa-comp-use/main/hide-grading-autoclick.js
+++ b/plugins/archetypes/qa-comp-use/main/hide-grading-autoclick.js
@@ -1,0 +1,70 @@
+
+// ============= hide-grading-autoclick.js =============
+// Clicks "Hide Grading" once when the control is present and clickable (not disabled).
+
+const plugin = {
+    id: 'hideGradingAutoclick',
+    name: 'Hide Grading Autoclick',
+    description:
+        'Automatically clicks the "Hide Grading" button once when it becomes available after load.',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        clicked: false,
+        missingLogged: false,
+        notClickableLogged: false
+    },
+
+    onMutation(state) {
+        if (state.clicked) return;
+
+        const button = this.findHideGradingButton();
+        if (!button) {
+            if (!state.missingLogged) {
+                Logger.debug('Hide Grading Autoclick: "Hide Grading" button not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        if (!this.isButtonClickable(button)) {
+            if (!state.notClickableLogged) {
+                Logger.debug('Hide Grading Autoclick: "Hide Grading" not clickable yet');
+                state.notClickableLogged = true;
+            }
+            return;
+        }
+
+        try {
+            button.click();
+            state.clicked = true;
+            Logger.log('✓ Hide Grading Autoclick: clicked "Hide Grading"');
+        } catch (error) {
+            Logger.error('Hide Grading Autoclick: failed to click "Hide Grading"', error);
+        }
+    },
+
+    findHideGradingButton() {
+        const options = { context: `${this.id}.findHideGradingButton` };
+        const buttons =
+            typeof Context !== 'undefined' && Context.dom
+                ? Context.dom.queryAll('button', options)
+                : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+            if (text === 'Hide Grading') {
+                return btn;
+            }
+        }
+
+        return null;
+    },
+
+    isButtonClickable(button) {
+        if (button.disabled) return false;
+        if (button.getAttribute('aria-disabled') === 'true') return false;
+        return true;
+    }
+};

--- a/plugins/archetypes/qa-comp-use/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/qa-comp-use/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '2.2',
+    _version: '2.3',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -417,24 +417,42 @@ const plugin = {
             button.dataset.diffCopyTarget = label;
 
             let copyFeedbackTimeoutId = null;
+            const pulseCopyFailure = () => {
+                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                const prevT = button.style.transition;
+                button.style.transition = 'none';
+                button.style.backgroundColor = 'rgb(239, 68, 68)';
+                button.style.color = 'white';
+                void button.offsetHeight;
+                button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                copyFeedbackTimeoutId = setTimeout(() => {
+                    button.style.transition = prevT || '';
+                    copyFeedbackTimeoutId = null;
+                }, 500);
+            };
             button.addEventListener('click', async () => {
                 const pre = column.querySelector(this.selectors.beforePre);
                 if (!pre) {
                     Logger.warn(`Missing ${label} pre element for copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 const fallbackText = pre.textContent || '';
                 const sourceText = pre.dataset.originalText || fallbackText;
                 if (!sourceText) {
                     Logger.warn(`No ${label} text found to copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 try {
                     await navigator.clipboard.writeText(sourceText);
                     Logger.info(`Copied ${label} prompt to clipboard (${sourceText.length} chars)`);
+                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                    button.style.transition = '';
                     button.style.backgroundColor = 'rgb(34, 197, 94)';
                     button.style.color = 'white';
-                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
                     copyFeedbackTimeoutId = setTimeout(() => {
                         button.style.backgroundColor = '';
                         button.style.color = '';
@@ -442,6 +460,7 @@ const plugin = {
                     }, 1000);
                 } catch (err) {
                     Logger.error(`Failed to copy ${label} prompt`, err);
+                    pulseCopyFailure();
                 }
             });
 

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -16,7 +16,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.8',
+    _version: '3.9',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -458,14 +458,17 @@ const plugin = {
         meridianGroup.appendChild(meridianOpen);
         wrapper.appendChild(meridianGroup);
 
-        const copyResultParamsBtn = document.createElement('button');
-        copyResultParamsBtn.type = 'button';
-        copyResultParamsBtn.className = buttonClass;
-        copyResultParamsBtn.setAttribute('data-fleet-plugin', this.id);
-        copyResultParamsBtn.textContent = 'Copy Result Params and Inputs';
-        copyResultParamsBtn.title = 'Copy parameter labels and values to clipboard';
-        copyResultParamsBtn.addEventListener('click', () => this.handleCopyResultParamsClick(copyResultParamsBtn));
-        wrapper.appendChild(copyResultParamsBtn);
+        // Only add Copy Result Params button if the target grid exists
+        if (this.hasResultParamsGrid()) {
+            const copyResultParamsBtn = document.createElement('button');
+            copyResultParamsBtn.type = 'button';
+            copyResultParamsBtn.className = buttonClass;
+            copyResultParamsBtn.setAttribute('data-fleet-plugin', this.id);
+            copyResultParamsBtn.textContent = 'Copy Result Params and Inputs';
+            copyResultParamsBtn.title = 'Copy parameter labels and values to clipboard';
+            copyResultParamsBtn.addEventListener('click', () => this.handleCopyResultParamsClick(copyResultParamsBtn));
+            wrapper.appendChild(copyResultParamsBtn);
+        }
 
         this.syncGuidelineCopyButtons(wrapper, meridianEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
@@ -475,6 +478,35 @@ const plugin = {
     syncGuidelineCopyButtons(wrapper, meridianEnabled) {
         const meridianGroup = wrapper.querySelector('[data-guideline-group="meridian"]');
         if (meridianGroup) meridianGroup.style.display = meridianEnabled ? '' : 'none';
+        
+        // Handle Copy Result Params button visibility based on whether the grid exists
+        const hasGrid = this.hasResultParamsGrid();
+        const copyResultParamsBtn = Array.from(wrapper.querySelectorAll('button[data-fleet-plugin="requestRevisions"]'))
+            .find(btn => btn.textContent === 'Copy Result Params and Inputs');
+        
+        if (hasGrid) {
+            // Grid exists - ensure button is visible or create it if missing
+            if (copyResultParamsBtn) {
+                copyResultParamsBtn.style.display = '';
+            } else {
+                // Button doesn't exist but grid does - create it
+                const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+                const newBtn = document.createElement('button');
+                newBtn.type = 'button';
+                newBtn.className = buttonClass;
+                newBtn.setAttribute('data-fleet-plugin', this.id);
+                newBtn.textContent = 'Copy Result Params and Inputs';
+                newBtn.title = 'Copy parameter labels and values to clipboard';
+                newBtn.addEventListener('click', () => this.handleCopyResultParamsClick(newBtn));
+                wrapper.appendChild(newBtn);
+                Logger.debug('Request Revisions: Copy Result Params button created dynamically');
+            }
+        } else {
+            // Grid doesn't exist - hide button if it exists
+            if (copyResultParamsBtn) {
+                copyResultParamsBtn.style.display = 'none';
+            }
+        }
     },
 
     copyGuidelineLink(button, originalText, url) {
@@ -498,6 +530,20 @@ const plugin = {
             }
         }
         return null;
+    },
+
+    hasResultParamsGrid() {
+        const section = this.findYourAnswerSection();
+        if (!section) return false;
+        const grid = section.querySelector('.grid.grid-cols-1.gap-4') || section.querySelector('.grid');
+        if (!grid) return false;
+        const rows = grid.querySelectorAll('.space-y-2');
+        for (const row of rows) {
+            const label = row.querySelector('label');
+            const input = row.querySelector('input, textarea');
+            if (label && input) return true;
+        }
+        return false;
     },
 
     getResultParamsTextFromPage() {
@@ -661,6 +707,7 @@ const plugin = {
             }
         }
         if (failures.length > 0) {
+            lines.push('');
             lines.push('#### Failures');
             for (const t of failures) {
                 lines.push(`> ❌ ${t}`);

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -10,7 +10,7 @@ const COPY_PROMPT_MARKER = 'data-fleet-revisions-copy-prompt';
 const COPY_PROMPT_SUBOPTION_ID = 'copy-prompt-button';
 const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
 const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
-const COPY_SUCCESS_FLASH_MS = 3000;
+const COPY_SUCCESS_FLASH_MS = 1000;
 const COPY_SUCCESS_GREEN_BG = 'rgb(34, 197, 94)';
 const COPY_FAILURE_PULSE_MS = 500;
 const COPY_FAILURE_RED_BG = 'rgb(239, 68, 68)';
@@ -22,7 +22,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.13',
+    _version: '4.0',
     enabledByDefault: true,
     phase: 'mutation',
     

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -10,8 +10,10 @@ const COPY_PROMPT_MARKER = 'data-fleet-revisions-copy-prompt';
 const COPY_PROMPT_SUBOPTION_ID = 'copy-prompt-button';
 const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
 const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
-const COPY_RESULT_PARAMS_CONFIRMATION_MS = 3000;
-const COPY_RESULT_PARAMS_GREEN_BG = 'rgb(34, 197, 94)';
+const COPY_SUCCESS_FLASH_MS = 3000;
+const COPY_SUCCESS_GREEN_BG = 'rgb(34, 197, 94)';
+const COPY_FAILURE_PULSE_MS = 500;
+const COPY_FAILURE_RED_BG = 'rgb(239, 68, 68)';
 
 const PROMPT_QUALITY_VALUES = ['Top 10%', 'Average', 'Bottom 10%'];
 const PROMPT_QUALITY_LISTENER_MARKER = 'data-fleet-prompt-quality-listener';
@@ -20,7 +22,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.12',
+    _version: '3.13',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -335,17 +337,18 @@ const plugin = {
     },
 
     handleCopyPromptClick(state, button) {
-        const originalText = 'Copy Prompt';
         const text = this.getPromptTextForClipboard(state);
         if (!text) {
             Logger.warn('Request Revisions: No prompt text to copy');
+            this.showCopyFailurePulse(button);
             return;
         }
         navigator.clipboard.writeText(text).then(() => {
             Logger.log(`Request Revisions: Copied prompt to clipboard (${text.length} chars)`);
-            this.showCopyResultParamsConfirmation(button, originalText);
+            this.showCopySuccessFlash(button);
         }).catch((err) => {
             Logger.error('Request Revisions: Failed to copy prompt', err);
+            this.showCopyFailurePulse(button);
         });
     },
 
@@ -361,17 +364,18 @@ const plugin = {
     },
 
     handleCopyVerifierOutputClick(state, button) {
-        const originalText = 'Copy Verifier Output';
         const text = this.getVerifierTextForClipboard(state);
         if (!text) {
             Logger.warn('Request Revisions: No verifier output to copy');
+            this.showCopyFailurePulse(button);
             return;
         }
         navigator.clipboard.writeText(text).then(() => {
             Logger.log(`Request Revisions: Copied verifier output to clipboard (${text.length} chars)`);
-            this.showCopyResultParamsConfirmation(button, originalText);
+            this.showCopySuccessFlash(button);
         }).catch((err) => {
             Logger.error('Request Revisions: Failed to copy verifier output', err);
+            this.showCopyFailurePulse(button);
         });
     },
 
@@ -421,31 +425,60 @@ const plugin = {
         return lines.join('\n');
     },
 
-    showCopyResultParamsConfirmation(button, originalText) {
-        button.textContent = 'Copied!';
-        button.style.backgroundColor = COPY_RESULT_PARAMS_GREEN_BG;
-        button.style.color = 'white';
-        if (button._copyResultParamsTimeout) clearTimeout(button._copyResultParamsTimeout);
-        button._copyResultParamsTimeout = setTimeout(() => {
-            button.textContent = originalText;
+    clearRequestRevisionsCopyButtonFeedback(button) {
+        if (button._copySuccessFlashTimeout) {
+            clearTimeout(button._copySuccessFlashTimeout);
+            button._copySuccessFlashTimeout = null;
+        }
+        if (button._copyFailurePulseTimeout) {
+            clearTimeout(button._copyFailurePulseTimeout);
+            button._copyFailurePulseTimeout = null;
+        }
+        button.style.transition = '';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+    },
+
+    showCopySuccessFlash(button) {
+        this.clearRequestRevisionsCopyButtonFeedback(button);
+        button.style.backgroundColor = COPY_SUCCESS_GREEN_BG;
+        button.style.color = '#ffffff';
+        button._copySuccessFlashTimeout = setTimeout(() => {
             button.style.backgroundColor = '';
             button.style.color = '';
-            button._copyResultParamsTimeout = null;
-        }, COPY_RESULT_PARAMS_CONFIRMATION_MS);
+            button._copySuccessFlashTimeout = null;
+        }, COPY_SUCCESS_FLASH_MS);
+    },
+
+    showCopyFailurePulse(button) {
+        this.clearRequestRevisionsCopyButtonFeedback(button);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = COPY_FAILURE_RED_BG;
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = `background-color ${COPY_FAILURE_PULSE_MS}ms ease-out, color ${COPY_FAILURE_PULSE_MS}ms ease-out`;
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._copyFailurePulseTimeout = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._copyFailurePulseTimeout = null;
+        }, COPY_FAILURE_PULSE_MS);
     },
 
     handleCopyResultParamsClick(button) {
-        const originalText = button.textContent;
         const text = this.getResultParamsTextFromPage();
         if (!text) {
             Logger.warn('Request Revisions: No result params to copy');
+            this.showCopyFailurePulse(button);
             return;
         }
         navigator.clipboard.writeText(text).then(() => {
             Logger.log(`Request Revisions: Copied result params to clipboard (${text.length} chars)`);
-            this.showCopyResultParamsConfirmation(button, originalText);
+            this.showCopySuccessFlash(button);
         }).catch((err) => {
             Logger.error('Request Revisions: Failed to copy result params', err);
+            this.showCopyFailurePulse(button);
         });
     },
 

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -16,7 +16,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.7',
+    _version: '3.8',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -630,7 +630,7 @@ const plugin = {
     },
 
     buildScoreVerifierMarkdown(container) {
-        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0\\.5');
         if (!list) {
             return null;
         }

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -16,7 +16,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.9',
+    _version: '3.10',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -36,8 +36,8 @@ const plugin = {
         },
         {
             id: 'copy-link-meridian-guidelines',
-            name: 'Copy Link to Meridian Guidelines',
-            description: 'Show a button under "Where are the issues?" that copies the Meridian Guidelines link to the clipboard',
+            name: 'Meridian Guidelines',
+            description: 'Show a button under "Where are the issues?" that opens Meridian Guidelines in a new tab',
             enabledByDefault: true
         }
     ],
@@ -140,7 +140,7 @@ const plugin = {
         // Get modal ID to track observers
         const modalId = requestRevisionsModal.id;
         
-        // Inject guideline copy-link buttons if enabled
+        // Inject guideline open buttons if enabled
         this.injectGuidelineCopyButtons(state, requestRevisionsModal);
         
         // Persist and restore Prompt Quality Rating selection within this page instance
@@ -435,28 +435,14 @@ const plugin = {
         wrapper.className = 'flex flex-wrap gap-2 mt-2';
 
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
-        const linkClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-2 pr-2 text-xs no-underline text-foreground';
 
-        const meridianGroup = document.createElement('span');
-        meridianGroup.className = 'inline-flex items-center gap-1';
-        meridianGroup.setAttribute('data-guideline-group', 'meridian');
-        const meridianBtn = document.createElement('button');
-        meridianBtn.type = 'button';
-        meridianBtn.className = buttonClass;
-        meridianBtn.setAttribute('data-fleet-plugin', this.id);
-        meridianBtn.setAttribute('data-guideline-copy', 'meridian');
-        meridianBtn.textContent = 'Copy Link to Meridian Guidelines';
-        meridianBtn.addEventListener('click', () => this.copyGuidelineLink(meridianBtn, 'Copy Link to Meridian Guidelines', GUIDELINE_LINKS.meridian));
-        meridianGroup.appendChild(meridianBtn);
-        const meridianOpen = document.createElement('a');
-        meridianOpen.href = GUIDELINE_LINKS.meridian;
-        meridianOpen.target = '_blank';
-        meridianOpen.rel = 'noopener noreferrer';
-        meridianOpen.className = linkClass;
-        meridianOpen.setAttribute('data-fleet-plugin', this.id);
-        meridianOpen.textContent = 'Open';
-        meridianGroup.appendChild(meridianOpen);
-        wrapper.appendChild(meridianGroup);
+        const meridianBtn = this.createGuidelineOpenButton(
+            buttonClass,
+            'meridian',
+            GUIDELINE_LINKS.meridian,
+            'Meridian Guidelines'
+        );
+        wrapper.appendChild(meridianBtn);
 
         // Only add Copy Result Params button if the target grid exists
         if (this.hasResultParamsGrid()) {
@@ -472,10 +458,38 @@ const plugin = {
 
         this.syncGuidelineCopyButtons(wrapper, meridianEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
-        Logger.log('Request Revisions: guideline copy-link buttons added');
+        Logger.log('Request Revisions: guideline buttons added');
+    },
+
+    createGuidelineOpenButton(buttonClass, groupId, url, shortTitle) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = buttonClass;
+        btn.setAttribute('data-fleet-plugin', this.id);
+        btn.setAttribute('data-guideline-group', groupId);
+        btn.textContent = shortTitle;
+        btn.title = `Open ${shortTitle} in a new tab`;
+        btn.addEventListener('click', () => {
+            window.open(url, '_blank');
+            Logger.log(`Request Revisions: opened ${shortTitle}`);
+        });
+        return btn;
+    },
+
+    migrateLegacyGuidelineOpenControl(wrapper, groupId, url, shortTitle, buttonClass) {
+        const el = wrapper.querySelector(`[data-guideline-group="${groupId}"]`);
+        if (!el) return;
+        const isLegacy = el.tagName === 'SPAN' && el.querySelector('a');
+        if (!isLegacy) return;
+        const btn = this.createGuidelineOpenButton(buttonClass, groupId, url, shortTitle);
+        el.replaceWith(btn);
+        Logger.debug(`Request Revisions: migrated legacy ${shortTitle} control to open-only button`);
     },
 
     syncGuidelineCopyButtons(wrapper, meridianEnabled) {
+        const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+        this.migrateLegacyGuidelineOpenControl(wrapper, 'meridian', GUIDELINE_LINKS.meridian, 'Meridian Guidelines', buttonClass);
+
         const meridianGroup = wrapper.querySelector('[data-guideline-group="meridian"]');
         if (meridianGroup) meridianGroup.style.display = meridianEnabled ? '' : 'none';
         
@@ -507,15 +521,6 @@ const plugin = {
                 copyResultParamsBtn.style.display = 'none';
             }
         }
-    },
-
-    copyGuidelineLink(button, originalText, url) {
-        navigator.clipboard.writeText(url).then(() => {
-            Logger.log(`Request Revisions: copied ${originalText} to clipboard`);
-            this.showCopyResultParamsConfirmation(button, originalText);
-        }).catch((err) => {
-            Logger.error('Request Revisions: failed to copy guideline link', err);
-        });
     },
 
     findYourAnswerSection(root = document) {

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -2,6 +2,7 @@
 // Improvements to the Request Revisions Workflow (qa-comp-use)
 
 const GUIDELINE_LINKS = {
+    qaGuidelines: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56',
     meridian: 'https://fleetai.notion.site/Project-Meridian-Guidelines-2eafe5dd3fba80079b86de5dce865477'
 };
 
@@ -22,7 +23,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.0',
+    _version: '4.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -38,6 +39,12 @@ const plugin = {
             id: COPY_VERIFIER_SUBOPTION_ID,
             name: 'Copy Verifier Output button',
             description: 'Show a button in Request Revisions that copies verifier output to the clipboard (paste into Grading manually if needed)',
+            enabledByDefault: true
+        },
+        {
+            id: 'copy-link-qa-guidelines',
+            name: 'QA Guidelines',
+            description: 'Show a button under "Where are the issues?" that opens QA Guidelines in a new tab',
             enabledByDefault: true
         },
         {
@@ -176,10 +183,11 @@ const plugin = {
         if (!buttonRow) return;
 
         let wrapper = modal.querySelector(`[${GUIDELINE_COPY_WRAPPER_MARKER}="true"]`);
+        const qaGuidelinesEnabled = Storage.getSubOptionEnabled(this.id, 'copy-link-qa-guidelines', true);
         const meridianEnabled = Storage.getSubOptionEnabled(this.id, 'copy-link-meridian-guidelines', true);
 
         if (wrapper) {
-            this.syncGuidelineCopyButtons(state, wrapper, meridianEnabled);
+            this.syncGuidelineCopyButtons(state, wrapper, meridianEnabled, qaGuidelinesEnabled);
             return;
         }
 
@@ -189,6 +197,14 @@ const plugin = {
         wrapper.className = 'flex flex-wrap gap-2 mt-2';
 
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+
+        const qaBtn = this.createGuidelineOpenButton(
+            buttonClass,
+            'qa-guidelines',
+            GUIDELINE_LINKS.qaGuidelines,
+            'QA Guidelines'
+        );
+        wrapper.appendChild(qaBtn);
 
         const meridianBtn = this.createGuidelineOpenButton(
             buttonClass,
@@ -210,7 +226,7 @@ const plugin = {
             wrapper.appendChild(copyResultParamsBtn);
         }
 
-        this.syncGuidelineCopyButtons(state, wrapper, meridianEnabled);
+        this.syncGuidelineCopyButtons(state, wrapper, meridianEnabled, qaGuidelinesEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
         Logger.log('Request Revisions: guideline buttons added');
     },
@@ -240,9 +256,27 @@ const plugin = {
         Logger.debug(`Request Revisions: migrated legacy ${shortTitle} control to open-only button`);
     },
 
-    syncGuidelineCopyButtons(state, wrapper, meridianEnabled) {
+    syncGuidelineCopyButtons(state, wrapper, meridianEnabled, qaGuidelinesEnabled) {
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+        this.migrateLegacyGuidelineOpenControl(wrapper, 'qa-guidelines', GUIDELINE_LINKS.qaGuidelines, 'QA Guidelines', buttonClass);
         this.migrateLegacyGuidelineOpenControl(wrapper, 'meridian', GUIDELINE_LINKS.meridian, 'Meridian Guidelines', buttonClass);
+
+        let qaGroup = wrapper.querySelector('[data-guideline-group="qa-guidelines"]');
+        if (!qaGroup) {
+            qaGroup = this.createGuidelineOpenButton(
+                buttonClass,
+                'qa-guidelines',
+                GUIDELINE_LINKS.qaGuidelines,
+                'QA Guidelines'
+            );
+            const meridianEl = wrapper.querySelector('[data-guideline-group="meridian"]');
+            if (meridianEl) {
+                wrapper.insertBefore(qaGroup, meridianEl);
+            } else {
+                wrapper.insertBefore(qaGroup, wrapper.firstChild);
+            }
+        }
+        qaGroup.style.display = qaGuidelinesEnabled ? '' : 'none';
 
         const meridianGroup = wrapper.querySelector('[data-guideline-group="meridian"]');
         if (meridianGroup) meridianGroup.style.display = meridianEnabled ? '' : 'none';

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -6,6 +6,8 @@ const GUIDELINE_LINKS = {
 };
 
 const GUIDELINE_COPY_WRAPPER_MARKER = 'data-fleet-guideline-copy-links';
+const COPY_PROMPT_MARKER = 'data-fleet-revisions-copy-prompt';
+const COPY_PROMPT_SUBOPTION_ID = 'copy-prompt-button';
 const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
 const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
 const COPY_RESULT_PARAMS_CONFIRMATION_MS = 3000;
@@ -18,16 +20,16 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.11',
+    _version: '3.12',
     enabledByDefault: true,
     phase: 'mutation',
     
     // ========== SUB-OPTIONS ==========
     subOptions: [
         {
-            id: 'auto-paste-prompt-to-task',
-            name: 'Auto-paste prompt to Task issue',
-            description: 'Saves the prompt text on page load and automatically pastes it into the Task issue box when Task is selected',
+            id: COPY_PROMPT_SUBOPTION_ID,
+            name: 'Copy Prompt button',
+            description: 'Show a button in Request Revisions that copies the task prompt to the clipboard (paste into Task feedback manually if needed)',
             enabledByDefault: true
         },
         {
@@ -46,9 +48,7 @@ const plugin = {
     
     initialState: {
         missingLogged: false,
-        promptText: null,
-        promptSaved: false,
-        taskObservers: new Map(), // Map of modalId -> { observer, taskButton }
+        promptText: null, // last-known prompt (optional cache for copy fallback)
         verifierOutput: null,
         verifierObserver: null,
         verifierElement: null,
@@ -58,17 +58,6 @@ const plugin = {
     },
     
     onMutation(state, context) {
-        // Ensure taskObservers Map exists
-        if (!state.taskObservers || !(state.taskObservers instanceof Map)) {
-            state.taskObservers = new Map();
-        }
-        
-        // Save prompt text if not already saved and the feature is enabled
-        const autoPastePromptEnabled = Storage.getSubOptionEnabled(this.id, 'auto-paste-prompt-to-task', true);
-        if (autoPastePromptEnabled && !state.promptSaved) {
-            this.savePromptText(state);
-        }
-        
         // Defer starting verifier watch until after initial load (avoids second body observer during mutation storm)
         if (state.verifierWatchEligibleAt === undefined) {
             state.verifierWatchEligibleAt = Date.now() + 1500;
@@ -80,8 +69,6 @@ const plugin = {
         });
         
         if (dialogs.length === 0) {
-            // Clean up observers when no dialogs are open
-            this.cleanupTaskObservers(state);
             return;
         }
         
@@ -132,96 +119,12 @@ const plugin = {
             this.watchVerifierOutput(state);
         }
         
-        // Get modal ID to track observers
-        const modalId = requestRevisionsModal.id;
-        
         // Inject guideline open buttons if enabled
         this.injectGuidelineCopyButtons(state, requestRevisionsModal);
         
         // Persist and restore Prompt Quality Rating selection within this page instance
         this.capturePromptQualityRating(state, requestRevisionsModal);
         this.restorePromptQualityRating(state, requestRevisionsModal);
-        
-        // Set up Task button observer if not already set up and feature is enabled
-        if (autoPastePromptEnabled && state.promptText && !state.taskObservers.has(modalId)) {
-            this.setupTaskButtonObserver(state, requestRevisionsModal, modalId);
-        }
-    },
-    
-    applyTextareaValue(textarea, value) {
-        // Try to find React's onChange handler and call it directly
-        // This is the proper way to work with React controlled components
-        const reactFiber = this.getReactFiber(textarea);
-        if (reactFiber) {
-            const props = reactFiber.memoizedProps || reactFiber.pendingProps;
-            if (props && props.onChange) {
-                // Create a synthetic event object that React expects
-                const syntheticEvent = {
-                    target: textarea,
-                    currentTarget: textarea,
-                    bubbles: true,
-                    cancelable: true,
-                    defaultPrevented: false,
-                    eventPhase: 2, // AT_TARGET
-                    isTrusted: false,
-                    nativeEvent: new Event('input', { bubbles: true }),
-                    preventDefault: () => {},
-                    stopPropagation: () => {},
-                    timeStamp: Date.now(),
-                    type: 'change'
-                };
-                
-                // Set the value using native setter first
-                const nativeValueSetter = Object.getOwnPropertyDescriptor(
-                    window.HTMLTextAreaElement.prototype,
-                    'value'
-                )?.set;
-                
-                if (nativeValueSetter) {
-                    nativeValueSetter.call(textarea, value);
-                } else {
-                    textarea.value = value;
-                }
-                
-                // Call React's onChange handler directly
-                try {
-                    props.onChange(syntheticEvent);
-                    Logger.debug('Called React onChange handler directly');
-                    return;
-                } catch (error) {
-                    Logger.warn('Error calling React onChange:', error);
-                    // Fall through to event dispatch method
-                }
-            }
-        }
-        
-        // Fallback: Use native value setter and dispatch events
-        // This should work for most React versions
-        const nativeValueSetter = Object.getOwnPropertyDescriptor(
-            window.HTMLTextAreaElement.prototype,
-            'value'
-        )?.set;
-        
-        if (nativeValueSetter) {
-            nativeValueSetter.call(textarea, value);
-        } else {
-            textarea.value = value;
-        }
-        
-        // Focus the textarea first (React sometimes needs this)
-        textarea.focus();
-        
-        // Dispatch input event (React listens to this)
-        const inputEvent = new Event('input', { bubbles: true, cancelable: true });
-        textarea.dispatchEvent(inputEvent);
-        
-        // Also dispatch change event
-        const changeEvent = new Event('change', { bubbles: true, cancelable: true });
-        textarea.dispatchEvent(changeEvent);
-        
-        // Blur and refocus to ensure React processes the change
-        textarea.blur();
-        textarea.focus();
     },
     
     // Same search logic as copy-prompt.js (qa-comp-use)
@@ -250,147 +153,6 @@ const plugin = {
             return preWrap.textContent.trim();
         }
         return null;
-    },
-
-    savePromptText(state) {
-        const promptSection = this.findPromptSection();
-        if (!promptSection) return;
-        const text = this.getPromptTextFromSection(promptSection);
-        if (text) {
-            state.promptText = text;
-            state.promptSaved = true;
-            Logger.log(`✓ Prompt text saved (${state.promptText.length} chars)`);
-        }
-    },
-    
-    setupTaskButtonObserver(state, modal, modalId) {
-        // Find the Task button
-        const taskButton = this.findTaskIssueButton(modal);
-        if (!taskButton) {
-            Logger.debug('Task button not found, will retry on next mutation');
-            return;
-        }
-        
-        // Check if already processed (button is already clicked)
-        if (this.isTaskButtonSelected(taskButton)) {
-            // Button is already selected, wait a bit for textarea to appear, then paste
-            setTimeout(() => {
-                this.handleTaskIssuePaste(state, modal, modalId);
-            }, 100);
-            // Mark as having observer (even though we won't set one up) to prevent retries
-            state.taskObservers.set(modalId, { observer: null, taskButton });
-            return;
-        }
-        
-        // Set up MutationObserver to watch for class changes on the Task button
-        const observer = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                    if (this.isTaskButtonSelected(taskButton)) {
-                        // Task button was clicked, wait a bit for textarea to appear, then paste
-                        setTimeout(() => {
-                            this.handleTaskIssuePaste(state, modal, modalId);
-                        }, 100);
-                        // Disconnect observer after detecting click
-                        observer.disconnect();
-                        state.taskObservers.delete(modalId);
-                        break;
-                    }
-                }
-            }
-        });
-        
-        // Observe class attribute changes on the Task button
-        observer.observe(taskButton, {
-            attributes: true,
-            attributeFilter: ['class']
-        });
-        
-        // Store observer info
-        state.taskObservers.set(modalId, { observer, taskButton });
-        
-        Logger.debug('Task button observer set up');
-    },
-    
-    isTaskButtonSelected(button) {
-        // Check if button has the selected state classes
-        return button.classList.contains('border-brand') || 
-               button.classList.contains('bg-brand') ||
-               button.querySelector('.border-brand') !== null ||
-               button.querySelector('.bg-brand') !== null;
-    },
-    
-    findTaskIssueButton(modal) {
-        // Find button with "Task" text in the issues section
-        const buttons = Context.dom.queryAll('button', {
-            root: modal,
-            context: `${this.id}.issueButtons`
-        });
-        
-        for (const button of buttons) {
-            const buttonText = button.textContent.trim();
-            if (buttonText === 'Task') {
-                // Check if any ancestor contains "Where are the issues"
-                // (it's in a sibling div, not the immediate parent)
-                let ancestor = button.parentElement;
-                while (ancestor && ancestor !== modal) {
-                    const ancestorText = ancestor.textContent || '';
-                    if (ancestorText.includes('Where are the issues')) {
-                        return button;
-                    }
-                    ancestor = ancestor.parentElement;
-                }
-            }
-        }
-        return null;
-    },
-    
-    handleTaskIssuePaste(state, modal, modalId) {
-        // Prefer id-based selector (#feedback-Task); fallback for older markup
-        let taskFeedbackTextarea = document.getElementById('feedback-Task');
-        if (!taskFeedbackTextarea || !modal.contains(taskFeedbackTextarea) || taskFeedbackTextarea.tagName !== 'TEXTAREA') {
-            taskFeedbackTextarea = Context.dom.query('textarea#feedback-Task', {
-                root: modal,
-                context: `${this.id}.taskFeedbackTextarea`
-            });
-        }
-
-        if (!taskFeedbackTextarea) {
-            Logger.debug('Task feedback textarea not found yet, waiting...');
-            return; // Textarea doesn't exist yet (might appear slightly after button click)
-        }
-        
-        // Check if textarea already has content (trim to handle whitespace-only content)
-        const currentValue = taskFeedbackTextarea.value ? taskFeedbackTextarea.value.trim() : '';
-        if (currentValue.length > 0) {
-            Logger.debug(`Task issue textarea already has content (${currentValue.length} chars), skipping paste`);
-            return; // Don't overwrite existing content
-        }
-        
-        if (!state.promptText) {
-            Logger.warn('Prompt text not available for pasting');
-            return;
-        }
-        
-        // Format the prompt text
-        const formattedPrompt = `---\n${state.promptText}\n---`;
-        
-        Logger.log(`Pasting prompt text to Task issue box (${formattedPrompt.length} chars)`);
-        
-        // Apply the value using the same method that worked for workflow copy
-        this.applyTextareaValue(taskFeedbackTextarea, formattedPrompt);
-        
-        Logger.log('✓ Prompt text pasted to Task issue box');
-    },
-    
-    cleanupTaskObservers(state) {
-        // Clean up all Task button observers
-        for (const [modalId, observerInfo] of state.taskObservers.entries()) {
-            if (observerInfo.observer) {
-                observerInfo.observer.disconnect();
-            }
-        }
-        state.taskObservers.clear();
     },
 
     findWhereAreTheIssuesButtonRow(modal) {
@@ -485,6 +247,8 @@ const plugin = {
 
         const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
         this.syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass);
+        const copyPromptEnabled = Storage.getSubOptionEnabled(this.id, COPY_PROMPT_SUBOPTION_ID, true);
+        this.syncCopyPromptButton(state, wrapper, copyPromptEnabled, buttonClass);
         
         // Handle Copy Result Params button visibility based on whether the grid exists
         const hasGrid = this.hasResultParamsGrid();
@@ -528,13 +292,61 @@ const plugin = {
                 btn.textContent = 'Copy Verifier Output';
                 btn.title = 'Copy verifier output to clipboard';
                 btn.addEventListener('click', () => this.handleCopyVerifierOutputClick(state, btn));
-                wrapper.appendChild(btn);
+                wrapper.insertBefore(btn, wrapper.firstChild);
                 Logger.debug('Request Revisions: Copy Verifier Output button added');
             }
             btn.style.display = '';
         } else if (btn) {
             btn.style.display = 'none';
         }
+    },
+
+    syncCopyPromptButton(state, wrapper, copyPromptEnabled, buttonClass) {
+        let btn = wrapper.querySelector(`[${COPY_PROMPT_MARKER}="true"]`);
+        if (copyPromptEnabled) {
+            if (!btn) {
+                btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = buttonClass;
+                btn.setAttribute('data-fleet-plugin', this.id);
+                btn.setAttribute(COPY_PROMPT_MARKER, 'true');
+                btn.textContent = 'Copy Prompt';
+                btn.title = 'Copy task prompt to clipboard';
+                btn.addEventListener('click', () => this.handleCopyPromptClick(state, btn));
+                wrapper.insertBefore(btn, wrapper.firstChild);
+                Logger.debug('Request Revisions: Copy Prompt button added');
+            }
+            btn.style.display = '';
+        } else if (btn) {
+            btn.style.display = 'none';
+        }
+    },
+
+    getPromptTextForClipboard(state) {
+        const section = this.findPromptSection();
+        if (section) {
+            const text = this.getPromptTextFromSection(section);
+            if (text) {
+                state.promptText = text;
+                return text;
+            }
+        }
+        return (state.promptText && String(state.promptText).trim()) || '';
+    },
+
+    handleCopyPromptClick(state, button) {
+        const originalText = 'Copy Prompt';
+        const text = this.getPromptTextForClipboard(state);
+        if (!text) {
+            Logger.warn('Request Revisions: No prompt text to copy');
+            return;
+        }
+        navigator.clipboard.writeText(text).then(() => {
+            Logger.log(`Request Revisions: Copied prompt to clipboard (${text.length} chars)`);
+            this.showCopyResultParamsConfirmation(button, originalText);
+        }).catch((err) => {
+            Logger.error('Request Revisions: Failed to copy prompt', err);
+        });
     },
 
     getVerifierTextForClipboard(state) {
@@ -844,30 +656,5 @@ const plugin = {
         });
 
         state.verifierChangeObserver = changeObserver;
-    },
-    
-    getReactFiber(element) {
-        // Try different React internal property names
-        // React 16+: __reactInternalInstance or __reactFiber
-        // React 17+: __reactFiber$<random>
-        // React 18+: __reactFiber$<random> or __reactInternalInstance$<random>
-        const keys = Object.keys(element);
-        for (const key of keys) {
-            if (key.startsWith('__reactFiber') || key.startsWith('__reactInternalInstance')) {
-                return element[key];
-            }
-        }
-        
-        // Also check for React 18's alternate fiber
-        for (const key of keys) {
-            if (key.includes('reactFiber') || key.includes('reactInternalInstance')) {
-                const fiber = element[key];
-                if (fiber && (fiber.memoizedProps || fiber.pendingProps)) {
-                    return fiber;
-                }
-            }
-        }
-        
-        return null;
     }
 };

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -16,7 +16,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.6',
+    _version: '3.7',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -607,6 +607,18 @@ const plugin = {
     },
 
     // Same search logic as copy-verifier-output.js (qa-comp-use)
+    findScoreRow() {
+        const candidates = document.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+        for (const el of candidates) {
+            for (const s of el.querySelectorAll('span')) {
+                if (s.textContent.trim() === 'Score:') {
+                    return el;
+                }
+            }
+        }
+        return null;
+    },
+
     findStdoutRow() {
         const candidates = document.querySelectorAll('div.text-sm.text-muted-foreground.font-medium.mb-1');
         for (const el of candidates) {
@@ -617,9 +629,68 @@ const plugin = {
         return null;
     },
 
+    buildScoreVerifierMarkdown(container) {
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        if (!list) {
+            return null;
+        }
+        const rows = list.querySelectorAll(':scope > div.flex.items-start');
+        const successes = [];
+        const failures = [];
+        for (const row of rows) {
+            const svg = row.querySelector(':scope > svg');
+            if (!svg) continue;
+            const cls = svg.getAttribute('class') || '';
+            const span = row.querySelector(':scope > span');
+            const text = span ? span.textContent.trim() : '';
+            if (!text) continue;
+            if (cls.includes('text-emerald')) {
+                successes.push(text);
+            } else if (cls.includes('text-red')) {
+                failures.push(text);
+            }
+        }
+        if (successes.length === 0 && failures.length === 0) {
+            return null;
+        }
+        const lines = ['## Verifier'];
+        if (successes.length > 0) {
+            lines.push('#### Successes');
+            for (const t of successes) {
+                lines.push(`> ✅ ${t}`);
+            }
+        }
+        if (failures.length > 0) {
+            lines.push('#### Failures');
+            for (const t of failures) {
+                lines.push(`> ❌ ${t}`);
+            }
+        }
+        return lines.join('\n');
+    },
+
     getVerifierPreFromContainer(container) {
         const pre = container.querySelector('div.overflow-x-auto.bg-background.border.rounded pre');
         return pre && pre.textContent.trim().length > 0 ? pre : null;
+    },
+
+    tryCaptureVerifierOutput() {
+        const scoreRow = this.findScoreRow();
+        if (scoreRow) {
+            const container = scoreRow.closest('div.p-3');
+            if (container) {
+                const md = this.buildScoreVerifierMarkdown(container);
+                if (md && md.length > 0) {
+                    return { kind: 'score', node: container };
+                }
+            }
+        }
+        const stdoutRow = this.findStdoutRow();
+        if (!stdoutRow) return null;
+        const container = stdoutRow.closest('div.text-xs.w-full');
+        if (!container) return null;
+        const pre = this.getVerifierPreFromContainer(container);
+        return pre ? { kind: 'pre', node: pre } : null;
     },
 
     watchVerifierOutput(state) {
@@ -627,28 +698,22 @@ const plugin = {
             return;
         }
 
-        const tryCaptureVerifier = () => {
-            const stdoutRow = this.findStdoutRow();
-            if (!stdoutRow) return null;
-            const container = stdoutRow.closest('div.text-xs.w-full');
-            if (!container) return null;
-            return this.getVerifierPreFromContainer(container);
-        };
+        const tryCaptureVerifier = () => this.tryCaptureVerifierOutput();
 
-        const pre = tryCaptureVerifier();
-        if (pre) {
+        const captured = tryCaptureVerifier();
+        if (captured) {
             Logger.log('✓ Verifier container detected');
-            this.saveVerifierOutput(state, pre);
+            this.saveVerifierOutput(state, captured);
             return;
         }
 
         const containerObserver = new MutationObserver(() => {
-            const pre = tryCaptureVerifier();
-            if (pre) {
+            const next = tryCaptureVerifier();
+            if (next) {
                 Logger.log('✓ Verifier container detected');
                 containerObserver.disconnect();
                 state.verifierObserver = null;
-                this.saveVerifierOutput(state, pre);
+                this.saveVerifierOutput(state, next);
             }
         });
 
@@ -658,35 +723,34 @@ const plugin = {
         });
         state.verifierObserver = containerObserver;
     },
-    
-    saveVerifierOutput(state, verifierPre) {
-        // Save the verifier output
-        state.verifierOutput = verifierPre.textContent.trim();
-        state.verifierElement = verifierPre;
-        
+
+    saveVerifierOutput(state, capture) {
+        const getText = () => {
+            if (capture.kind === 'pre') {
+                return capture.node.textContent.trim();
+            }
+            return this.buildScoreVerifierMarkdown(capture.node) || '';
+        };
+
+        state.verifierOutput = getText();
+        state.verifierElement = capture.node;
+
         Logger.log(`✓ Verifier output saved (${state.verifierOutput.length} chars)`);
-        
-        // Set up MutationObserver to watch for changes (in case of regrading)
-        const changeObserver = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-                if (mutation.type === 'childList' || mutation.type === 'characterData') {
-                    const newOutput = verifierPre.textContent.trim();
-                    if (newOutput !== state.verifierOutput && newOutput.length > 0) {
-                        state.verifierOutput = newOutput;
-                        Logger.log(`✓ Verifier output updated (${state.verifierOutput.length} chars)`);
-                    }
-                }
+
+        const changeObserver = new MutationObserver(() => {
+            const newOutput = getText();
+            if (newOutput !== state.verifierOutput && newOutput.length > 0) {
+                state.verifierOutput = newOutput;
+                Logger.log(`✓ Verifier output updated (${state.verifierOutput.length} chars)`);
             }
         });
-        
-        // Observe changes to the pre element and its children
-        changeObserver.observe(verifierPre, {
+
+        changeObserver.observe(capture.node, {
             childList: true,
             subtree: true,
             characterData: true
         });
-        
-        // Store the change observer (we'll keep the original observer reference for cleanup)
+
         state.verifierChangeObserver = changeObserver;
     },
     

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -6,6 +6,8 @@ const GUIDELINE_LINKS = {
 };
 
 const GUIDELINE_COPY_WRAPPER_MARKER = 'data-fleet-guideline-copy-links';
+const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
+const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
 const COPY_RESULT_PARAMS_CONFIRMATION_MS = 3000;
 const COPY_RESULT_PARAMS_GREEN_BG = 'rgb(34, 197, 94)';
 
@@ -16,7 +18,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '3.10',
+    _version: '3.11',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -29,9 +31,9 @@ const plugin = {
             enabledByDefault: true
         },
         {
-            id: 'auto-paste-verifier-to-grading',
-            name: 'Auto-paste verifier output to Grading issue',
-            description: 'Saves the verifier output when grading completes and automatically pastes it into the Grading issue box when Grading is selected',
+            id: COPY_VERIFIER_SUBOPTION_ID,
+            name: 'Copy Verifier Output button',
+            description: 'Show a button in Request Revisions that copies verifier output to the clipboard (paste into Grading manually if needed)',
             enabledByDefault: true
         },
         {
@@ -51,7 +53,6 @@ const plugin = {
         verifierObserver: null,
         verifierElement: null,
         verifierChangeObserver: null,
-        gradingObservers: new Map(), // Map of modalId -> { observer, gradingButton }
         verifierWatchEligibleAt: undefined, // defer body observer until this time (or once modal seen)
         promptQualityRating: null // persisted Prompt Quality Rating selection for this page instance
     },
@@ -60,11 +61,6 @@ const plugin = {
         // Ensure taskObservers Map exists
         if (!state.taskObservers || !(state.taskObservers instanceof Map)) {
             state.taskObservers = new Map();
-        }
-        
-        // Ensure gradingObservers Map exists
-        if (!state.gradingObservers || !(state.gradingObservers instanceof Map)) {
-            state.gradingObservers = new Map();
         }
         
         // Save prompt text if not already saved and the feature is enabled
@@ -86,7 +82,6 @@ const plugin = {
         if (dialogs.length === 0) {
             // Clean up observers when no dialogs are open
             this.cleanupTaskObservers(state);
-            this.cleanupGradingObservers(state);
             return;
         }
         
@@ -119,9 +114,9 @@ const plugin = {
                 Logger.debug('Request Revisions modal not found');
                 state.missingLogged = true;
             }
-            // Only run verifier watch when eligible (after delay or once modal has been seen)
-            const autoPasteVerifierEnabled = Storage.getSubOptionEnabled(this.id, 'auto-paste-verifier-to-grading', true);
-            if (autoPasteVerifierEnabled && state.verifierWatchEligibleAt !== undefined && Date.now() >= state.verifierWatchEligibleAt) {
+            // Capture verifier output for copy button when eligible (after delay or once modal has been seen)
+            const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
+            if (copyVerifierEnabled && state.verifierWatchEligibleAt !== undefined && Date.now() >= state.verifierWatchEligibleAt) {
                 this.watchVerifierOutput(state);
             }
             return;
@@ -131,9 +126,9 @@ const plugin = {
         state.missingLogged = false;
         state.verifierWatchEligibleAt = Math.min(state.verifierWatchEligibleAt ?? Infinity, Date.now());
         
-        // Watch for verifier output if feature is enabled (now eligible: modal seen or delay passed)
-        const autoPasteVerifierEnabled = Storage.getSubOptionEnabled(this.id, 'auto-paste-verifier-to-grading', true);
-        if (autoPasteVerifierEnabled && Date.now() >= state.verifierWatchEligibleAt) {
+        // Watch for verifier output when copy button is enabled (now eligible: modal seen or delay passed)
+        const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
+        if (copyVerifierEnabled && Date.now() >= state.verifierWatchEligibleAt) {
             this.watchVerifierOutput(state);
         }
         
@@ -150,11 +145,6 @@ const plugin = {
         // Set up Task button observer if not already set up and feature is enabled
         if (autoPastePromptEnabled && state.promptText && !state.taskObservers.has(modalId)) {
             this.setupTaskButtonObserver(state, requestRevisionsModal, modalId);
-        }
-        
-        // Set up Grading button observer if not already set up and feature is enabled
-        if (autoPasteVerifierEnabled && state.verifierOutput && !state.gradingObservers.has(modalId)) {
-            this.setupGradingButtonObserver(state, requestRevisionsModal, modalId);
         }
     },
     
@@ -425,7 +415,7 @@ const plugin = {
         const meridianEnabled = Storage.getSubOptionEnabled(this.id, 'copy-link-meridian-guidelines', true);
 
         if (wrapper) {
-            this.syncGuidelineCopyButtons(wrapper, meridianEnabled);
+            this.syncGuidelineCopyButtons(state, wrapper, meridianEnabled);
             return;
         }
 
@@ -456,7 +446,7 @@ const plugin = {
             wrapper.appendChild(copyResultParamsBtn);
         }
 
-        this.syncGuidelineCopyButtons(wrapper, meridianEnabled);
+        this.syncGuidelineCopyButtons(state, wrapper, meridianEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
         Logger.log('Request Revisions: guideline buttons added');
     },
@@ -486,12 +476,15 @@ const plugin = {
         Logger.debug(`Request Revisions: migrated legacy ${shortTitle} control to open-only button`);
     },
 
-    syncGuidelineCopyButtons(wrapper, meridianEnabled) {
+    syncGuidelineCopyButtons(state, wrapper, meridianEnabled) {
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
         this.migrateLegacyGuidelineOpenControl(wrapper, 'meridian', GUIDELINE_LINKS.meridian, 'Meridian Guidelines', buttonClass);
 
         const meridianGroup = wrapper.querySelector('[data-guideline-group="meridian"]');
         if (meridianGroup) meridianGroup.style.display = meridianEnabled ? '' : 'none';
+
+        const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
+        this.syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass);
         
         // Handle Copy Result Params button visibility based on whether the grid exists
         const hasGrid = this.hasResultParamsGrid();
@@ -521,6 +514,53 @@ const plugin = {
                 copyResultParamsBtn.style.display = 'none';
             }
         }
+    },
+
+    syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass) {
+        let btn = wrapper.querySelector(`[${COPY_VERIFIER_OUTPUT_MARKER}="true"]`);
+        if (copyVerifierEnabled) {
+            if (!btn) {
+                btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = buttonClass;
+                btn.setAttribute('data-fleet-plugin', this.id);
+                btn.setAttribute(COPY_VERIFIER_OUTPUT_MARKER, 'true');
+                btn.textContent = 'Copy Verifier Output';
+                btn.title = 'Copy verifier output to clipboard';
+                btn.addEventListener('click', () => this.handleCopyVerifierOutputClick(state, btn));
+                wrapper.appendChild(btn);
+                Logger.debug('Request Revisions: Copy Verifier Output button added');
+            }
+            btn.style.display = '';
+        } else if (btn) {
+            btn.style.display = 'none';
+        }
+    },
+
+    getVerifierTextForClipboard(state) {
+        const fresh = this.tryCaptureVerifierOutput();
+        if (fresh) {
+            const text = fresh.kind === 'pre'
+                ? fresh.node.textContent.trim()
+                : (this.buildScoreVerifierMarkdown(fresh.node) || '').trim();
+            if (text) return text;
+        }
+        return (state.verifierOutput && String(state.verifierOutput).trim()) || '';
+    },
+
+    handleCopyVerifierOutputClick(state, button) {
+        const originalText = 'Copy Verifier Output';
+        const text = this.getVerifierTextForClipboard(state);
+        if (!text) {
+            Logger.warn('Request Revisions: No verifier output to copy');
+            return;
+        }
+        navigator.clipboard.writeText(text).then(() => {
+            Logger.log(`Request Revisions: Copied verifier output to clipboard (${text.length} chars)`);
+            this.showCopyResultParamsConfirmation(button, originalText);
+        }).catch((err) => {
+            Logger.error('Request Revisions: Failed to copy verifier output', err);
+        });
     },
 
     findYourAnswerSection(root = document) {
@@ -804,134 +844,6 @@ const plugin = {
         });
 
         state.verifierChangeObserver = changeObserver;
-    },
-    
-    setupGradingButtonObserver(state, modal, modalId) {
-        // Find the Grading button
-        const gradingButton = this.findGradingIssueButton(modal);
-        if (!gradingButton) {
-            Logger.debug('Grading button not found, will retry on next mutation');
-            return;
-        }
-        
-        // Check if already processed (button is already clicked)
-        if (this.isGradingButtonSelected(gradingButton)) {
-            // Button is already selected, wait a bit for textarea to appear, then paste
-            setTimeout(() => {
-                this.handleGradingIssuePaste(state, modal, modalId);
-            }, 100);
-            // Mark as having observer (even though we won't set one up) to prevent retries
-            state.gradingObservers.set(modalId, { observer: null, gradingButton });
-            return;
-        }
-        
-        // Set up MutationObserver to watch for class changes on the Grading button
-        const observer = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                    if (this.isGradingButtonSelected(gradingButton)) {
-                        // Grading button was clicked, wait a bit for textarea to appear, then paste
-                        setTimeout(() => {
-                            this.handleGradingIssuePaste(state, modal, modalId);
-                        }, 100);
-                        // Disconnect observer after detecting click
-                        observer.disconnect();
-                        state.gradingObservers.delete(modalId);
-                        break;
-                    }
-                }
-            }
-        });
-        
-        // Observe class attribute changes on the Grading button
-        observer.observe(gradingButton, {
-            attributes: true,
-            attributeFilter: ['class']
-        });
-        
-        // Store observer info
-        state.gradingObservers.set(modalId, { observer, gradingButton });
-        
-        Logger.debug('Grading button observer set up');
-    },
-    
-    isGradingButtonSelected(button) {
-        // Check if button has the selected state classes
-        return button.classList.contains('border-brand') || 
-               button.classList.contains('bg-brand') ||
-               button.querySelector('.border-brand') !== null ||
-               button.querySelector('.bg-brand') !== null;
-    },
-    
-    findGradingIssueButton(modal) {
-        // Find button with "Grading" text in the issues section
-        const buttons = Context.dom.queryAll('button', {
-            root: modal,
-            context: `${this.id}.issueButtons`
-        });
-        
-        for (const button of buttons) {
-            const buttonText = button.textContent.trim();
-            if (buttonText === 'Grading') {
-                // Check if any ancestor contains "Where are the issues"
-                // (it's in a sibling div, not the immediate parent)
-                let ancestor = button.parentElement;
-                while (ancestor && ancestor !== modal) {
-                    const ancestorText = ancestor.textContent || '';
-                    if (ancestorText.includes('Where are the issues')) {
-                        return button;
-                    }
-                    ancestor = ancestor.parentElement;
-                }
-            }
-        }
-        return null;
-    },
-    
-    handleGradingIssuePaste(state, modal, modalId) {
-        // Prefer id-based selector (#feedback-Grading); fallback for older markup
-        let gradingFeedbackTextarea = document.getElementById('feedback-Grading');
-        if (!gradingFeedbackTextarea || !modal.contains(gradingFeedbackTextarea) || gradingFeedbackTextarea.tagName !== 'TEXTAREA') {
-            gradingFeedbackTextarea = Context.dom.query('textarea#feedback-Grading', {
-                root: modal,
-                context: `${this.id}.gradingFeedbackTextarea`
-            });
-        }
-
-        if (!gradingFeedbackTextarea) {
-            Logger.debug('Grading feedback textarea not found yet, waiting...');
-            return; // Textarea doesn't exist yet (might appear slightly after button click)
-        }
-        
-        // Check if textarea already has content (trim to handle whitespace-only content)
-        const currentValue = gradingFeedbackTextarea.value ? gradingFeedbackTextarea.value.trim() : '';
-        if (currentValue.length > 0) {
-            Logger.debug(`Grading issue textarea already has content (${currentValue.length} chars), skipping paste`);
-            return; // Don't overwrite existing content
-        }
-        
-        if (!state.verifierOutput) {
-            Logger.warn('Verifier output not available for pasting');
-            return;
-        }
-        
-        Logger.log(`Pasting verifier output to Grading issue box (${state.verifierOutput.length} chars)`);
-        
-        // Apply the value using the same method that worked for workflow copy
-        // No dashes around the verifier output (unlike prompt)
-        this.applyTextareaValue(gradingFeedbackTextarea, state.verifierOutput);
-        
-        Logger.log('✓ Verifier output pasted to Grading issue box');
-    },
-    
-    cleanupGradingObservers(state) {
-        // Clean up all Grading button observers
-        for (const [modalId, observerInfo] of state.gradingObservers.entries()) {
-            if (observerInfo.observer) {
-                observerInfo.observer.disconnect();
-            }
-        }
-        state.gradingObservers.clear();
     },
     
     getReactFiber(element) {

--- a/plugins/archetypes/qa-comp-use/main/verifier-diff-highlight-improved.js
+++ b/plugins/archetypes/qa-comp-use/main/verifier-diff-highlight-improved.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'verifierDiffHighlightImproved',
     name: 'Verifier Diff Highlight (Improved)',
     description: 'Custom side-by-side diff viewer for Expected vs Your Answer in verifier output',
-    _version: '1.3',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -711,16 +711,37 @@ const plugin = {
             Logger.info('Copied Expected and QA answer to clipboard');
             if (button) {
                 if (button._vdhiCopyTimeoutId) clearTimeout(button._vdhiCopyTimeoutId);
+                if (button._vdhiCopyFailTimeoutId) clearTimeout(button._vdhiCopyFailTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
                 button._vdhiCopyTimeoutId = setTimeout(() => {
                     button.style.backgroundColor = '';
                     button.style.color = '';
                     button._vdhiCopyTimeoutId = null;
-                }, 3000);
+                }, 1000);
             }
         }).catch((err) => {
             Logger.error('Failed to copy to clipboard', err);
+            if (button) {
+                if (button._vdhiCopyTimeoutId) {
+                    clearTimeout(button._vdhiCopyTimeoutId);
+                    button._vdhiCopyTimeoutId = null;
+                }
+                if (button._vdhiCopyFailTimeoutId) clearTimeout(button._vdhiCopyFailTimeoutId);
+                const prevTransition = button.style.transition;
+                button.style.transition = 'none';
+                button.style.backgroundColor = 'rgb(239, 68, 68)';
+                button.style.color = '#ffffff';
+                void button.offsetHeight;
+                button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._vdhiCopyFailTimeoutId = setTimeout(() => {
+                    button.style.transition = prevTransition || '';
+                    button._vdhiCopyFailTimeoutId = null;
+                }, 500);
+            }
         });
     },
 

--- a/plugins/archetypes/qa-tool-use/deprecated/json-editor-online.js
+++ b/plugins/archetypes/qa-tool-use/deprecated/json-editor-online.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'jsonEditorOnline',
     name: 'JSON Editor Online',
     description: 'Add button that opens JSON Editor Online in a new tab. Optionally show button on each tool result to copy output and open editor.',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -144,7 +144,8 @@ const plugin = {
                 if (isHandlingClick) return;
                 isHandlingClick = true;
                 try {
-                    await this.copyResultAndOpenEditor(card, resultArea);
+                    const copyOk = await this.copyResultAndOpenEditor(card, resultArea);
+                    this._flashJsonEditorToolButton(button, copyOk);
                 } finally {
                     // Reset after a short delay to allow async operations
                     setTimeout(() => { isHandlingClick = false; }, 1000);
@@ -247,57 +248,82 @@ const plugin = {
         return null;
     },
     
+    _flashJsonEditorToolButton(button, success) {
+        if (button._fleetJsonEdFlashT) clearTimeout(button._fleetJsonEdFlashT);
+        if (success) {
+            button.style.transition = '';
+            button.style.backgroundColor = 'rgb(34, 197, 94)';
+            button.style.color = '#ffffff';
+            button._fleetJsonEdFlashT = setTimeout(() => {
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._fleetJsonEdFlashT = null;
+            }, 1000);
+        } else {
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            button._fleetJsonEdFlashT = setTimeout(() => {
+                button.style.transition = prevT || '';
+                button._fleetJsonEdFlashT = null;
+            }, 500);
+        }
+    },
+
     async copyResultAndOpenEditor(card, resultArea) {
-        // Prevent double execution
         if (this._copying) {
-            return;
+            return false;
         }
         this._copying = true;
-        
+        let copyOk = false;
+
         try {
             Logger.log('Copying result and opening JSON Editor Online');
-            
-            // Find the result content div (the one with the actual JSON/text)
+
             const resultContent = this.findResultContent(resultArea);
             if (resultContent) {
-                try {
-                    // Extract text content
-                    const textContent = resultContent.textContent || resultContent.innerText || '';
-                    
-                    if (textContent.trim()) {
-                        // Use Clipboard API to copy directly
-                        await navigator.clipboard.writeText(textContent);
-                        Logger.log('✓ Copied result content to clipboard');
-                    } else {
-                        Logger.warn('Result content is empty');
-                    }
-                } catch (e) {
-                    Logger.warn('Failed to copy to clipboard:', e);
-                    // Fallback: try using document.execCommand for older browsers
+                const textContent = (resultContent.textContent || resultContent.innerText || '').trim();
+                if (textContent) {
                     try {
-                        const textArea = document.createElement('textarea');
-                        textArea.value = resultContent.textContent || resultContent.innerText || '';
-                        textArea.style.position = 'fixed';
-                        textArea.style.opacity = '0';
-                        document.body.appendChild(textArea);
-                        textArea.select();
-                        document.execCommand('copy');
-                        document.body.removeChild(textArea);
-                        Logger.log('✓ Copied result content to clipboard (fallback method)');
-                    } catch (fallbackError) {
-                        Logger.warn('Fallback copy method also failed:', fallbackError);
+                        await navigator.clipboard.writeText(textContent);
+                        copyOk = true;
+                        Logger.log('✓ Copied result content to clipboard');
+                    } catch (e) {
+                        Logger.warn('Failed to copy to clipboard:', e);
+                        try {
+                            const textArea = document.createElement('textarea');
+                            textArea.value = textContent;
+                            textArea.style.position = 'fixed';
+                            textArea.style.opacity = '0';
+                            document.body.appendChild(textArea);
+                            textArea.select();
+                            copyOk = document.execCommand('copy');
+                            document.body.removeChild(textArea);
+                            if (copyOk) {
+                                Logger.log('✓ Copied result content to clipboard (fallback method)');
+                            }
+                        } catch (fallbackError) {
+                            Logger.warn('Fallback copy method also failed:', fallbackError);
+                        }
                     }
+                } else {
+                    Logger.warn('Result content is empty');
                 }
             } else {
                 Logger.warn('Result content div not found, opening editor anyway');
             }
-            
-            // Open JSON Editor Online in new tab
+
             window.open('https://jsoneditoronline.org', '_blank');
             Logger.log('✓ Opened JSON Editor Online');
         } finally {
             this._copying = false;
         }
+        return copyOk;
     },
     
     findResultContent(resultArea) {

--- a/plugins/archetypes/qa-tool-use/main/copy-prompt.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-prompt.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyPrompt',
     name: 'Copy Prompt',
     description: 'Add a copy button next to the Prompt label. Click copies the prompt text to the clipboard',
-    _version: '1.5',
+    _version: '1.6',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -110,17 +110,34 @@ const plugin = {
         button.appendChild(svg);
 
         let copyFeedbackTimeoutId = null;
+        const pulseFailure = () => {
+            if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            copyFeedbackTimeoutId = setTimeout(() => {
+                button.style.transition = prevT || '';
+                copyFeedbackTimeoutId = null;
+            }, 500);
+        };
         button.addEventListener('click', () => {
             const text = this.getPromptText(promptSection);
             if (!text) {
                 Logger.warn('Copy Prompt: No prompt text to copy');
+                pulseFailure();
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Copy Prompt: Copied ${text.length} chars to clipboard`);
+                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
-                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
                 copyFeedbackTimeoutId = setTimeout(() => {
                     button.style.backgroundColor = '';
                     button.style.color = '';
@@ -128,6 +145,7 @@ const plugin = {
                 }, 1000);
             }).catch((err) => {
                 Logger.error('Copy Prompt: Failed to copy to clipboard', err);
+                pulseFailure();
             });
         });
 

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.7',
+    _version: '1.8',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -138,6 +138,7 @@ const plugin = {
             }
         }
         if (failures.length > 0) {
+            lines.push('');
             lines.push('#### Failures');
             for (const t of failures) {
                 lines.push(`> ❌ ${t}`);

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.8',
+    _version: '1.9',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -184,6 +184,7 @@ const plugin = {
             const text = this.getVerifierOutputText(cont);
             if (!text) {
                 Logger.warn('Copy Verifier Output: No verifier output to copy');
+                this.showVerifierCopyFailurePulse(btn);
                 return;
             }
             this.copyVerifierTextWithFeedback(btn, text);
@@ -192,12 +193,42 @@ const plugin = {
         win.addEventListener('click', handler, true);
     },
 
+    clearVerifierCopyButtonFeedback(button) {
+        if (button._fleetCopyFeedbackTimeoutId) {
+            clearTimeout(button._fleetCopyFeedbackTimeoutId);
+            button._fleetCopyFeedbackTimeoutId = null;
+        }
+        if (button._fleetCopyFailureTimeoutId) {
+            clearTimeout(button._fleetCopyFailureTimeoutId);
+            button._fleetCopyFailureTimeoutId = null;
+        }
+        button.style.transition = '';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+    },
+
+    showVerifierCopyFailurePulse(button) {
+        this.clearVerifierCopyButtonFeedback(button);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = 'rgb(239, 68, 68)';
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._fleetCopyFailureTimeoutId = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._fleetCopyFailureTimeoutId = null;
+        }, 500);
+    },
+
     copyVerifierTextWithFeedback(button, text) {
         const showOk = () => {
             Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            this.clearVerifierCopyButtonFeedback(button);
             button.style.backgroundColor = 'rgb(34, 197, 94)';
             button.style.color = 'white';
-            if (button._fleetCopyFeedbackTimeoutId) clearTimeout(button._fleetCopyFeedbackTimeoutId);
             button._fleetCopyFeedbackTimeoutId = setTimeout(() => {
                 button.style.backgroundColor = '';
                 button.style.color = '';
@@ -215,12 +246,14 @@ const plugin = {
                         showOk();
                     } else {
                         Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
+                        this.showVerifierCopyFailurePulse(button);
                     }
                 });
         } else if (this.copyVerifierTextFallback(text)) {
             showOk();
         } else {
             Logger.error('Copy Verifier Output: Failed to copy to clipboard');
+            this.showVerifierCopyFailurePulse(button);
         }
     },
 
@@ -276,6 +309,7 @@ const plugin = {
             const text = this.getVerifierOutputText(container);
             if (!text) {
                 Logger.warn('Copy Verifier Output: No verifier output to copy');
+                this.showVerifierCopyFailurePulse(button);
                 return;
             }
             this.copyVerifierTextWithFeedback(button, text);

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.5',
+    _version: '1.6',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -163,29 +163,32 @@ const plugin = {
             return;
         }
         this._copyVerifierWindowCaptureInstalled = true;
-        window.addEventListener(
-            'click',
-            (e) => {
-                const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
-                if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
-                    return;
-                }
-                const cont = btn._fleetCopyVerifierContainer;
-                if (!cont) {
-                    return;
-                }
-                e.stopImmediatePropagation();
-                e.stopPropagation();
-                e.preventDefault();
-                const text = this.getVerifierOutputText(cont);
-                if (!text) {
-                    Logger.warn('Copy Verifier Output: No verifier output to copy');
-                    return;
-                }
-                this.copyVerifierTextWithFeedback(btn, text);
-            },
-            true
-        );
+        const win = typeof Context !== 'undefined' && Context.getPageWindow ? Context.getPageWindow() : window;
+        const handler = (e) => {
+            const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
+            if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
+                return;
+            }
+            const cont = btn._fleetCopyVerifierContainer;
+            if (!cont) {
+                return;
+            }
+            if (btn._fleetCopyHandledAt && Date.now() - btn._fleetCopyHandledAt < 150) {
+                return;
+            }
+            btn._fleetCopyHandledAt = Date.now();
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            e.preventDefault();
+            const text = this.getVerifierOutputText(cont);
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No verifier output to copy');
+                return;
+            }
+            this.copyVerifierTextWithFeedback(btn, text);
+        };
+        win.addEventListener('pointerdown', handler, true);
+        win.addEventListener('click', handler, true);
     },
 
     copyVerifierTextWithFeedback(button, text) {
@@ -263,6 +266,31 @@ const plugin = {
         path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
         svg.appendChild(path);
         button.appendChild(svg);
+
+        const doCopy = () => {
+            if (button._fleetCopyHandledAt && Date.now() - button._fleetCopyHandledAt < 200) {
+                return;
+            }
+            button._fleetCopyHandledAt = Date.now();
+            const text = this.getVerifierOutputText(container);
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No verifier output to copy');
+                return;
+            }
+            this.copyVerifierTextWithFeedback(button, text);
+        };
+
+        button.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
 
         return button;
     }

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.6',
+    _version: '1.7',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -107,7 +107,7 @@ const plugin = {
     },
 
     buildScoreVerifierMarkdown(container) {
-        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0\\.5');
         if (!list) {
             return null;
         }

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -1,46 +1,57 @@
 // ============= copy-verifier-output.js =============
-// Adds a copy button after "Stdout" in the Verifier Output panel. Click copies the verifier output to the clipboard.
+// Adds a copy button in the Verifier Output panel: after "Stdout" (classic output) or after "Score: #" (checklist verifier). Click copies formatted verifier text to the clipboard.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
 
 const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
-    description: 'Add a copy button after to the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.3',
+    description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
     initialState: {
         buttonAdded: false,
-        stdoutRowMissingLogged: false
+        verifierTargetMissingLogged: false
     },
 
     onMutation(state, context) {
-        const stdoutRow = this.findStdoutRow();
-        if (!stdoutRow) {
-            if (!state.stdoutRowMissingLogged) {
-                Logger.debug('Copy Verifier Output: Stdout row not found');
-                state.stdoutRowMissingLogged = true;
+        const scoreRow = this.findScoreRow();
+        const stdoutRow = scoreRow ? null : this.findStdoutRow();
+        const anchorRow = scoreRow || stdoutRow;
+        if (!anchorRow) {
+            if (!state.verifierTargetMissingLogged) {
+                Logger.debug('Copy Verifier Output: Stdout/Score row not found');
+                state.verifierTargetMissingLogged = true;
             }
             return;
         }
-        state.stdoutRowMissingLogged = false;
+        state.verifierTargetMissingLogged = false;
 
-        if (stdoutRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
+        if (anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
             return;
         }
 
-        const container = stdoutRow.closest('div.text-xs.w-full');
-        if (!container) {
-            Logger.debug('Copy Verifier Output: Stdout container not found');
-            return;
+        let container;
+        if (scoreRow) {
+            container = scoreRow.closest('div.p-3');
+            if (!container) {
+                Logger.debug('Copy Verifier Output: Score card container not found');
+                return;
+            }
+        } else {
+            container = stdoutRow.closest('div.text-xs.w-full');
+            if (!container) {
+                Logger.debug('Copy Verifier Output: Stdout container not found');
+                return;
+            }
         }
 
         const button = this.createCopyButton(container);
-        stdoutRow.appendChild(button);
-        if (!stdoutRow.classList.contains('flex')) {
-            stdoutRow.classList.add('flex', 'items-center', 'gap-2');
+        anchorRow.appendChild(button);
+        if (!anchorRow.classList.contains('flex')) {
+            anchorRow.classList.add('flex', 'items-center', 'gap-2');
         }
         state.buttonAdded = true;
         Logger.log('Copy Verifier Output: Copy button added');
@@ -65,6 +76,22 @@ const plugin = {
         return null;
     },
 
+    findScoreRow() {
+        const gradingPanel = this.getGradingPanelRoot();
+        const roots = gradingPanel ? [gradingPanel, document] : [document];
+        for (const root of roots) {
+            const candidates = root.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+            for (const el of candidates) {
+                for (const s of el.querySelectorAll('span')) {
+                    if (s.textContent.trim() === 'Score:') {
+                        return el;
+                    }
+                }
+            }
+        }
+        return null;
+    },
+
     findStdoutRow() {
         const gradingPanel = this.getGradingPanelRoot();
         const roots = gradingPanel ? [gradingPanel, document] : [document];
@@ -79,9 +106,53 @@ const plugin = {
         return null;
     },
 
+    buildScoreVerifierMarkdown(container) {
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        if (!list) {
+            return null;
+        }
+        const rows = list.querySelectorAll(':scope > div.flex.items-start');
+        const successes = [];
+        const failures = [];
+        for (const row of rows) {
+            const svg = row.querySelector(':scope > svg');
+            if (!svg) continue;
+            const cls = svg.getAttribute('class') || '';
+            const span = row.querySelector(':scope > span');
+            const text = span ? span.textContent.trim() : '';
+            if (!text) continue;
+            if (cls.includes('text-emerald')) {
+                successes.push(text);
+            } else if (cls.includes('text-red')) {
+                failures.push(text);
+            }
+        }
+        if (successes.length === 0 && failures.length === 0) {
+            return null;
+        }
+        const lines = ['## Verifier'];
+        if (successes.length > 0) {
+            lines.push('#### Successes');
+            for (const t of successes) {
+                lines.push(`> ✅ ${t}`);
+            }
+        }
+        if (failures.length > 0) {
+            lines.push('#### Failures');
+            for (const t of failures) {
+                lines.push(`> ❌ ${t}`);
+            }
+        }
+        return lines.join('\n');
+    },
+
     getVerifierOutputText(container) {
+        const scoreMd = this.buildScoreVerifierMarkdown(container);
+        if (scoreMd) {
+            return scoreMd;
+        }
         const pre = container.querySelector('div.overflow-x-auto.bg-background.border.rounded pre');
-        if (pre) {
+        if (pre && pre.textContent.trim()) {
             return pre.textContent.trim();
         }
         return null;

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.4',
+    _version: '1.5',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -158,22 +158,104 @@ const plugin = {
         return null;
     },
 
+    ensureWindowCopyCapture() {
+        if (this._copyVerifierWindowCaptureInstalled) {
+            return;
+        }
+        this._copyVerifierWindowCaptureInstalled = true;
+        window.addEventListener(
+            'click',
+            (e) => {
+                const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
+                if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
+                    return;
+                }
+                const cont = btn._fleetCopyVerifierContainer;
+                if (!cont) {
+                    return;
+                }
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                e.preventDefault();
+                const text = this.getVerifierOutputText(cont);
+                if (!text) {
+                    Logger.warn('Copy Verifier Output: No verifier output to copy');
+                    return;
+                }
+                this.copyVerifierTextWithFeedback(btn, text);
+            },
+            true
+        );
+    },
+
+    copyVerifierTextWithFeedback(button, text) {
+        const showOk = () => {
+            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            button.style.backgroundColor = 'rgb(34, 197, 94)';
+            button.style.color = 'white';
+            if (button._fleetCopyFeedbackTimeoutId) clearTimeout(button._fleetCopyFeedbackTimeoutId);
+            button._fleetCopyFeedbackTimeoutId = setTimeout(() => {
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._fleetCopyFeedbackTimeoutId = null;
+            }, 1000);
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard
+                .writeText(text)
+                .then(showOk)
+                .catch((err) => {
+                    Logger.warn('Copy Verifier Output: Clipboard API failed, trying fallback', err);
+                    if (this.copyVerifierTextFallback(text)) {
+                        showOk();
+                    } else {
+                        Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
+                    }
+                });
+        } else if (this.copyVerifierTextFallback(text)) {
+            showOk();
+        } else {
+            Logger.error('Copy Verifier Output: Failed to copy to clipboard');
+        }
+    },
+
+    copyVerifierTextFallback(text) {
+        try {
+            const temp = document.createElement('textarea');
+            temp.value = text;
+            temp.style.position = 'fixed';
+            temp.style.top = '-1000px';
+            document.body.appendChild(temp);
+            temp.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(temp);
+            return ok;
+        } catch (e) {
+            return false;
+        }
+    },
+
     createCopyButton(container) {
+        this.ensureWindowCopyCapture();
+
         const button = document.createElement('button');
         button.setAttribute(COPY_BUTTON_MARKER, 'true');
         button.setAttribute('data-fleet-plugin', this.id);
         button.type = 'button';
-        button.className = 'inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        button.className =
+            'relative z-50 inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
         button.setAttribute('data-state', 'closed');
         button.title = 'Copy verifier output to clipboard';
         button.setAttribute('aria-label', 'Copy verifier output to clipboard');
+        button._fleetCopyVerifierContainer = container;
 
         const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
         svg.setAttribute('width', '12');
         svg.setAttribute('height', '12');
         svg.setAttribute('viewBox', '0 0 24 24');
         svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-        svg.className = 'fill-current h-3 w-3 text-muted-foreground';
+        svg.className = 'fill-current h-3 w-3 text-muted-foreground pointer-events-none';
         const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         path.setAttribute('fill', 'currentColor');
         path.setAttribute('fill-rule', 'evenodd');
@@ -181,28 +263,6 @@ const plugin = {
         path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
         svg.appendChild(path);
         button.appendChild(svg);
-
-        let copyFeedbackTimeoutId = null;
-        button.addEventListener('click', () => {
-            const text = this.getVerifierOutputText(container);
-            if (!text) {
-                Logger.warn('Copy Verifier Output: No verifier output to copy');
-                return;
-            }
-            navigator.clipboard.writeText(text).then(() => {
-                Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
-                button.style.backgroundColor = 'rgb(34, 197, 94)';
-                button.style.color = 'white';
-                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
-                copyFeedbackTimeoutId = setTimeout(() => {
-                    button.style.backgroundColor = '';
-                    button.style.color = '';
-                    copyFeedbackTimeoutId = null;
-                }, 1000);
-            }).catch((err) => {
-                Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
-            });
-        });
 
         return button;
     }

--- a/plugins/archetypes/qa-tool-use/main/hide-grading-autoclick.js
+++ b/plugins/archetypes/qa-tool-use/main/hide-grading-autoclick.js
@@ -1,0 +1,70 @@
+
+// ============= hide-grading-autoclick.js =============
+// Clicks "Hide Grading" once when the control is present and clickable (not disabled).
+
+const plugin = {
+    id: 'hideGradingAutoclick',
+    name: 'Hide Grading Autoclick',
+    description:
+        'Automatically clicks the "Hide Grading" button once when it becomes available after load.',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        clicked: false,
+        missingLogged: false,
+        notClickableLogged: false
+    },
+
+    onMutation(state) {
+        if (state.clicked) return;
+
+        const button = this.findHideGradingButton();
+        if (!button) {
+            if (!state.missingLogged) {
+                Logger.debug('Hide Grading Autoclick: "Hide Grading" button not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        if (!this.isButtonClickable(button)) {
+            if (!state.notClickableLogged) {
+                Logger.debug('Hide Grading Autoclick: "Hide Grading" not clickable yet');
+                state.notClickableLogged = true;
+            }
+            return;
+        }
+
+        try {
+            button.click();
+            state.clicked = true;
+            Logger.log('✓ Hide Grading Autoclick: clicked "Hide Grading"');
+        } catch (error) {
+            Logger.error('Hide Grading Autoclick: failed to click "Hide Grading"', error);
+        }
+    },
+
+    findHideGradingButton() {
+        const options = { context: `${this.id}.findHideGradingButton` };
+        const buttons =
+            typeof Context !== 'undefined' && Context.dom
+                ? Context.dom.queryAll('button', options)
+                : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+            if (text === 'Hide Grading') {
+                return btn;
+            }
+        }
+
+        return null;
+    },
+
+    isButtonClickable(button) {
+        if (button.disabled) return false;
+        if (button.getAttribute('aria-disabled') === 'true') return false;
+        return true;
+    }
+};

--- a/plugins/archetypes/qa-tool-use/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/qa-tool-use/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '2.2',
+    _version: '2.3',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -417,24 +417,42 @@ const plugin = {
             button.dataset.diffCopyTarget = label;
 
             let copyFeedbackTimeoutId = null;
+            const pulseCopyFailure = () => {
+                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                const prevT = button.style.transition;
+                button.style.transition = 'none';
+                button.style.backgroundColor = 'rgb(239, 68, 68)';
+                button.style.color = 'white';
+                void button.offsetHeight;
+                button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                copyFeedbackTimeoutId = setTimeout(() => {
+                    button.style.transition = prevT || '';
+                    copyFeedbackTimeoutId = null;
+                }, 500);
+            };
             button.addEventListener('click', async () => {
                 const pre = column.querySelector(this.selectors.beforePre);
                 if (!pre) {
                     Logger.warn(`Missing ${label} pre element for copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 const fallbackText = pre.textContent || '';
                 const sourceText = pre.dataset.originalText || fallbackText;
                 if (!sourceText) {
                     Logger.warn(`No ${label} text found to copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 try {
                     await navigator.clipboard.writeText(sourceText);
                     Logger.info(`Copied ${label} prompt to clipboard (${sourceText.length} chars)`);
+                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                    button.style.transition = '';
                     button.style.backgroundColor = 'rgb(34, 197, 94)';
                     button.style.color = 'white';
-                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
                     copyFeedbackTimeoutId = setTimeout(() => {
                         button.style.backgroundColor = '';
                         button.style.color = '';
@@ -442,6 +460,7 @@ const plugin = {
                     }, 1000);
                 } catch (err) {
                     Logger.error(`Failed to copy ${label} prompt`, err);
+                    pulseCopyFailure();
                 }
             });
 

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -2,6 +2,7 @@
 // Improvements to the Request Revisions Workflow
 
 const GUIDELINE_LINKS = {
+    qaGuidelines: 'https://fleetai.notion.site/QA-Guidelines-2f5fe5dd3fba80daa9b8f63a6ba85c56',
     kinesis: 'https://fleetai.notion.site/Project-Kinesis-Guidelines-2d6fe5dd3fba8023aa78e345939dac3d'
 };
 
@@ -22,7 +23,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '5.0',
+    _version: '5.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -38,6 +39,12 @@ const plugin = {
             id: COPY_VERIFIER_SUBOPTION_ID,
             name: 'Copy Verifier Output button',
             description: 'Show a button in Request Revisions that copies verifier output to the clipboard (paste into Grading manually if needed)',
+            enabledByDefault: true
+        },
+        {
+            id: 'copy-link-qa-guidelines',
+            name: 'QA Guidelines',
+            description: 'Show a button under "Where are the issues?" that opens QA Guidelines in a new tab',
             enabledByDefault: true
         },
         {
@@ -169,10 +176,11 @@ const plugin = {
         if (!buttonRow) return;
 
         let wrapper = modal.querySelector(`[${GUIDELINE_COPY_WRAPPER_MARKER}="true"]`);
+        const qaGuidelinesEnabled = Storage.getSubOptionEnabled(this.id, 'copy-link-qa-guidelines', true);
         const kinesisEnabled = Storage.getSubOptionEnabled(this.id, 'copy-link-kinesis-guidelines', true);
 
         if (wrapper) {
-            this.syncGuidelineCopyButtons(state, wrapper, kinesisEnabled);
+            this.syncGuidelineCopyButtons(state, wrapper, kinesisEnabled, qaGuidelinesEnabled);
             return;
         }
 
@@ -183,6 +191,14 @@ const plugin = {
 
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
 
+        const qaBtn = this.createGuidelineOpenButton(
+            buttonClass,
+            'qa-guidelines',
+            GUIDELINE_LINKS.qaGuidelines,
+            'QA Guidelines'
+        );
+        wrapper.appendChild(qaBtn);
+
         const kinesisBtn = this.createGuidelineOpenButton(
             buttonClass,
             'kinesis',
@@ -191,7 +207,7 @@ const plugin = {
         );
         wrapper.appendChild(kinesisBtn);
 
-        this.syncGuidelineCopyButtons(state, wrapper, kinesisEnabled);
+        this.syncGuidelineCopyButtons(state, wrapper, kinesisEnabled, qaGuidelinesEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
         Logger.log('Request Revisions: guideline buttons added');
     },
@@ -221,9 +237,27 @@ const plugin = {
         Logger.debug(`Request Revisions: migrated legacy ${shortTitle} control to open-only button`);
     },
 
-    syncGuidelineCopyButtons(state, wrapper, kinesisEnabled) {
+    syncGuidelineCopyButtons(state, wrapper, kinesisEnabled, qaGuidelinesEnabled) {
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+        this.migrateLegacyGuidelineOpenControl(wrapper, 'qa-guidelines', GUIDELINE_LINKS.qaGuidelines, 'QA Guidelines', buttonClass);
         this.migrateLegacyGuidelineOpenControl(wrapper, 'kinesis', GUIDELINE_LINKS.kinesis, 'Kinesis Guidelines', buttonClass);
+
+        let qaGroup = wrapper.querySelector('[data-guideline-group="qa-guidelines"]');
+        if (!qaGroup) {
+            qaGroup = this.createGuidelineOpenButton(
+                buttonClass,
+                'qa-guidelines',
+                GUIDELINE_LINKS.qaGuidelines,
+                'QA Guidelines'
+            );
+            const kinesisEl = wrapper.querySelector('[data-guideline-group="kinesis"]');
+            if (kinesisEl) {
+                wrapper.insertBefore(qaGroup, kinesisEl);
+            } else {
+                wrapper.insertBefore(qaGroup, wrapper.firstChild);
+            }
+        }
+        qaGroup.style.display = qaGuidelinesEnabled ? '' : 'none';
 
         const kinesisGroup = wrapper.querySelector('[data-guideline-group="kinesis"]');
         if (kinesisGroup) kinesisGroup.style.display = kinesisEnabled ? '' : 'none';

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -14,7 +14,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.6',
+    _version: '4.7',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -591,6 +591,7 @@ const plugin = {
             }
         }
         if (failures.length > 0) {
+            lines.push('');
             lines.push('#### Failures');
             for (const t of failures) {
                 lines.push(`> ❌ ${t}`);

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -14,7 +14,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.5',
+    _version: '4.6',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -560,7 +560,7 @@ const plugin = {
     },
 
     buildScoreVerifierMarkdown(container) {
-        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0\\.5');
         if (!list) {
             return null;
         }

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -6,6 +6,10 @@ const GUIDELINE_LINKS = {
 };
 
 const GUIDELINE_COPY_WRAPPER_MARKER = 'data-fleet-guideline-copy-links';
+const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
+const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
+const COPY_BUTTON_CONFIRMATION_MS = 3000;
+const COPY_BUTTON_CONFIRMATION_GREEN_BG = 'rgb(34, 197, 94)';
 
 const PROMPT_QUALITY_VALUES = ['Top 10%', 'Average', 'Bottom 10%'];
 const PROMPT_QUALITY_LISTENER_MARKER = 'data-fleet-prompt-quality-listener';
@@ -14,7 +18,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.8',
+    _version: '4.9',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -27,9 +31,9 @@ const plugin = {
             enabledByDefault: true
         },
         {
-            id: 'auto-paste-verifier-to-grading',
-            name: 'Auto-paste verifier output to Grading issue',
-            description: 'Saves the verifier output when grading completes and automatically pastes it into the Grading issue box when Grading is selected',
+            id: COPY_VERIFIER_SUBOPTION_ID,
+            name: 'Copy Verifier Output button',
+            description: 'Show a button in Request Revisions that copies verifier output to the clipboard (paste into Grading manually if needed)',
             enabledByDefault: true
         },
         {
@@ -49,7 +53,6 @@ const plugin = {
         verifierObserver: null,
         verifierElement: null,
         verifierChangeObserver: null,
-        gradingObservers: new Map(), // Map of modalId -> { observer, gradingButton }
         verifierWatchEligibleAt: undefined, // defer body observer until this time (or once modal seen)
         promptQualityRating: null // persisted Prompt Quality Rating selection for this page instance
     },
@@ -58,11 +61,6 @@ const plugin = {
         // Ensure taskObservers Map exists
         if (!state.taskObservers || !(state.taskObservers instanceof Map)) {
             state.taskObservers = new Map();
-        }
-        
-        // Ensure gradingObservers Map exists
-        if (!state.gradingObservers || !(state.gradingObservers instanceof Map)) {
-            state.gradingObservers = new Map();
         }
         
         // Save prompt text if not already saved and the feature is enabled
@@ -84,7 +82,6 @@ const plugin = {
         if (dialogs.length === 0) {
             // Clean up observers when no dialogs are open
             this.cleanupTaskObservers(state);
-            this.cleanupGradingObservers(state);
             return;
         }
         
@@ -117,9 +114,9 @@ const plugin = {
                 Logger.debug('Request Revisions modal not found');
                 state.missingLogged = true;
             }
-            // Only run verifier watch when eligible (after delay or once modal has been seen)
-            const autoPasteVerifierEnabled = Storage.getSubOptionEnabled(this.id, 'auto-paste-verifier-to-grading', true);
-            if (autoPasteVerifierEnabled && state.verifierWatchEligibleAt !== undefined && Date.now() >= state.verifierWatchEligibleAt) {
+            // Capture verifier output for copy button when eligible (after delay or once modal has been seen)
+            const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
+            if (copyVerifierEnabled && state.verifierWatchEligibleAt !== undefined && Date.now() >= state.verifierWatchEligibleAt) {
                 this.watchVerifierOutput(state);
             }
             return;
@@ -129,9 +126,9 @@ const plugin = {
         state.missingLogged = false;
         state.verifierWatchEligibleAt = Math.min(state.verifierWatchEligibleAt ?? Infinity, Date.now());
         
-        // Watch for verifier output if feature is enabled (now eligible: modal seen or delay passed)
-        const autoPasteVerifierEnabled = Storage.getSubOptionEnabled(this.id, 'auto-paste-verifier-to-grading', true);
-        if (autoPasteVerifierEnabled && Date.now() >= state.verifierWatchEligibleAt) {
+        // Watch for verifier output when copy button is enabled (now eligible: modal seen or delay passed)
+        const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
+        if (copyVerifierEnabled && Date.now() >= state.verifierWatchEligibleAt) {
             this.watchVerifierOutput(state);
         }
         
@@ -148,11 +145,6 @@ const plugin = {
         // Set up Task button observer if not already set up and feature is enabled
         if (autoPastePromptEnabled && state.promptText && !state.taskObservers.has(modalId)) {
             this.setupTaskButtonObserver(state, requestRevisionsModal, modalId);
-        }
-        
-        // Set up Grading button observer if not already set up and feature is enabled
-        if (autoPasteVerifierEnabled && state.verifierOutput && !state.gradingObservers.has(modalId)) {
-            this.setupGradingButtonObserver(state, requestRevisionsModal, modalId);
         }
     },
     
@@ -421,7 +413,7 @@ const plugin = {
         const kinesisEnabled = Storage.getSubOptionEnabled(this.id, 'copy-link-kinesis-guidelines', true);
 
         if (wrapper) {
-            this.syncGuidelineCopyButtons(wrapper, kinesisEnabled);
+            this.syncGuidelineCopyButtons(state, wrapper, kinesisEnabled);
             return;
         }
 
@@ -440,7 +432,7 @@ const plugin = {
         );
         wrapper.appendChild(kinesisBtn);
 
-        this.syncGuidelineCopyButtons(wrapper, kinesisEnabled);
+        this.syncGuidelineCopyButtons(state, wrapper, kinesisEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
         Logger.log('Request Revisions: guideline buttons added');
     },
@@ -470,12 +462,75 @@ const plugin = {
         Logger.debug(`Request Revisions: migrated legacy ${shortTitle} control to open-only button`);
     },
 
-    syncGuidelineCopyButtons(wrapper, kinesisEnabled) {
+    syncGuidelineCopyButtons(state, wrapper, kinesisEnabled) {
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
         this.migrateLegacyGuidelineOpenControl(wrapper, 'kinesis', GUIDELINE_LINKS.kinesis, 'Kinesis Guidelines', buttonClass);
 
         const kinesisGroup = wrapper.querySelector('[data-guideline-group="kinesis"]');
         if (kinesisGroup) kinesisGroup.style.display = kinesisEnabled ? '' : 'none';
+
+        const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
+        this.syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass);
+    },
+
+    syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass) {
+        let btn = wrapper.querySelector(`[${COPY_VERIFIER_OUTPUT_MARKER}="true"]`);
+        if (copyVerifierEnabled) {
+            if (!btn) {
+                btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = buttonClass;
+                btn.setAttribute('data-fleet-plugin', this.id);
+                btn.setAttribute(COPY_VERIFIER_OUTPUT_MARKER, 'true');
+                btn.textContent = 'Copy Verifier Output';
+                btn.title = 'Copy verifier output to clipboard';
+                btn.addEventListener('click', () => this.handleCopyVerifierOutputClick(state, btn));
+                wrapper.appendChild(btn);
+                Logger.debug('Request Revisions: Copy Verifier Output button added');
+            }
+            btn.style.display = '';
+        } else if (btn) {
+            btn.style.display = 'none';
+        }
+    },
+
+    getVerifierTextForClipboard(state) {
+        const fresh = this.tryCaptureVerifierOutput();
+        if (fresh) {
+            const text = fresh.kind === 'pre'
+                ? fresh.node.textContent.trim()
+                : (this.buildScoreVerifierMarkdown(fresh.node) || '').trim();
+            if (text) return text;
+        }
+        return (state.verifierOutput && String(state.verifierOutput).trim()) || '';
+    },
+
+    showCopyButtonConfirmation(button, originalText) {
+        button.textContent = 'Copied!';
+        button.style.backgroundColor = COPY_BUTTON_CONFIRMATION_GREEN_BG;
+        button.style.color = 'white';
+        if (button._fleetCopyConfirmTimeout) clearTimeout(button._fleetCopyConfirmTimeout);
+        button._fleetCopyConfirmTimeout = setTimeout(() => {
+            button.textContent = originalText;
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            button._fleetCopyConfirmTimeout = null;
+        }, COPY_BUTTON_CONFIRMATION_MS);
+    },
+
+    handleCopyVerifierOutputClick(state, button) {
+        const originalText = 'Copy Verifier Output';
+        const text = this.getVerifierTextForClipboard(state);
+        if (!text) {
+            Logger.warn('Request Revisions: No verifier output to copy');
+            return;
+        }
+        navigator.clipboard.writeText(text).then(() => {
+            Logger.log(`Request Revisions: Copied verifier output to clipboard (${text.length} chars)`);
+            this.showCopyButtonConfirmation(button, originalText);
+        }).catch((err) => {
+            Logger.error('Request Revisions: Failed to copy verifier output', err);
+        });
     },
 
     findPromptQualityRatingSection(modal) {
@@ -685,134 +740,6 @@ const plugin = {
         });
 
         state.verifierChangeObserver = changeObserver;
-    },
-    
-    setupGradingButtonObserver(state, modal, modalId) {
-        // Find the Grading button
-        const gradingButton = this.findGradingIssueButton(modal);
-        if (!gradingButton) {
-            Logger.debug('Grading button not found, will retry on next mutation');
-            return;
-        }
-        
-        // Check if already processed (button is already clicked)
-        if (this.isGradingButtonSelected(gradingButton)) {
-            // Button is already selected, wait a bit for textarea to appear, then paste
-            setTimeout(() => {
-                this.handleGradingIssuePaste(state, modal, modalId);
-            }, 100);
-            // Mark as having observer (even though we won't set one up) to prevent retries
-            state.gradingObservers.set(modalId, { observer: null, gradingButton });
-            return;
-        }
-        
-        // Set up MutationObserver to watch for class changes on the Grading button
-        const observer = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                    if (this.isGradingButtonSelected(gradingButton)) {
-                        // Grading button was clicked, wait a bit for textarea to appear, then paste
-                        setTimeout(() => {
-                            this.handleGradingIssuePaste(state, modal, modalId);
-                        }, 100);
-                        // Disconnect observer after detecting click
-                        observer.disconnect();
-                        state.gradingObservers.delete(modalId);
-                        break;
-                    }
-                }
-            }
-        });
-        
-        // Observe class attribute changes on the Grading button
-        observer.observe(gradingButton, {
-            attributes: true,
-            attributeFilter: ['class']
-        });
-        
-        // Store observer info
-        state.gradingObservers.set(modalId, { observer, gradingButton });
-        
-        Logger.debug('Grading button observer set up');
-    },
-    
-    isGradingButtonSelected(button) {
-        // Check if button has the selected state classes
-        return button.classList.contains('border-brand') || 
-               button.classList.contains('bg-brand') ||
-               button.querySelector('.border-brand') !== null ||
-               button.querySelector('.bg-brand') !== null;
-    },
-    
-    findGradingIssueButton(modal) {
-        // Find button with "Grading" text in the issues section
-        const buttons = Context.dom.queryAll('button', {
-            root: modal,
-            context: `${this.id}.issueButtons`
-        });
-        
-        for (const button of buttons) {
-            const buttonText = button.textContent.trim();
-            if (buttonText === 'Grading') {
-                // Check if any ancestor contains "Where are the issues"
-                // (it's in a sibling div, not the immediate parent)
-                let ancestor = button.parentElement;
-                while (ancestor && ancestor !== modal) {
-                    const ancestorText = ancestor.textContent || '';
-                    if (ancestorText.includes('Where are the issues')) {
-                        return button;
-                    }
-                    ancestor = ancestor.parentElement;
-                }
-            }
-        }
-        return null;
-    },
-    
-    handleGradingIssuePaste(state, modal, modalId) {
-        // Prefer id-based selector (#feedback-Grading); fallback for older markup
-        let gradingFeedbackTextarea = document.getElementById('feedback-Grading');
-        if (!gradingFeedbackTextarea || !modal.contains(gradingFeedbackTextarea) || gradingFeedbackTextarea.tagName !== 'TEXTAREA') {
-            gradingFeedbackTextarea = Context.dom.query('textarea#feedback-Grading', {
-                root: modal,
-                context: `${this.id}.gradingFeedbackTextarea`
-            });
-        }
-        
-        if (!gradingFeedbackTextarea) {
-            Logger.debug('Grading feedback textarea not found yet, waiting...');
-            return; // Textarea doesn't exist yet (might appear slightly after button click)
-        }
-        
-        // Check if textarea already has content (trim to handle whitespace-only content)
-        const currentValue = gradingFeedbackTextarea.value ? gradingFeedbackTextarea.value.trim() : '';
-        if (currentValue.length > 0) {
-            Logger.debug(`Grading issue textarea already has content (${currentValue.length} chars), skipping paste`);
-            return; // Don't overwrite existing content
-        }
-        
-        if (!state.verifierOutput) {
-            Logger.warn('Verifier output not available for pasting');
-            return;
-        }
-        
-        Logger.log(`Pasting verifier output to Grading issue box (${state.verifierOutput.length} chars)`);
-        
-        // Apply the value using the same method that worked for workflow copy
-        // No dashes around the verifier output (unlike prompt)
-        this.applyTextareaValue(gradingFeedbackTextarea, state.verifierOutput);
-        
-        Logger.log('✓ Verifier output pasted to Grading issue box');
-    },
-    
-    cleanupGradingObservers(state) {
-        // Clean up all Grading button observers
-        for (const [modalId, observerInfo] of state.gradingObservers.entries()) {
-            if (observerInfo.observer) {
-                observerInfo.observer.disconnect();
-            }
-        }
-        state.gradingObservers.clear();
     },
     
     getReactFiber(element) {

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -6,6 +6,8 @@ const GUIDELINE_LINKS = {
 };
 
 const GUIDELINE_COPY_WRAPPER_MARKER = 'data-fleet-guideline-copy-links';
+const COPY_PROMPT_MARKER = 'data-fleet-revisions-copy-prompt';
+const COPY_PROMPT_SUBOPTION_ID = 'copy-prompt-button';
 const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
 const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
 const COPY_BUTTON_CONFIRMATION_MS = 3000;
@@ -18,16 +20,16 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.9',
+    _version: '4.10',
     enabledByDefault: true,
     phase: 'mutation',
     
     // ========== SUB-OPTIONS ==========
     subOptions: [
         {
-            id: 'auto-paste-prompt-to-task',
-            name: 'Auto-paste prompt to Task issue',
-            description: 'Saves the prompt text on page load and automatically pastes it into the Task issue box when Task is selected',
+            id: COPY_PROMPT_SUBOPTION_ID,
+            name: 'Copy Prompt button',
+            description: 'Show a button in Request Revisions that copies the task prompt to the clipboard (paste into Task feedback manually if needed)',
             enabledByDefault: true
         },
         {
@@ -47,8 +49,6 @@ const plugin = {
     initialState: {
         missingLogged: false,
         promptText: null,
-        promptSaved: false,
-        taskObservers: new Map(), // Map of modalId -> { observer, taskButton }
         verifierOutput: null,
         verifierObserver: null,
         verifierElement: null,
@@ -58,17 +58,6 @@ const plugin = {
     },
     
     onMutation(state, context) {
-        // Ensure taskObservers Map exists
-        if (!state.taskObservers || !(state.taskObservers instanceof Map)) {
-            state.taskObservers = new Map();
-        }
-        
-        // Save prompt text if not already saved and the feature is enabled
-        const autoPastePromptEnabled = Storage.getSubOptionEnabled(this.id, 'auto-paste-prompt-to-task', true);
-        if (autoPastePromptEnabled && !state.promptSaved) {
-            this.savePromptText(state);
-        }
-        
         // Defer starting verifier watch until after initial load (avoids second body observer during mutation storm)
         if (state.verifierWatchEligibleAt === undefined) {
             state.verifierWatchEligibleAt = Date.now() + 1500;
@@ -80,8 +69,6 @@ const plugin = {
         });
         
         if (dialogs.length === 0) {
-            // Clean up observers when no dialogs are open
-            this.cleanupTaskObservers(state);
             return;
         }
         
@@ -132,109 +119,12 @@ const plugin = {
             this.watchVerifierOutput(state);
         }
         
-        // Get modal ID to track observers
-        const modalId = requestRevisionsModal.id;
-        
         // Inject guideline open buttons if enabled
         this.injectGuidelineCopyButtons(state, requestRevisionsModal);
         
         // Persist and restore Prompt Quality Rating selection within this page instance
         this.capturePromptQualityRating(state, requestRevisionsModal);
         this.restorePromptQualityRating(state, requestRevisionsModal);
-        
-        // Set up Task button observer if not already set up and feature is enabled
-        if (autoPastePromptEnabled && state.promptText && !state.taskObservers.has(modalId)) {
-            this.setupTaskButtonObserver(state, requestRevisionsModal, modalId);
-        }
-    },
-    
-    applyTextareaValue(textarea, value) {
-        // Try to find React's onChange handler and call it directly
-        // This is the proper way to work with React controlled components
-        const reactFiber = this.getReactFiber(textarea);
-        if (reactFiber) {
-            const props = reactFiber.memoizedProps || reactFiber.pendingProps;
-            if (props && props.onChange) {
-                // Create a synthetic event object that React expects
-                const syntheticEvent = {
-                    target: textarea,
-                    currentTarget: textarea,
-                    bubbles: true,
-                    cancelable: true,
-                    defaultPrevented: false,
-                    eventPhase: 2, // AT_TARGET
-                    isTrusted: false,
-                    nativeEvent: new Event('input', { bubbles: true }),
-                    preventDefault: () => {},
-                    stopPropagation: () => {},
-                    timeStamp: Date.now(),
-                    type: 'change'
-                };
-                
-                // Set the value using native setter first
-                const nativeValueSetter = Object.getOwnPropertyDescriptor(
-                    window.HTMLTextAreaElement.prototype,
-                    'value'
-                )?.set;
-                
-                if (nativeValueSetter) {
-                    nativeValueSetter.call(textarea, value);
-                } else {
-                    textarea.value = value;
-                }
-                
-                // Call React's onChange handler directly
-                try {
-                    props.onChange(syntheticEvent);
-                    Logger.debug('Called React onChange handler directly');
-                    return;
-                } catch (error) {
-                    Logger.warn('Error calling React onChange:', error);
-                    // Fall through to event dispatch method
-                }
-            }
-        }
-        
-        // Fallback: Use native value setter and dispatch events
-        // This should work for most React versions
-        const nativeValueSetter = Object.getOwnPropertyDescriptor(
-            window.HTMLTextAreaElement.prototype,
-            'value'
-        )?.set;
-        
-        if (nativeValueSetter) {
-            nativeValueSetter.call(textarea, value);
-        } else {
-            textarea.value = value;
-        }
-        
-        // Focus the textarea first (React sometimes needs this)
-        textarea.focus();
-        
-        // Dispatch input event (React listens to this)
-        const inputEvent = new Event('input', { bubbles: true, cancelable: true });
-        textarea.dispatchEvent(inputEvent);
-        
-        // Also dispatch change event
-        const changeEvent = new Event('change', { bubbles: true, cancelable: true });
-        textarea.dispatchEvent(changeEvent);
-        
-        // Blur and refocus to ensure React processes the change
-        textarea.blur();
-        textarea.focus();
-    },
-    
-    savePromptText(state) {
-        // Find the task panel: prefer structure (panel containing Prompt section). Radix panel IDs like :re: are unstable.
-        const panel = this.findTaskPanel();
-        if (!panel) return;
-
-        const promptElement = panel.querySelector('.text-sm.whitespace-pre-wrap');
-        if (promptElement) {
-            state.promptText = promptElement.textContent.trim();
-            state.promptSaved = true;
-            Logger.log(`✓ Prompt text saved (${state.promptText.length} chars)`);
-        }
     },
 
     findTaskPanel() {
@@ -256,139 +146,6 @@ const plugin = {
         }
         // Strategy 3: fallback to Radix ID (unstable across sessions)
         return document.querySelector('[id=":re:"]') || document.querySelector('[data-panel-id=":re:"]');
-    },
-    
-    setupTaskButtonObserver(state, modal, modalId) {
-        // Find the Task button
-        const taskButton = this.findTaskIssueButton(modal);
-        if (!taskButton) {
-            Logger.debug('Task button not found, will retry on next mutation');
-            return;
-        }
-        
-        // Check if already processed (button is already clicked)
-        if (this.isTaskButtonSelected(taskButton)) {
-            // Button is already selected, wait a bit for textarea to appear, then paste
-            setTimeout(() => {
-                this.handleTaskIssuePaste(state, modal, modalId);
-            }, 100);
-            // Mark as having observer (even though we won't set one up) to prevent retries
-            state.taskObservers.set(modalId, { observer: null, taskButton });
-            return;
-        }
-        
-        // Set up MutationObserver to watch for class changes on the Task button
-        const observer = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-                if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                    if (this.isTaskButtonSelected(taskButton)) {
-                        // Task button was clicked, wait a bit for textarea to appear, then paste
-                        setTimeout(() => {
-                            this.handleTaskIssuePaste(state, modal, modalId);
-                        }, 100);
-                        // Disconnect observer after detecting click
-                        observer.disconnect();
-                        state.taskObservers.delete(modalId);
-                        break;
-                    }
-                }
-            }
-        });
-        
-        // Observe class attribute changes on the Task button
-        observer.observe(taskButton, {
-            attributes: true,
-            attributeFilter: ['class']
-        });
-        
-        // Store observer info
-        state.taskObservers.set(modalId, { observer, taskButton });
-        
-        Logger.debug('Task button observer set up');
-    },
-    
-    isTaskButtonSelected(button) {
-        // Check if button has the selected state classes
-        return button.classList.contains('border-brand') || 
-               button.classList.contains('bg-brand') ||
-               button.querySelector('.border-brand') !== null ||
-               button.querySelector('.bg-brand') !== null;
-    },
-    
-    findTaskIssueButton(modal) {
-        // Find button for Task option in the issues section (label-tolerant: "Task", "Problems with Task", etc.)
-        const buttons = Context.dom.queryAll('button', {
-            root: modal,
-            context: `${this.id}.issueButtons`
-        });
-        
-        for (const button of buttons) {
-            const buttonText = button.textContent.trim();
-            // Accept exact "Task" or labels that include "Task" but are not Environment/Grading
-            const isTaskOption = buttonText === 'Task' ||
-                (buttonText.includes('Task') && !buttonText.includes('Environment') && !buttonText.includes('Grading'));
-            if (!isTaskOption) continue;
-            // Check if any ancestor contains "Where are the issues"
-            // (it's in a sibling div, not the immediate parent)
-            let ancestor = button.parentElement;
-            while (ancestor && ancestor !== modal) {
-                const ancestorText = ancestor.textContent || '';
-                if (ancestorText.includes('Where are the issues')) {
-                    return button;
-                }
-                ancestor = ancestor.parentElement;
-            }
-        }
-        return null;
-    },
-    
-    handleTaskIssuePaste(state, modal, modalId) {
-        Logger.log('Request Revisions: handleTaskIssuePaste ran');
-        // Prefer id-based selector (#feedback-Task); fallback for older markup
-        let taskFeedbackTextarea = document.getElementById('feedback-Task');
-        if (!taskFeedbackTextarea || !modal.contains(taskFeedbackTextarea) || taskFeedbackTextarea.tagName !== 'TEXTAREA') {
-            taskFeedbackTextarea = Context.dom.query('textarea#feedback-Task', {
-                root: modal,
-                context: `${this.id}.taskFeedbackTextarea`
-            });
-        }
-        
-        if (!taskFeedbackTextarea) {
-            Logger.log('Request Revisions: Task paste skipped — no textarea');
-            return; // Textarea doesn't exist yet (might appear slightly after button click)
-        }
-        
-        // Check if textarea already has content (trim to handle whitespace-only content)
-        const currentValue = taskFeedbackTextarea.value ? taskFeedbackTextarea.value.trim() : '';
-        if (currentValue.length > 0) {
-            Logger.log(`Request Revisions: Task paste skipped — already has content (${currentValue.length} chars)`);
-            return; // Don't overwrite existing content
-        }
-        
-        if (!state.promptText) {
-            Logger.log('Request Revisions: Task paste skipped — no promptText');
-            return;
-        }
-        
-        // Format the prompt text
-        const formattedPrompt = `---\n${state.promptText}\n---`;
-        
-        Logger.log(`Pasting prompt text to Task issue box (${formattedPrompt.length} chars)`);
-        
-        // Apply the value using the same method that worked for workflow copy
-        this.applyTextareaValue(taskFeedbackTextarea, formattedPrompt);
-        
-        Logger.log('✓ Prompt text pasted to Task issue box');
-    },
-    
-    cleanupTaskObservers(state) {
-        // Clean up all Task button observers
-        for (const [modalId, observerInfo] of state.taskObservers.entries()) {
-            if (observerInfo.observer) {
-                observerInfo.observer.disconnect();
-            }
-        }
-        state.taskObservers.clear();
     },
 
     findWhereAreTheIssuesButtonRow(modal) {
@@ -471,6 +228,8 @@ const plugin = {
 
         const copyVerifierEnabled = Storage.getSubOptionEnabled(this.id, COPY_VERIFIER_SUBOPTION_ID, true);
         this.syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass);
+        const copyPromptEnabled = Storage.getSubOptionEnabled(this.id, COPY_PROMPT_SUBOPTION_ID, true);
+        this.syncCopyPromptButton(state, wrapper, copyPromptEnabled, buttonClass);
     },
 
     syncCopyVerifierOutputButton(state, wrapper, copyVerifierEnabled, buttonClass) {
@@ -485,13 +244,65 @@ const plugin = {
                 btn.textContent = 'Copy Verifier Output';
                 btn.title = 'Copy verifier output to clipboard';
                 btn.addEventListener('click', () => this.handleCopyVerifierOutputClick(state, btn));
-                wrapper.appendChild(btn);
+                wrapper.insertBefore(btn, wrapper.firstChild);
                 Logger.debug('Request Revisions: Copy Verifier Output button added');
             }
             btn.style.display = '';
         } else if (btn) {
             btn.style.display = 'none';
         }
+    },
+
+    syncCopyPromptButton(state, wrapper, copyPromptEnabled, buttonClass) {
+        let btn = wrapper.querySelector(`[${COPY_PROMPT_MARKER}="true"]`);
+        if (copyPromptEnabled) {
+            if (!btn) {
+                btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = buttonClass;
+                btn.setAttribute('data-fleet-plugin', this.id);
+                btn.setAttribute(COPY_PROMPT_MARKER, 'true');
+                btn.textContent = 'Copy Prompt';
+                btn.title = 'Copy task prompt to clipboard';
+                btn.addEventListener('click', () => this.handleCopyPromptClick(state, btn));
+                wrapper.insertBefore(btn, wrapper.firstChild);
+                Logger.debug('Request Revisions: Copy Prompt button added');
+            }
+            btn.style.display = '';
+        } else if (btn) {
+            btn.style.display = 'none';
+        }
+    },
+
+    getPromptTextForClipboard(state) {
+        const panel = this.findTaskPanel();
+        if (panel) {
+            const el = panel.querySelector('.text-sm.whitespace-pre-wrap') ||
+                panel.querySelector('[class*="whitespace-pre-wrap"]');
+            if (el) {
+                const text = el.textContent.trim();
+                if (text) {
+                    state.promptText = text;
+                    return text;
+                }
+            }
+        }
+        return (state.promptText && String(state.promptText).trim()) || '';
+    },
+
+    handleCopyPromptClick(state, button) {
+        const originalText = 'Copy Prompt';
+        const text = this.getPromptTextForClipboard(state);
+        if (!text) {
+            Logger.warn('Request Revisions: No prompt text to copy');
+            return;
+        }
+        navigator.clipboard.writeText(text).then(() => {
+            Logger.log(`Request Revisions: Copied prompt to clipboard (${text.length} chars)`);
+            this.showCopyButtonConfirmation(button, originalText);
+        }).catch((err) => {
+            Logger.error('Request Revisions: Failed to copy prompt', err);
+        });
     },
 
     getVerifierTextForClipboard(state) {
@@ -740,30 +551,5 @@ const plugin = {
         });
 
         state.verifierChangeObserver = changeObserver;
-    },
-    
-    getReactFiber(element) {
-        // Try different React internal property names
-        // React 16+: __reactInternalInstance or __reactFiber
-        // React 17+: __reactFiber$<random>
-        // React 18+: __reactFiber$<random> or __reactInternalInstance$<random>
-        const keys = Object.keys(element);
-        for (const key of keys) {
-            if (key.startsWith('__reactFiber') || key.startsWith('__reactInternalInstance')) {
-                return element[key];
-            }
-        }
-        
-        // Also check for React 18's alternate fiber
-        for (const key of keys) {
-            if (key.includes('reactFiber') || key.includes('reactInternalInstance')) {
-                const fiber = element[key];
-                if (fiber && (fiber.memoizedProps || fiber.pendingProps)) {
-                    return fiber;
-                }
-            }
-        }
-        
-        return null;
     }
 };

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -10,8 +10,10 @@ const COPY_PROMPT_MARKER = 'data-fleet-revisions-copy-prompt';
 const COPY_PROMPT_SUBOPTION_ID = 'copy-prompt-button';
 const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
 const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
-const COPY_BUTTON_CONFIRMATION_MS = 3000;
-const COPY_BUTTON_CONFIRMATION_GREEN_BG = 'rgb(34, 197, 94)';
+const COPY_SUCCESS_FLASH_MS = 3000;
+const COPY_SUCCESS_GREEN_BG = 'rgb(34, 197, 94)';
+const COPY_FAILURE_PULSE_MS = 500;
+const COPY_FAILURE_RED_BG = 'rgb(239, 68, 68)';
 
 const PROMPT_QUALITY_VALUES = ['Top 10%', 'Average', 'Bottom 10%'];
 const PROMPT_QUALITY_LISTENER_MARKER = 'data-fleet-prompt-quality-listener';
@@ -20,7 +22,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.10',
+    _version: '4.11',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -291,17 +293,18 @@ const plugin = {
     },
 
     handleCopyPromptClick(state, button) {
-        const originalText = 'Copy Prompt';
         const text = this.getPromptTextForClipboard(state);
         if (!text) {
             Logger.warn('Request Revisions: No prompt text to copy');
+            this.showCopyFailurePulse(button);
             return;
         }
         navigator.clipboard.writeText(text).then(() => {
             Logger.log(`Request Revisions: Copied prompt to clipboard (${text.length} chars)`);
-            this.showCopyButtonConfirmation(button, originalText);
+            this.showCopySuccessFlash(button);
         }).catch((err) => {
             Logger.error('Request Revisions: Failed to copy prompt', err);
+            this.showCopyFailurePulse(button);
         });
     },
 
@@ -316,31 +319,60 @@ const plugin = {
         return (state.verifierOutput && String(state.verifierOutput).trim()) || '';
     },
 
-    showCopyButtonConfirmation(button, originalText) {
-        button.textContent = 'Copied!';
-        button.style.backgroundColor = COPY_BUTTON_CONFIRMATION_GREEN_BG;
-        button.style.color = 'white';
-        if (button._fleetCopyConfirmTimeout) clearTimeout(button._fleetCopyConfirmTimeout);
-        button._fleetCopyConfirmTimeout = setTimeout(() => {
-            button.textContent = originalText;
+    clearRequestRevisionsCopyButtonFeedback(button) {
+        if (button._copySuccessFlashTimeout) {
+            clearTimeout(button._copySuccessFlashTimeout);
+            button._copySuccessFlashTimeout = null;
+        }
+        if (button._copyFailurePulseTimeout) {
+            clearTimeout(button._copyFailurePulseTimeout);
+            button._copyFailurePulseTimeout = null;
+        }
+        button.style.transition = '';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+    },
+
+    showCopySuccessFlash(button) {
+        this.clearRequestRevisionsCopyButtonFeedback(button);
+        button.style.backgroundColor = COPY_SUCCESS_GREEN_BG;
+        button.style.color = '#ffffff';
+        button._copySuccessFlashTimeout = setTimeout(() => {
             button.style.backgroundColor = '';
             button.style.color = '';
-            button._fleetCopyConfirmTimeout = null;
-        }, COPY_BUTTON_CONFIRMATION_MS);
+            button._copySuccessFlashTimeout = null;
+        }, COPY_SUCCESS_FLASH_MS);
+    },
+
+    showCopyFailurePulse(button) {
+        this.clearRequestRevisionsCopyButtonFeedback(button);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = COPY_FAILURE_RED_BG;
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = `background-color ${COPY_FAILURE_PULSE_MS}ms ease-out, color ${COPY_FAILURE_PULSE_MS}ms ease-out`;
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._copyFailurePulseTimeout = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._copyFailurePulseTimeout = null;
+        }, COPY_FAILURE_PULSE_MS);
     },
 
     handleCopyVerifierOutputClick(state, button) {
-        const originalText = 'Copy Verifier Output';
         const text = this.getVerifierTextForClipboard(state);
         if (!text) {
             Logger.warn('Request Revisions: No verifier output to copy');
+            this.showCopyFailurePulse(button);
             return;
         }
         navigator.clipboard.writeText(text).then(() => {
             Logger.log(`Request Revisions: Copied verifier output to clipboard (${text.length} chars)`);
-            this.showCopyButtonConfirmation(button, originalText);
+            this.showCopySuccessFlash(button);
         }).catch((err) => {
             Logger.error('Request Revisions: Failed to copy verifier output', err);
+            this.showCopyFailurePulse(button);
         });
     },
 

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -14,7 +14,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.7',
+    _version: '4.8',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -34,8 +34,8 @@ const plugin = {
         },
         {
             id: 'copy-link-kinesis-guidelines',
-            name: 'Copy Link to Kinesis Guidelines',
-            description: 'Show a button under "Where are the issues?" that copies the Kinesis Guidelines link to the clipboard',
+            name: 'Kinesis Guidelines',
+            description: 'Show a button under "Where are the issues?" that opens Kinesis Guidelines in a new tab',
             enabledByDefault: true
         }
     ],
@@ -138,7 +138,7 @@ const plugin = {
         // Get modal ID to track observers
         const modalId = requestRevisionsModal.id;
         
-        // Inject guideline copy-link buttons if enabled
+        // Inject guideline open buttons if enabled
         this.injectGuidelineCopyButtons(state, requestRevisionsModal);
         
         // Persist and restore Prompt Quality Rating selection within this page instance
@@ -431,49 +431,51 @@ const plugin = {
         wrapper.className = 'flex flex-wrap gap-2 mt-2';
 
         const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
-        const linkClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-2 pr-2 text-xs no-underline text-foreground';
 
-        const kinesisGroup = document.createElement('span');
-        kinesisGroup.className = 'inline-flex items-center gap-1';
-        kinesisGroup.setAttribute('data-guideline-group', 'kinesis');
-        const kinesisBtn = document.createElement('button');
-        kinesisBtn.type = 'button';
-        kinesisBtn.className = buttonClass;
-        kinesisBtn.setAttribute('data-fleet-plugin', this.id);
-        kinesisBtn.setAttribute('data-guideline-copy', 'kinesis');
-        kinesisBtn.textContent = 'Copy Link to Kinesis Guidelines';
-        kinesisBtn.addEventListener('click', () => this.copyGuidelineLink(kinesisBtn, 'Copy Link to Kinesis Guidelines', GUIDELINE_LINKS.kinesis));
-        kinesisGroup.appendChild(kinesisBtn);
-        const kinesisOpen = document.createElement('a');
-        kinesisOpen.href = GUIDELINE_LINKS.kinesis;
-        kinesisOpen.target = '_blank';
-        kinesisOpen.rel = 'noopener noreferrer';
-        kinesisOpen.className = linkClass;
-        kinesisOpen.setAttribute('data-fleet-plugin', this.id);
-        kinesisOpen.textContent = 'Open';
-        kinesisGroup.appendChild(kinesisOpen);
-        wrapper.appendChild(kinesisGroup);
+        const kinesisBtn = this.createGuidelineOpenButton(
+            buttonClass,
+            'kinesis',
+            GUIDELINE_LINKS.kinesis,
+            'Kinesis Guidelines'
+        );
+        wrapper.appendChild(kinesisBtn);
 
         this.syncGuidelineCopyButtons(wrapper, kinesisEnabled);
         buttonRow.insertAdjacentElement('afterend', wrapper);
-        Logger.log('Request Revisions: guideline copy-link buttons added');
+        Logger.log('Request Revisions: guideline buttons added');
+    },
+
+    createGuidelineOpenButton(buttonClass, groupId, url, shortTitle) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = buttonClass;
+        btn.setAttribute('data-fleet-plugin', this.id);
+        btn.setAttribute('data-guideline-group', groupId);
+        btn.textContent = shortTitle;
+        btn.title = `Open ${shortTitle} in a new tab`;
+        btn.addEventListener('click', () => {
+            window.open(url, '_blank');
+            Logger.log(`Request Revisions: opened ${shortTitle}`);
+        });
+        return btn;
+    },
+
+    migrateLegacyGuidelineOpenControl(wrapper, groupId, url, shortTitle, buttonClass) {
+        const el = wrapper.querySelector(`[data-guideline-group="${groupId}"]`);
+        if (!el) return;
+        const isLegacy = el.tagName === 'SPAN' && el.querySelector('a');
+        if (!isLegacy) return;
+        const btn = this.createGuidelineOpenButton(buttonClass, groupId, url, shortTitle);
+        el.replaceWith(btn);
+        Logger.debug(`Request Revisions: migrated legacy ${shortTitle} control to open-only button`);
     },
 
     syncGuidelineCopyButtons(wrapper, kinesisEnabled) {
+        const buttonClass = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+        this.migrateLegacyGuidelineOpenControl(wrapper, 'kinesis', GUIDELINE_LINKS.kinesis, 'Kinesis Guidelines', buttonClass);
+
         const kinesisGroup = wrapper.querySelector('[data-guideline-group="kinesis"]');
         if (kinesisGroup) kinesisGroup.style.display = kinesisEnabled ? '' : 'none';
-    },
-
-    copyGuidelineLink(button, originalText, url) {
-        navigator.clipboard.writeText(url).then(() => {
-            button.textContent = 'Copied!';
-            Logger.log(`Request Revisions: copied ${originalText} to clipboard`);
-            setTimeout(() => {
-                button.textContent = originalText;
-            }, 2500);
-        }).catch((err) => {
-            Logger.error('Request Revisions: failed to copy guideline link', err);
-        });
     },
 
     findPromptQualityRatingSection(modal) {

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -14,7 +14,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.4',
+    _version: '4.5',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -537,6 +537,18 @@ const plugin = {
     },
 
     // Same search logic as copy-verifier-output.js
+    findScoreRow() {
+        const candidates = document.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+        for (const el of candidates) {
+            for (const s of el.querySelectorAll('span')) {
+                if (s.textContent.trim() === 'Score:') {
+                    return el;
+                }
+            }
+        }
+        return null;
+    },
+
     findStdoutRow() {
         const candidates = document.querySelectorAll('div.text-sm.text-muted-foreground.font-medium.mb-1');
         for (const el of candidates) {
@@ -547,9 +559,68 @@ const plugin = {
         return null;
     },
 
+    buildScoreVerifierMarkdown(container) {
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0.5');
+        if (!list) {
+            return null;
+        }
+        const rows = list.querySelectorAll(':scope > div.flex.items-start');
+        const successes = [];
+        const failures = [];
+        for (const row of rows) {
+            const svg = row.querySelector(':scope > svg');
+            if (!svg) continue;
+            const cls = svg.getAttribute('class') || '';
+            const span = row.querySelector(':scope > span');
+            const text = span ? span.textContent.trim() : '';
+            if (!text) continue;
+            if (cls.includes('text-emerald')) {
+                successes.push(text);
+            } else if (cls.includes('text-red')) {
+                failures.push(text);
+            }
+        }
+        if (successes.length === 0 && failures.length === 0) {
+            return null;
+        }
+        const lines = ['## Verifier'];
+        if (successes.length > 0) {
+            lines.push('#### Successes');
+            for (const t of successes) {
+                lines.push(`> ✅ ${t}`);
+            }
+        }
+        if (failures.length > 0) {
+            lines.push('#### Failures');
+            for (const t of failures) {
+                lines.push(`> ❌ ${t}`);
+            }
+        }
+        return lines.join('\n');
+    },
+
     getVerifierPreFromContainer(container) {
         const pre = container.querySelector('div.overflow-x-auto.bg-background.border.rounded pre');
         return pre && pre.textContent.trim().length > 0 ? pre : null;
+    },
+
+    tryCaptureVerifierOutput() {
+        const scoreRow = this.findScoreRow();
+        if (scoreRow) {
+            const container = scoreRow.closest('div.p-3');
+            if (container) {
+                const md = this.buildScoreVerifierMarkdown(container);
+                if (md && md.length > 0) {
+                    return { kind: 'score', node: container };
+                }
+            }
+        }
+        const stdoutRow = this.findStdoutRow();
+        if (!stdoutRow) return null;
+        const container = stdoutRow.closest('div.text-xs.w-full');
+        if (!container) return null;
+        const pre = this.getVerifierPreFromContainer(container);
+        return pre ? { kind: 'pre', node: pre } : null;
     },
 
     watchVerifierOutput(state) {
@@ -557,28 +628,22 @@ const plugin = {
             return;
         }
 
-        const tryCaptureVerifier = () => {
-            const stdoutRow = this.findStdoutRow();
-            if (!stdoutRow) return null;
-            const container = stdoutRow.closest('div.text-xs.w-full');
-            if (!container) return null;
-            return this.getVerifierPreFromContainer(container);
-        };
+        const tryCaptureVerifier = () => this.tryCaptureVerifierOutput();
 
-        const pre = tryCaptureVerifier();
-        if (pre) {
+        const captured = tryCaptureVerifier();
+        if (captured) {
             Logger.log('✓ Verifier container detected');
-            this.saveVerifierOutput(state, pre);
+            this.saveVerifierOutput(state, captured);
             return;
         }
 
         const containerObserver = new MutationObserver(() => {
-            const pre = tryCaptureVerifier();
-            if (pre) {
+            const next = tryCaptureVerifier();
+            if (next) {
                 Logger.log('✓ Verifier container detected');
                 containerObserver.disconnect();
                 state.verifierObserver = null;
-                this.saveVerifierOutput(state, pre);
+                this.saveVerifierOutput(state, next);
             }
         });
 
@@ -588,35 +653,34 @@ const plugin = {
         });
         state.verifierObserver = containerObserver;
     },
-    
-    saveVerifierOutput(state, verifierPre) {
-        // Save the verifier output
-        state.verifierOutput = verifierPre.textContent.trim();
-        state.verifierElement = verifierPre;
-        
+
+    saveVerifierOutput(state, capture) {
+        const getText = () => {
+            if (capture.kind === 'pre') {
+                return capture.node.textContent.trim();
+            }
+            return this.buildScoreVerifierMarkdown(capture.node) || '';
+        };
+
+        state.verifierOutput = getText();
+        state.verifierElement = capture.node;
+
         Logger.log(`✓ Verifier output saved (${state.verifierOutput.length} chars)`);
-        
-        // Set up MutationObserver to watch for changes (in case of regrading)
-        const changeObserver = new MutationObserver((mutations) => {
-            for (const mutation of mutations) {
-                if (mutation.type === 'childList' || mutation.type === 'characterData') {
-                    const newOutput = verifierPre.textContent.trim();
-                    if (newOutput !== state.verifierOutput && newOutput.length > 0) {
-                        state.verifierOutput = newOutput;
-                        Logger.log(`✓ Verifier output updated (${state.verifierOutput.length} chars)`);
-                    }
-                }
+
+        const changeObserver = new MutationObserver(() => {
+            const newOutput = getText();
+            if (newOutput !== state.verifierOutput && newOutput.length > 0) {
+                state.verifierOutput = newOutput;
+                Logger.log(`✓ Verifier output updated (${state.verifierOutput.length} chars)`);
             }
         });
-        
-        // Observe changes to the pre element and its children
-        changeObserver.observe(verifierPre, {
+
+        changeObserver.observe(capture.node, {
             childList: true,
             subtree: true,
             characterData: true
         });
-        
-        // Store the change observer (we'll keep the original observer reference for cleanup)
+
         state.verifierChangeObserver = changeObserver;
     },
     

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -10,7 +10,7 @@ const COPY_PROMPT_MARKER = 'data-fleet-revisions-copy-prompt';
 const COPY_PROMPT_SUBOPTION_ID = 'copy-prompt-button';
 const COPY_VERIFIER_OUTPUT_MARKER = 'data-fleet-revisions-copy-verifier';
 const COPY_VERIFIER_SUBOPTION_ID = 'copy-verifier-output-button';
-const COPY_SUCCESS_FLASH_MS = 3000;
+const COPY_SUCCESS_FLASH_MS = 1000;
 const COPY_SUCCESS_GREEN_BG = 'rgb(34, 197, 94)';
 const COPY_FAILURE_PULSE_MS = 500;
 const COPY_FAILURE_RED_BG = 'rgb(239, 68, 68)';
@@ -22,7 +22,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.11',
+    _version: '5.0',
     enabledByDefault: true,
     phase: 'mutation',
     

--- a/plugins/archetypes/qa-tool-use/main/text-sanitizer.js
+++ b/plugins/archetypes/qa-tool-use/main/text-sanitizer.js
@@ -105,7 +105,7 @@ const plugin = {
     id: 'textSanitizer',
     name: 'Text Sanitizer',
     description: 'Adds a text sanitizer utility for quickly cleaning and transforming text',
-    _version: '2.5',
+    _version: '2.6',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -436,23 +436,38 @@ const plugin = {
         executeBtn.className = buttonClass;
         executeBtn.setAttribute('data-fleet-plugin', this.id);
         executeBtn.textContent = 'Execute';
-        const showExecuteFeedback = () => {
-            executeBtn.textContent = 'Executed';
+        const showExecuteSuccess = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            executeBtn.style.transition = '';
             executeBtn.style.backgroundColor = 'rgb(34, 197, 94)';
             executeBtn.style.color = 'white';
-            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
             state.executeFeedbackTimeoutId = setTimeout(() => {
-                executeBtn.textContent = 'Execute';
                 executeBtn.style.backgroundColor = '';
                 executeBtn.style.color = '';
                 state.executeFeedbackTimeoutId = null;
-            }, 3000);
+            }, 1000);
+        };
+        const showExecuteFailure = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            const prevT = executeBtn.style.transition;
+            executeBtn.style.transition = 'none';
+            executeBtn.style.backgroundColor = 'rgb(239, 68, 68)';
+            executeBtn.style.color = '#ffffff';
+            void executeBtn.offsetHeight;
+            executeBtn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            executeBtn.style.backgroundColor = '';
+            executeBtn.style.color = '';
+            state.executeFeedbackTimeoutId = setTimeout(() => {
+                executeBtn.style.transition = prevT || '';
+                state.executeFeedbackTimeoutId = null;
+            }, 500);
         };
         const onExecute = () => {
             const id = select.value;
             const action = this.actions[id];
             if (!action) return;
             const input = textarea.value || '';
+            let ok = true;
             try {
                 const output = action.run(input);
                 textarea.value = output;
@@ -461,8 +476,13 @@ const plugin = {
             } catch (e) {
                 Logger.error('Text Sanitizer: Execute failed', e);
                 textarea.value = input;
+                ok = false;
             }
-            showExecuteFeedback();
+            if (ok) {
+                showExecuteSuccess();
+            } else {
+                showExecuteFailure();
+            }
         };
         executeBtn.addEventListener('click', onExecute);
         CleanupRegistry.registerEventListener(executeBtn, 'click', onExecute);
@@ -485,31 +505,50 @@ const plugin = {
         button.title = 'Copy text';
         button.setAttribute('aria-label', 'Copy text');
 
+        const pulseCopyFailure = () => {
+            if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            state.copyFeedbackTimeoutId = setTimeout(() => {
+                button.style.transition = prevT || '';
+                state.copyFeedbackTimeoutId = null;
+            }, 500);
+        };
         const handleCopy = () => {
             const container = button.closest('[data-qa-text-sanitizer="true"]');
             const textarea = container ? container.querySelector('[data-qa-text-sanitizer-textarea="true"]') : null;
-            if (!textarea) return;
+            if (!textarea) {
+                pulseCopyFailure();
+                return;
+            }
             const text = textarea.value || '';
             if (!text) {
                 Logger.debug('Text Sanitizer: No text to copy');
+                pulseCopyFailure();
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Text Sanitizer: Copied ${text.length} chars and cleared`);
-                button.textContent = 'Copied';
+                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
-                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
                 state.copyFeedbackTimeoutId = setTimeout(() => {
-                    button.textContent = 'Copy';
                     button.style.backgroundColor = '';
                     button.style.color = '';
                     state.copyFeedbackTimeoutId = null;
-                }, 3000);
+                }, 1000);
                 textarea.value = '';
                 if (opts && opts.onAfterClear) opts.onAfterClear();
             }).catch((err) => {
                 Logger.error('Text Sanitizer: Failed to copy to clipboard', err);
+                pulseCopyFailure();
             });
         };
 

--- a/plugins/archetypes/qa-tool-use/main/useful-links-buttons.js
+++ b/plugins/archetypes/qa-tool-use/main/useful-links-buttons.js
@@ -13,7 +13,7 @@ const plugin = {
     id: 'guidelineButtons',
     name: 'Useful Link Buttons',
     description: 'Add useful link buttons to the page',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -28,6 +28,33 @@ const plugin = {
     initialState: {
         wrapperAdded: false,
         missingLogged: false
+    },
+
+    flashClipboardSuccess(btn) {
+        if (btn._fleetClipboardFbT) clearTimeout(btn._fleetClipboardFbT);
+        btn.style.backgroundColor = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._fleetClipboardFbT = setTimeout(() => {
+            btn.style.backgroundColor = '';
+            btn.style.color = '';
+            btn._fleetClipboardFbT = null;
+        }, 1000);
+    },
+
+    flashClipboardFailure(btn) {
+        if (btn._fleetClipboardFbT) clearTimeout(btn._fleetClipboardFbT);
+        const prevT = btn.style.transition;
+        btn.style.transition = 'none';
+        btn.style.backgroundColor = 'rgb(239, 68, 68)';
+        btn.style.color = '#ffffff';
+        void btn.offsetHeight;
+        btn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+        btn.style.backgroundColor = '';
+        btn.style.color = '';
+        btn._fleetClipboardFbT = setTimeout(() => {
+            btn.style.transition = prevT || '';
+            btn._fleetClipboardFbT = null;
+        }, 500);
     },
 
     onMutation(state, context) {
@@ -183,8 +210,10 @@ const plugin = {
                     btn.addEventListener('click', () => {
                         navigator.clipboard.writeText(b.link).then(() => {
                             Logger.log(`Useful Link Buttons: copied link to clipboard`);
+                            this.flashClipboardSuccess(btn);
                         }).catch((err) => {
                             Logger.error('Useful Link Buttons: failed to copy link', err);
+                            this.flashClipboardFailure(btn);
                         });
                     });
                 } else {

--- a/plugins/archetypes/task-view/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/task-view/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '3.2',
+    _version: '3.3',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -417,24 +417,42 @@ const plugin = {
             button.dataset.diffCopyTarget = label;
 
             let copyFeedbackTimeoutId = null;
+            const pulseCopyFailure = () => {
+                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                const prevT = button.style.transition;
+                button.style.transition = 'none';
+                button.style.backgroundColor = 'rgb(239, 68, 68)';
+                button.style.color = 'white';
+                void button.offsetHeight;
+                button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                copyFeedbackTimeoutId = setTimeout(() => {
+                    button.style.transition = prevT || '';
+                    copyFeedbackTimeoutId = null;
+                }, 500);
+            };
             button.addEventListener('click', async () => {
                 const pre = column.querySelector(this.selectors.beforePre);
                 if (!pre) {
                     Logger.warn(`Missing ${label} pre element for copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 const fallbackText = pre.textContent || '';
                 const sourceText = pre.dataset.originalText || fallbackText;
                 if (!sourceText) {
                     Logger.warn(`No ${label} text found to copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 try {
                     await navigator.clipboard.writeText(sourceText);
                     Logger.info(`Copied ${label} prompt to clipboard (${sourceText.length} chars)`);
+                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                    button.style.transition = '';
                     button.style.backgroundColor = 'rgb(34, 197, 94)';
                     button.style.color = 'white';
-                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
                     copyFeedbackTimeoutId = setTimeout(() => {
                         button.style.backgroundColor = '';
                         button.style.color = '';
@@ -442,6 +460,7 @@ const plugin = {
                     }, 1000);
                 } catch (err) {
                     Logger.error(`Failed to copy ${label} prompt`, err);
+                    pulseCopyFailure();
                 }
             });
 

--- a/plugins/archetypes/tool-use-revision/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/tool-use-revision/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '3.2',
+    _version: '3.3',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -417,24 +417,42 @@ const plugin = {
             button.dataset.diffCopyTarget = label;
 
             let copyFeedbackTimeoutId = null;
+            const pulseCopyFailure = () => {
+                if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                const prevT = button.style.transition;
+                button.style.transition = 'none';
+                button.style.backgroundColor = 'rgb(239, 68, 68)';
+                button.style.color = 'white';
+                void button.offsetHeight;
+                button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                copyFeedbackTimeoutId = setTimeout(() => {
+                    button.style.transition = prevT || '';
+                    copyFeedbackTimeoutId = null;
+                }, 500);
+            };
             button.addEventListener('click', async () => {
                 const pre = column.querySelector(this.selectors.beforePre);
                 if (!pre) {
                     Logger.warn(`Missing ${label} pre element for copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 const fallbackText = pre.textContent || '';
                 const sourceText = pre.dataset.originalText || fallbackText;
                 if (!sourceText) {
                     Logger.warn(`No ${label} text found to copy`);
+                    pulseCopyFailure();
                     return;
                 }
                 try {
                     await navigator.clipboard.writeText(sourceText);
                     Logger.info(`Copied ${label} prompt to clipboard (${sourceText.length} chars)`);
+                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
+                    button.style.transition = '';
                     button.style.backgroundColor = 'rgb(34, 197, 94)';
                     button.style.color = 'white';
-                    if (copyFeedbackTimeoutId) clearTimeout(copyFeedbackTimeoutId);
                     copyFeedbackTimeoutId = setTimeout(() => {
                         button.style.backgroundColor = '';
                         button.style.color = '';
@@ -442,6 +460,7 @@ const plugin = {
                     }, 1000);
                 } catch (err) {
                     Logger.error(`Failed to copy ${label} prompt`, err);
+                    pulseCopyFailure();
                 }
             });
 

--- a/plugins/archetypes/tool-use-revision/main/text-sanitizer.js
+++ b/plugins/archetypes/tool-use-revision/main/text-sanitizer.js
@@ -105,7 +105,7 @@ const plugin = {
     id: 'textSanitizer',
     name: 'Text Sanitizer',
     description: 'Adds a text sanitizer utility for quickly cleaning and transforming text',
-    _version: '3.0',
+    _version: '3.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -451,23 +451,38 @@ const plugin = {
         executeBtn.className = buttonClass;
         executeBtn.setAttribute('data-fleet-plugin', this.id);
         executeBtn.textContent = 'Execute';
-        const showExecuteFeedback = () => {
-            executeBtn.textContent = 'Executed';
+        const showExecuteSuccess = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            executeBtn.style.transition = '';
             executeBtn.style.backgroundColor = 'rgb(34, 197, 94)';
             executeBtn.style.color = 'white';
-            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
             state.executeFeedbackTimeoutId = setTimeout(() => {
-                executeBtn.textContent = 'Execute';
                 executeBtn.style.backgroundColor = '';
                 executeBtn.style.color = '';
                 state.executeFeedbackTimeoutId = null;
-            }, 3000);
+            }, 1000);
+        };
+        const showExecuteFailure = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            const prevT = executeBtn.style.transition;
+            executeBtn.style.transition = 'none';
+            executeBtn.style.backgroundColor = 'rgb(239, 68, 68)';
+            executeBtn.style.color = '#ffffff';
+            void executeBtn.offsetHeight;
+            executeBtn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            executeBtn.style.backgroundColor = '';
+            executeBtn.style.color = '';
+            state.executeFeedbackTimeoutId = setTimeout(() => {
+                executeBtn.style.transition = prevT || '';
+                state.executeFeedbackTimeoutId = null;
+            }, 500);
         };
         const onExecute = () => {
             const id = select.value;
             const action = this.actions[id];
             if (!action) return;
             const input = textarea.value || '';
+            let ok = true;
             try {
                 const output = action.run(input);
                 textarea.value = output;
@@ -476,8 +491,13 @@ const plugin = {
             } catch (e) {
                 Logger.error('Text Sanitizer: Execute failed', e);
                 textarea.value = input;
+                ok = false;
             }
-            showExecuteFeedback();
+            if (ok) {
+                showExecuteSuccess();
+            } else {
+                showExecuteFailure();
+            }
         };
         executeBtn.addEventListener('click', onExecute);
         CleanupRegistry.registerEventListener(executeBtn, 'click', onExecute);
@@ -500,31 +520,50 @@ const plugin = {
         button.title = 'Copy text';
         button.setAttribute('aria-label', 'Copy text');
 
+        const pulseCopyFailure = () => {
+            if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            state.copyFeedbackTimeoutId = setTimeout(() => {
+                button.style.transition = prevT || '';
+                state.copyFeedbackTimeoutId = null;
+            }, 500);
+        };
         const handleCopy = () => {
             const container = button.closest('[data-qa-text-sanitizer="true"]');
             const textarea = container ? container.querySelector('[data-qa-text-sanitizer-textarea="true"]') : null;
-            if (!textarea) return;
+            if (!textarea) {
+                pulseCopyFailure();
+                return;
+            }
             const text = textarea.value || '';
             if (!text) {
                 Logger.debug('Text Sanitizer: No text to copy');
+                pulseCopyFailure();
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Text Sanitizer: Copied ${text.length} chars and cleared`);
-                button.textContent = 'Copied';
+                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
-                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
                 state.copyFeedbackTimeoutId = setTimeout(() => {
-                    button.textContent = 'Copy';
                     button.style.backgroundColor = '';
                     button.style.color = '';
                     state.copyFeedbackTimeoutId = null;
-                }, 3000);
+                }, 1000);
                 textarea.value = '';
                 if (opts && opts.onAfterClear) opts.onAfterClear();
             }).catch((err) => {
                 Logger.error('Text Sanitizer: Failed to copy to clipboard', err);
+                pulseCopyFailure();
             });
         };
 

--- a/plugins/archetypes/tool-use-task-creation-openclaw/main/json-editor-online.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/main/json-editor-online.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'jsonEditorOnline',
     name: 'JSON Editor Online',
     description: 'Add button that opens JSON Editor Online in a new tab. Optionally show button on each tool result to copy output and open editor.',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -183,7 +183,8 @@ const plugin = {
                 if (isHandlingClick) return;
                 isHandlingClick = true;
                 try {
-                    await this.copyResultAndOpenEditor(card, resultArea);
+                    const copyOk = await this.copyResultAndOpenEditor(card, resultArea);
+                    this._flashJsonEditorToolButton(button, copyOk);
                 } finally {
                     // Reset after a short delay to allow async operations
                     setTimeout(() => { isHandlingClick = false; }, 1000);
@@ -289,57 +290,82 @@ const plugin = {
         return null;
     },
     
+    _flashJsonEditorToolButton(button, success) {
+        if (button._fleetJsonEdFlashT) clearTimeout(button._fleetJsonEdFlashT);
+        if (success) {
+            button.style.transition = '';
+            button.style.backgroundColor = 'rgb(34, 197, 94)';
+            button.style.color = '#ffffff';
+            button._fleetJsonEdFlashT = setTimeout(() => {
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._fleetJsonEdFlashT = null;
+            }, 1000);
+        } else {
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            button._fleetJsonEdFlashT = setTimeout(() => {
+                button.style.transition = prevT || '';
+                button._fleetJsonEdFlashT = null;
+            }, 500);
+        }
+    },
+
     async copyResultAndOpenEditor(card, resultArea) {
-        // Prevent double execution
         if (this._copying) {
-            return;
+            return false;
         }
         this._copying = true;
-        
+        let copyOk = false;
+
         try {
             Logger.log('Copying result and opening JSON Editor Online');
-            
-            // Find the result content div (the one with the actual JSON/text)
+
             const resultContent = this.findResultContent(resultArea);
             if (resultContent) {
-                try {
-                    // Extract text content
-                    const textContent = resultContent.textContent || resultContent.innerText || '';
-                    
-                    if (textContent.trim()) {
-                        // Use Clipboard API to copy directly
-                        await navigator.clipboard.writeText(textContent);
-                        Logger.log('✓ Copied result content to clipboard');
-                    } else {
-                        Logger.warn('Result content is empty');
-                    }
-                } catch (e) {
-                    Logger.warn('Failed to copy to clipboard:', e);
-                    // Fallback: try using document.execCommand for older browsers
+                const textContent = (resultContent.textContent || resultContent.innerText || '').trim();
+                if (textContent) {
                     try {
-                        const textArea = document.createElement('textarea');
-                        textArea.value = resultContent.textContent || resultContent.innerText || '';
-                        textArea.style.position = 'fixed';
-                        textArea.style.opacity = '0';
-                        document.body.appendChild(textArea);
-                        textArea.select();
-                        document.execCommand('copy');
-                        document.body.removeChild(textArea);
-                        Logger.log('✓ Copied result content to clipboard (fallback method)');
-                    } catch (fallbackError) {
-                        Logger.warn('Fallback copy method also failed:', fallbackError);
+                        await navigator.clipboard.writeText(textContent);
+                        copyOk = true;
+                        Logger.log('✓ Copied result content to clipboard');
+                    } catch (e) {
+                        Logger.warn('Failed to copy to clipboard:', e);
+                        try {
+                            const textArea = document.createElement('textarea');
+                            textArea.value = textContent;
+                            textArea.style.position = 'fixed';
+                            textArea.style.opacity = '0';
+                            document.body.appendChild(textArea);
+                            textArea.select();
+                            copyOk = document.execCommand('copy');
+                            document.body.removeChild(textArea);
+                            if (copyOk) {
+                                Logger.log('✓ Copied result content to clipboard (fallback method)');
+                            }
+                        } catch (fallbackError) {
+                            Logger.warn('Fallback copy method also failed:', fallbackError);
+                        }
                     }
+                } else {
+                    Logger.warn('Result content is empty');
                 }
             } else {
                 Logger.warn('Result content div not found, opening editor anyway');
             }
-            
-            // Open JSON Editor Online in new tab
+
             window.open('https://jsoneditoronline.org', '_blank');
             Logger.log('✓ Opened JSON Editor Online');
         } finally {
             this._copying = false;
         }
+        return copyOk;
     },
     
     findResultContent(resultArea) {

--- a/plugins/archetypes/tool-use-task-creation-openclaw/main/text-sanitizer.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/main/text-sanitizer.js
@@ -105,7 +105,7 @@ const plugin = {
     id: 'textSanitizer',
     name: 'Text Sanitizer',
     description: 'Adds a text sanitizer utility for quickly cleaning and transforming text',
-    _version: '3.2',
+    _version: '3.3',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -461,23 +461,38 @@ const plugin = {
         executeBtn.className = buttonClass;
         executeBtn.setAttribute('data-fleet-plugin', this.id);
         executeBtn.textContent = 'Execute';
-        const showExecuteFeedback = () => {
-            executeBtn.textContent = 'Executed';
+        const showExecuteSuccess = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            executeBtn.style.transition = '';
             executeBtn.style.backgroundColor = 'rgb(34, 197, 94)';
             executeBtn.style.color = 'white';
-            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
             state.executeFeedbackTimeoutId = setTimeout(() => {
-                executeBtn.textContent = 'Execute';
                 executeBtn.style.backgroundColor = '';
                 executeBtn.style.color = '';
                 state.executeFeedbackTimeoutId = null;
-            }, 3000);
+            }, 1000);
+        };
+        const showExecuteFailure = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            const prevT = executeBtn.style.transition;
+            executeBtn.style.transition = 'none';
+            executeBtn.style.backgroundColor = 'rgb(239, 68, 68)';
+            executeBtn.style.color = '#ffffff';
+            void executeBtn.offsetHeight;
+            executeBtn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            executeBtn.style.backgroundColor = '';
+            executeBtn.style.color = '';
+            state.executeFeedbackTimeoutId = setTimeout(() => {
+                executeBtn.style.transition = prevT || '';
+                state.executeFeedbackTimeoutId = null;
+            }, 500);
         };
         const onExecute = () => {
             const id = select.value;
             const action = this.actions[id];
             if (!action) return;
             const input = textarea.value || '';
+            let ok = true;
             try {
                 const output = action.run(input);
                 textarea.value = output;
@@ -486,8 +501,13 @@ const plugin = {
             } catch (e) {
                 Logger.error('Text Sanitizer: Execute failed', e);
                 textarea.value = input;
+                ok = false;
             }
-            showExecuteFeedback();
+            if (ok) {
+                showExecuteSuccess();
+            } else {
+                showExecuteFailure();
+            }
         };
         executeBtn.addEventListener('click', onExecute);
         CleanupRegistry.registerEventListener(executeBtn, 'click', onExecute);
@@ -510,31 +530,50 @@ const plugin = {
         button.title = 'Copy text';
         button.setAttribute('aria-label', 'Copy text');
 
+        const pulseCopyFailure = () => {
+            if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            state.copyFeedbackTimeoutId = setTimeout(() => {
+                button.style.transition = prevT || '';
+                state.copyFeedbackTimeoutId = null;
+            }, 500);
+        };
         const handleCopy = () => {
             const container = button.closest('[data-qa-text-sanitizer="true"]');
             const textarea = container ? container.querySelector('[data-qa-text-sanitizer-textarea="true"]') : null;
-            if (!textarea) return;
+            if (!textarea) {
+                pulseCopyFailure();
+                return;
+            }
             const text = textarea.value || '';
             if (!text) {
                 Logger.debug('Text Sanitizer: No text to copy');
+                pulseCopyFailure();
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Text Sanitizer: Copied ${text.length} chars and cleared`);
-                button.textContent = 'Copied';
+                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
-                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
                 state.copyFeedbackTimeoutId = setTimeout(() => {
-                    button.textContent = 'Copy';
                     button.style.backgroundColor = '';
                     button.style.color = '';
                     state.copyFeedbackTimeoutId = null;
-                }, 3000);
+                }, 1000);
                 textarea.value = '';
                 if (opts && opts.onAfterClear) opts.onAfterClear();
             }).catch((err) => {
                 Logger.error('Text Sanitizer: Failed to copy to clipboard', err);
+                pulseCopyFailure();
             });
         };
 

--- a/plugins/archetypes/tool-use-task-creation/main/json-editor-online.js
+++ b/plugins/archetypes/tool-use-task-creation/main/json-editor-online.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'jsonEditorOnline',
     name: 'JSON Editor Online',
     description: 'Add button that opens JSON Editor Online in a new tab. Optionally show button on each tool result to copy output and open editor.',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -183,7 +183,8 @@ const plugin = {
                 if (isHandlingClick) return;
                 isHandlingClick = true;
                 try {
-                    await this.copyResultAndOpenEditor(card, resultArea);
+                    const copyOk = await this.copyResultAndOpenEditor(card, resultArea);
+                    this._flashJsonEditorToolButton(button, copyOk);
                 } finally {
                     // Reset after a short delay to allow async operations
                     setTimeout(() => { isHandlingClick = false; }, 1000);
@@ -289,57 +290,82 @@ const plugin = {
         return null;
     },
     
+    _flashJsonEditorToolButton(button, success) {
+        if (button._fleetJsonEdFlashT) clearTimeout(button._fleetJsonEdFlashT);
+        if (success) {
+            button.style.transition = '';
+            button.style.backgroundColor = 'rgb(34, 197, 94)';
+            button.style.color = '#ffffff';
+            button._fleetJsonEdFlashT = setTimeout(() => {
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._fleetJsonEdFlashT = null;
+            }, 1000);
+        } else {
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            button._fleetJsonEdFlashT = setTimeout(() => {
+                button.style.transition = prevT || '';
+                button._fleetJsonEdFlashT = null;
+            }, 500);
+        }
+    },
+
     async copyResultAndOpenEditor(card, resultArea) {
-        // Prevent double execution
         if (this._copying) {
-            return;
+            return false;
         }
         this._copying = true;
-        
+        let copyOk = false;
+
         try {
             Logger.log('Copying result and opening JSON Editor Online');
-            
-            // Find the result content div (the one with the actual JSON/text)
+
             const resultContent = this.findResultContent(resultArea);
             if (resultContent) {
-                try {
-                    // Extract text content
-                    const textContent = resultContent.textContent || resultContent.innerText || '';
-                    
-                    if (textContent.trim()) {
-                        // Use Clipboard API to copy directly
-                        await navigator.clipboard.writeText(textContent);
-                        Logger.log('✓ Copied result content to clipboard');
-                    } else {
-                        Logger.warn('Result content is empty');
-                    }
-                } catch (e) {
-                    Logger.warn('Failed to copy to clipboard:', e);
-                    // Fallback: try using document.execCommand for older browsers
+                const textContent = (resultContent.textContent || resultContent.innerText || '').trim();
+                if (textContent) {
                     try {
-                        const textArea = document.createElement('textarea');
-                        textArea.value = resultContent.textContent || resultContent.innerText || '';
-                        textArea.style.position = 'fixed';
-                        textArea.style.opacity = '0';
-                        document.body.appendChild(textArea);
-                        textArea.select();
-                        document.execCommand('copy');
-                        document.body.removeChild(textArea);
-                        Logger.log('✓ Copied result content to clipboard (fallback method)');
-                    } catch (fallbackError) {
-                        Logger.warn('Fallback copy method also failed:', fallbackError);
+                        await navigator.clipboard.writeText(textContent);
+                        copyOk = true;
+                        Logger.log('✓ Copied result content to clipboard');
+                    } catch (e) {
+                        Logger.warn('Failed to copy to clipboard:', e);
+                        try {
+                            const textArea = document.createElement('textarea');
+                            textArea.value = textContent;
+                            textArea.style.position = 'fixed';
+                            textArea.style.opacity = '0';
+                            document.body.appendChild(textArea);
+                            textArea.select();
+                            copyOk = document.execCommand('copy');
+                            document.body.removeChild(textArea);
+                            if (copyOk) {
+                                Logger.log('✓ Copied result content to clipboard (fallback method)');
+                            }
+                        } catch (fallbackError) {
+                            Logger.warn('Fallback copy method also failed:', fallbackError);
+                        }
                     }
+                } else {
+                    Logger.warn('Result content is empty');
                 }
             } else {
                 Logger.warn('Result content div not found, opening editor anyway');
             }
-            
-            // Open JSON Editor Online in new tab
+
             window.open('https://jsoneditoronline.org', '_blank');
             Logger.log('✓ Opened JSON Editor Online');
         } finally {
             this._copying = false;
         }
+        return copyOk;
     },
     
     findResultContent(resultArea) {

--- a/plugins/archetypes/tool-use-task-creation/main/text-sanitizer.js
+++ b/plugins/archetypes/tool-use-task-creation/main/text-sanitizer.js
@@ -105,7 +105,7 @@ const plugin = {
     id: 'textSanitizer',
     name: 'Text Sanitizer',
     description: 'Adds a text sanitizer utility for quickly cleaning and transforming text',
-    _version: '3.2',
+    _version: '3.3',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -461,23 +461,38 @@ const plugin = {
         executeBtn.className = buttonClass;
         executeBtn.setAttribute('data-fleet-plugin', this.id);
         executeBtn.textContent = 'Execute';
-        const showExecuteFeedback = () => {
-            executeBtn.textContent = 'Executed';
+        const showExecuteSuccess = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            executeBtn.style.transition = '';
             executeBtn.style.backgroundColor = 'rgb(34, 197, 94)';
             executeBtn.style.color = 'white';
-            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
             state.executeFeedbackTimeoutId = setTimeout(() => {
-                executeBtn.textContent = 'Execute';
                 executeBtn.style.backgroundColor = '';
                 executeBtn.style.color = '';
                 state.executeFeedbackTimeoutId = null;
-            }, 3000);
+            }, 1000);
+        };
+        const showExecuteFailure = () => {
+            if (state.executeFeedbackTimeoutId) clearTimeout(state.executeFeedbackTimeoutId);
+            const prevT = executeBtn.style.transition;
+            executeBtn.style.transition = 'none';
+            executeBtn.style.backgroundColor = 'rgb(239, 68, 68)';
+            executeBtn.style.color = '#ffffff';
+            void executeBtn.offsetHeight;
+            executeBtn.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            executeBtn.style.backgroundColor = '';
+            executeBtn.style.color = '';
+            state.executeFeedbackTimeoutId = setTimeout(() => {
+                executeBtn.style.transition = prevT || '';
+                state.executeFeedbackTimeoutId = null;
+            }, 500);
         };
         const onExecute = () => {
             const id = select.value;
             const action = this.actions[id];
             if (!action) return;
             const input = textarea.value || '';
+            let ok = true;
             try {
                 const output = action.run(input);
                 textarea.value = output;
@@ -486,8 +501,13 @@ const plugin = {
             } catch (e) {
                 Logger.error('Text Sanitizer: Execute failed', e);
                 textarea.value = input;
+                ok = false;
             }
-            showExecuteFeedback();
+            if (ok) {
+                showExecuteSuccess();
+            } else {
+                showExecuteFailure();
+            }
         };
         executeBtn.addEventListener('click', onExecute);
         CleanupRegistry.registerEventListener(executeBtn, 'click', onExecute);
@@ -510,31 +530,50 @@ const plugin = {
         button.title = 'Copy text';
         button.setAttribute('aria-label', 'Copy text');
 
+        const pulseCopyFailure = () => {
+            if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+            const prevT = button.style.transition;
+            button.style.transition = 'none';
+            button.style.backgroundColor = 'rgb(239, 68, 68)';
+            button.style.color = '#ffffff';
+            void button.offsetHeight;
+            button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            button.style.backgroundColor = '';
+            button.style.color = '';
+            state.copyFeedbackTimeoutId = setTimeout(() => {
+                button.style.transition = prevT || '';
+                state.copyFeedbackTimeoutId = null;
+            }, 500);
+        };
         const handleCopy = () => {
             const container = button.closest('[data-qa-text-sanitizer="true"]');
             const textarea = container ? container.querySelector('[data-qa-text-sanitizer-textarea="true"]') : null;
-            if (!textarea) return;
+            if (!textarea) {
+                pulseCopyFailure();
+                return;
+            }
             const text = textarea.value || '';
             if (!text) {
                 Logger.debug('Text Sanitizer: No text to copy');
+                pulseCopyFailure();
                 return;
             }
             navigator.clipboard.writeText(text).then(() => {
                 Logger.log(`Text Sanitizer: Copied ${text.length} chars and cleared`);
-                button.textContent = 'Copied';
+                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
+                button.style.transition = '';
                 button.style.backgroundColor = 'rgb(34, 197, 94)';
                 button.style.color = 'white';
-                if (state.copyFeedbackTimeoutId) clearTimeout(state.copyFeedbackTimeoutId);
                 state.copyFeedbackTimeoutId = setTimeout(() => {
-                    button.textContent = 'Copy';
                     button.style.backgroundColor = '';
                     button.style.color = '';
                     state.copyFeedbackTimeoutId = null;
-                }, 3000);
+                }, 1000);
                 textarea.value = '';
                 if (opts && opts.onAfterClear) opts.onAfterClear();
             }).catch((err) => {
                 Logger.error('Text Sanitizer: Failed to copy to clipboard', err);
+                pulseCopyFailure();
             });
         };
 

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.5',
+    _version: '2.6',
     enabledByDefault: false,
     phase: 'core',
 
@@ -371,7 +371,9 @@ const plugin = {
             },
             onToggle: () => this._updateVisibility(state, !state.isVisible),
             onClear: () => this._clearLogs(state),
-            onCopyAll: () => this._copyAll(state),
+            onCopyAll: () => {
+                void this._copyAll(state);
+            },
             onMinimize: () => this._updateVisibility(state, false),
             onSearch: (event) => {
                 state.searchQuery = event.target.value.trim().toLowerCase();
@@ -501,7 +503,10 @@ const plugin = {
             entry.style.background = 'transparent';
         });
         entry.addEventListener('click', () => {
-            this._copyToClipboard(message);
+            void (async () => {
+                const ok = await this._copyToClipboard(message);
+                this._flashDevLoggerCopyFeedback(entry, ok);
+            })();
         });
 
         return entry;
@@ -591,17 +596,52 @@ const plugin = {
         this._updateNewLogIndicator(state);
     },
 
-    _copyAll(state) {
+    async _copyAll(state) {
         const text = state.logs.map((log) => log.text).join('\n');
-        this._copyToClipboard(text);
+        const ui = state.ui;
+        const btn = ui && ui.copyButton;
+        const ok = await this._copyToClipboard(text);
+        if (btn) {
+            this._flashDevLoggerCopyFeedback(btn, ok);
+        }
+        if (!ok && text) {
+            Logger.warn('Dev logger: copy all to clipboard failed');
+        }
     },
 
-    _copyToClipboard: async function(text) {
-        if (!text) return;
+    _flashDevLoggerCopyFeedback(targetEl, success) {
+        if (targetEl._fleetLoggerCopyT) clearTimeout(targetEl._fleetLoggerCopyT);
+        if (success) {
+            targetEl.style.transition = '';
+            targetEl.style.backgroundColor = 'rgb(34, 197, 94)';
+            targetEl.style.color = '#ffffff';
+            targetEl._fleetLoggerCopyT = setTimeout(() => {
+                targetEl.style.backgroundColor = '';
+                targetEl.style.color = '';
+                targetEl._fleetLoggerCopyT = null;
+            }, 1000);
+        } else {
+            const prevT = targetEl.style.transition;
+            targetEl.style.transition = 'none';
+            targetEl.style.backgroundColor = 'rgb(239, 68, 68)';
+            targetEl.style.color = '#ffffff';
+            void targetEl.offsetHeight;
+            targetEl.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+            targetEl.style.backgroundColor = '';
+            targetEl.style.color = '';
+            targetEl._fleetLoggerCopyT = setTimeout(() => {
+                targetEl.style.transition = prevT || '';
+                targetEl._fleetLoggerCopyT = null;
+            }, 500);
+        }
+    },
+
+    async _copyToClipboard(text) {
+        if (!text) return false;
         try {
             if (navigator.clipboard && navigator.clipboard.writeText) {
                 await navigator.clipboard.writeText(text);
-                return;
+                return true;
             }
         } catch (e) {
             // Fall back below
@@ -613,12 +653,14 @@ const plugin = {
         temp.style.top = '-1000px';
         document.body.appendChild(temp);
         temp.select();
+        let ok = false;
         try {
-            document.execCommand('copy');
+            ok = document.execCommand('copy');
         } catch (e) {
-            // Ignore
+            ok = false;
         }
         document.body.removeChild(temp);
+        return ok;
     },
 
     _setupLogging(state, context) {


### PR DESCRIPTION
## Summary

This PR enhances the QA workflow with improved copy functionality, standardized feedback, and new automation features. The main focus is on the Request Revisions modal, where auto-paste has been replaced with copy buttons, and guideline access has been streamlined. Additionally, a new Hide Grading Autoclick plugin automates grading panel interactions for QA archetypes.

## Changes

### Request Revisions Modal Improvements

- **Replaced auto-paste with copy buttons**: The Task and Grading auto-paste functionality has been replaced with "Copy Prompt" and "Copy Verifier Output" buttons, giving users explicit control over when content is copied to the clipboard
- **Added QA Guidelines button**: A new button under "Where are the issues?" opens QA Guidelines in a new tab for both qa-tool-use and qa-comp-use archetypes
- **Standardized copy feedback**: All copy buttons now use color-only feedback (1s green flash on success, 0.5s red pulse on failure) without label swapping, providing consistent visual feedback across the extension

### Copy Verifier Output Enhancements

- **Support for checklist verifiers**: Extended copy-verifier-output to work with both classic stdout output and new Score/checklist verifier UI
- **Improved click handling**: Fixed click event handling to use window capture and direct listeners, ensuring copy operations work reliably
- **Better formatting**: Added blank line before Failures heading for improved readability

### New Plugin: Hide Grading Autoclick

- Added `hide-grading-autoclick.js` plugin for both qa-tool-use and qa-comp-use archetypes
- Automatically clicks "Hide Grading" button once when it becomes available after page load
- Uses observer-based architecture with proper state management to avoid duplicate clicks

### Additional Improvements

- **Copy Result Params**: Button now hides when target grid doesn't exist
- **Text sanitizer**: Updated across multiple archetypes for consistency
- **Logger panel**: Enhanced with improved functionality
- **Prompt diff highlight**: Standardized across multiple archetypes
- **JSON editor**: Updated deprecated versions for consistency

## New Plugins

| Plugin | Archetype | Version | Description |
|--------|-----------|---------|-------------|
| `hide-grading-autoclick.js` | qa-tool-use | 1.0 | Automatically clicks "Hide Grading" button when available |
| `hide-grading-autoclick.js` | qa-comp-use | 1.0 | Automatically clicks "Hide Grading" button when available |

## Commit History

- fcbff40 feat(request-revisions): add QA Guidelines button to both revision modals
- 9eba50d feat(ux): standardize copy feedback (1s green, 0.5s red pulse, no label swap)
- 780e920 Request Revisions: color-only copy success + red failure pulse
- 5a784f8 Request Revisions: replace Task auto-paste with Copy Prompt button
- c8d7c10 Request Revisions: replace Grading auto-paste with Copy Verifier Output
- d68cf4a Request Revisions: single guideline open buttons (Meridian/Kinesis)
- e1a3ffa feat(copy-verifier): add blank line before Failures heading
- bc6cd5c Hide Copy Result Params button when target grid doesn't exist
- 5ec9f66 fix(copy-verifier): escape dot in space-y-0.5 selector
- beab3a5 fix(copy-verifier): use page window, pointerdown, and direct listeners
- 52ca8b7 fix(copy-verifier): handle clicks via window capture so copy runs
- 8bc7b85 feat(verifier): copy + auto-paste for Score/checklist verifier UI
- 0246521 feat(qa): add Hide Grading Autoclick for qa-tool-use and qa-comp-use

## Stats

```
36 files changed, 2392 insertions(+), 1382 deletions(-)
```
