### PR TITLE
Add dispute-detail verifier plugins and centralize fleet branch sync

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.75",
+  "archetypesVersion": "6.77",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -579,6 +579,11 @@
           "name": "clear-search.js",
           "version": "1.0",
           "hash": "sha256-80b40af93a2889dc851f876b304f8dd015080f0d6c3acd2f3e5bc32a29795e23"
+        },
+        {
+          "name": "create-instance-autoclick.js",
+          "version": "1.1",
+          "hash": "sha256-347d7d13d41af849764a88acbcf392c3b2e0c5a487cf2c6e456c2fd930d3004f"
         },
         {
           "name": "favorites.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.78",
+  "archetypesVersion": "6.79",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.9",
-          "hash": "sha256-9e77d8f75789817ee4c43f6d71d1886a75dbb8c69d7e92e1769efe2fc5e6ba50"
+          "version": "2.0",
+          "hash": "sha256-1b13b3bdc92749882de73ad3d7304cdccae2d00f54a745c7401fa79994e20158"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.8",
-          "hash": "sha256-0899b7312a8dc2bcba72aad9d236263c30033589af95407200c33420427fb906"
+          "version": "1.9",
+          "hash": "sha256-bdbecbdf73ac1ccd439306cb4a8981f5e4bd4b6fb965d06afa2b40964ec0a061"
         },
         {
           "name": "copy-result-params.js",
@@ -612,8 +612,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.0",
-          "hash": "sha256-10d2779718e3e2c67981808d69dd2c568557d348bffa53bbd3a8e482459dab01"
+          "version": "1.1",
+          "hash": "sha256-4969571a31d8dda112975bffa8d42c30c570812e49d7e7f30cc07d79130554f0"
         },
         {
           "name": "verifier-diff-highlight-improved.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.77",
+  "archetypesVersion": "6.78",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -609,6 +609,11 @@
           "name": "tool-description-truncate.js",
           "version": "1.0",
           "hash": "sha256-0d5430a1eae172431ca9692c3809b478d58d2779ccb30ea4cb277a3845f2d2d1"
+        },
+        {
+          "name": "copy-verifier-output.js",
+          "version": "1.0",
+          "hash": "sha256-10d2779718e3e2c67981808d69dd2c568557d348bffa53bbd3a8e482459dab01"
         },
         {
           "name": "verifier-diff-highlight-improved.js",

--- a/dev/module-workflow.md
+++ b/dev/module-workflow.md
@@ -92,6 +92,10 @@ Scripts that touch `fleet.user.js` (checkout, release, test) ensure:
 - Updates `fleet.user.js` for the new branch, commits with message "Sync branch config", pushes.
 - Prints the GitHub tree URL; install the userscript from that URL for development.
 
+**sync-branch-config.sh** — `./dev/utils/sync-branch-config.sh [-m] [-c] [--dry-run] [--fleet PATH] [--branch NAME]`
+
+- Aligns `fleet.user.js` with the current git branch (`-m` treats the branch as `main`). `-c` commits the file if it changed. `--dry-run` prints the planned field updates without writing. `--fleet` uses a specific file path (default: `<repo>/fleet.user.js`). `--branch` uses a branch name instead of `git` HEAD (ignored when `-m` is set). Used by `checkout.sh` and `test.sh`; safe to run by hand after switching branches.
+
 **push.sh** — `./utils/push.sh [--dry-run] ["optional commit message"]`
 
 - Lists uncommitted changes; for each changed versioned file (plugins, fleet.user.js, settings-modal docs), bumps version by 0.1 if working tree is not already higher than HEAD. Updates `archetypes.json` settingsModalDocs for .md changes.
@@ -106,8 +110,8 @@ Scripts that touch `fleet.user.js` (checkout, release, test) ensure:
 
 **test.sh** — `./utils/test.sh [--dry-run] <new_branch_name>`
 
-- Requires clean working tree. Branch name must not be `main` and must not exist. Depends on `sync-branch-config.sh` in `utils/` (or `local-utils/` if symlinked/copied). `--dry-run` prints planned changes without modifying anything.
-- Fetches `origin/main`, creates branch from `main`, runs `sync-branch-config.sh` to update `fleet.user.js`, commits and pushes.
+- Requires clean working tree. Branch name must not be `main` and must not exist. Depends on `sync-branch-config.sh` in the same directory as the script (e.g. `dev/utils/`). `--dry-run` prints planned changes without modifying anything.
+- Fetches `origin/main`, creates a new branch from the **current** branch (so non-fleet files stay as on your branch), replaces `fleet.user.js` with `origin/main`’s copy, runs `sync-branch-config.sh` to update `fleet.user.js` for the new branch name, commits and pushes.
 - Use to validate an upcoming main release: install the test-branch script, use it as normal, then merge to main with `release.sh` when satisfied.
 
 **update-versions.sh** — `./utils/update-versions.sh [--dry-run] [options]`

--- a/dev/utils/checkout.sh
+++ b/dev/utils/checkout.sh
@@ -50,156 +50,29 @@ if [[ -z "$BRANCH" ]]; then
   exit 1
 fi
 
-if [[ "$dry_run" != true ]]; then
-  git -C "$root" checkout main
-  git -C "$root" checkout -b "$BRANCH"
-fi
-
-# Inlined sync-branch-config.sh logic
-file_path="$root/fleet.user.js"
-if [[ ! -f "$file_path" ]]; then
-  echo "[error] fleet.user.js not found: $file_path"
+sync_script="$script_dir/sync-branch-config.sh"
+if [[ ! -f "$sync_script" ]]; then
+  echo "[error] sync-branch-config.sh not found: $sync_script" >&2
   exit 1
 fi
+
 if [[ "$dry_run" == true ]]; then
-  branch="$BRANCH"
   echo "[info] Dry run - would create branch: $BRANCH (no git or file changes)"
-else
-  branch="$(git -C "$root" rev-parse --abbrev-ref HEAD)"
-  echo "[info] Current branch: $branch"
-fi
-header_version="$(
-  awk '/^\/\/ @version[[:space:]]+/ {print $3; exit}' "$file_path"
-)"
-if [[ -z "$header_version" ]]; then
-  echo "[error] Could not find @version in header"
-  exit 1
-fi
-needs_name_change() {
-  BRANCH="$branch" perl -0ne '
-    if (/^\/\/ \@name\s+(\[[^\]]+\]\s+)?(.+?)(?:\r?\n|\z)/m) {
-      my ($tag, $name) = ($1, $2);
-      $name =~ s/^\s+|\s+$//g;
-      if ($ENV{BRANCH} eq "main") {
-        print($tag ? "1" : "0");
-      } else {
-        my $expected = "[" . $ENV{BRANCH} . "] ";
-        print((!defined $tag || $tag ne $expected) ? "1" : "0");
-      }
-    }
-  ' "$file_path"
-}
-needs_download_url_change() {
-  BRANCH="$branch" perl -0ne '
-    if (/^\/\/ @downloadURL\s+https:\/\/raw\.githubusercontent\.com\/[^\/]+\/[^\/]+\/([^\/]+)\/fleet\.user\.js/m) {
-      print($1 ne $ENV{BRANCH} ? "1" : "0");
-    }
-  ' "$file_path"
-}
-needs_update_url_change() {
-  BRANCH="$branch" perl -0ne '
-    if (/^\/\/ @updateURL\s+https:\/\/raw\.githubusercontent\.com\/[^\/]+\/[^\/]+\/([^\/]+)\/fleet\.user\.js/m) {
-      print($1 ne $ENV{BRANCH} ? "1" : "0");
-    }
-  ' "$file_path"
-}
-needs_github_config_change() {
-  BRANCH="$branch" perl -0ne '
-    if (/branch:\s*[\"\x27]([^\"\x27]+)[\"\x27]/) {
-      print($1 ne $ENV{BRANCH} ? "1" : "0");
-    }
-  ' "$file_path"
-}
-needs_version_constant_change() {
-  HEADER_VERSION="$header_version" perl -0ne '
-    if (/const VERSION\s*=\s*[\"\x27]([^\"\x27]+)[\"\x27]/) {
-      print($1 ne $ENV{HEADER_VERSION} ? "1" : "0");
-    }
-  ' "$file_path"
-}
-name_change="$(needs_name_change)"
-download_change="$(needs_download_url_change)"
-update_change="$(needs_update_url_change)"
-github_change="$(needs_github_config_change)"
-version_change="$(needs_version_constant_change)"
-content="$(cat "$file_path")"
-new_content="$(printf "%s" "$content" | BRANCH="$branch" HEADER_VERSION="$header_version" perl -0pe '
-  s{(// \@name\s+)(\[[^\]]+\]\s+)?(.+?)(\r?\n|\z)}{
-    my ($p, $tag, $name, $eol) = ($1, $2, $3, $4);
-    $name =~ s/^\s+|\s+$//g;
-    ($ENV{BRANCH} eq "main" ? $p . $name : $p . "[" . $ENV{BRANCH} . "] " . $name) . $eol
-  }mge;
-  s{(// @(?:download|update)URL\s+https://raw\.githubusercontent\.com/[^/]+/[^/]+/)([^/]+)(/fleet\.user\.js)}{$1.$ENV{BRANCH}.$3}ge;
-  s{(branch:\s*[\"\x27])([^\"\x27]+)([\"\x27])}{$1.$ENV{BRANCH}.$3}ge;
-  s{(const VERSION\s*=\s*[\"\x27])([^\"\x27]+)([\"\x27])}{$1.$ENV{HEADER_VERSION}.$3}ge;
-')"
-if [[ "$new_content" != "$content" ]]; then
-  if [[ "$dry_run" == false ]]; then
-    printf "%s" "$new_content" > "$file_path"
-  fi
-fi
-
-# Enumerate every change (for dry run or summary)
-print_fleet_changes() {
-  local c="$1" n="$2"
-  if [[ "$name_change" == "1" ]]; then
-    local cur new
-    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@name\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@name\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    echo "  fleet.user.js: @name: \"$cur\" -> \"$new\""
-  fi
-  if [[ "$download_change" == "1" ]]; then
-    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@downloadURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@downloadURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    echo "  fleet.user.js: @downloadURL: \"$cur\" -> \"$new\""
-  fi
-  if [[ "$update_change" == "1" ]]; then
-    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@updateURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@updateURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    echo "  fleet.user.js: @updateURL: \"$cur\" -> \"$new\""
-  fi
-  if [[ "$github_change" == "1" ]]; then
-    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /branch:\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /branch:\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    echo "  fleet.user.js: GITHUB_CONFIG.branch: \"$cur\" -> \"$new\""
-  fi
-  if [[ "$version_change" == "1" ]]; then
-    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /const VERSION\s*=\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /const VERSION\s*=\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-    echo "  fleet.user.js: const VERSION: \"$cur\" -> \"$new\""
-  fi
-}
-
-changed=()
-if [[ "$name_change" == "1" ]]; then changed+=("@name"); fi
-if [[ "$download_change" == "1" ]]; then changed+=("@downloadURL"); fi
-if [[ "$update_change" == "1" ]]; then changed+=("@updateURL"); fi
-if [[ "$github_change" == "1" ]]; then changed+=("GITHUB_CONFIG.branch"); fi
-if [[ "$version_change" == "1" ]]; then changed+=("VERSION constant"); fi
-if [[ "${#changed[@]}" -gt 0 ]]; then
-  if [[ "$dry_run" == true ]]; then
-    echo "[dry-run] Would update fleet.user.js:"
-    print_fleet_changes "$content" "$new_content"
-  else
-    echo "[info] Updated: ${changed[*]}"
-  fi
-else
-  if [[ "$dry_run" == true ]]; then
-    echo "[dry-run] fleet.user.js: no changes (all values already in sync for branch $branch)"
-  else
-    echo "[info] All values already in sync - no changes needed"
-  fi
-fi
-
-if [[ "$dry_run" == true ]]; then
+  "$sync_script" --dry-run --branch "$BRANCH"
   echo "[dry-run] Would run: git checkout main"
   echo "[dry-run] Would run: git checkout -b $BRANCH"
-  [[ "${#changed[@]}" -gt 0 ]] && echo "[dry-run] Would run: (write fleet.user.js with above changes)"
+  echo "[dry-run] Would run: $sync_script"
   echo "[dry-run] Would run: git add ."
   echo "[dry-run] Would run: git commit -m \"Sync branch config\""
   echo "[dry-run] Would run: git push -u origin $BRANCH"
   exit 0
 fi
+
+git -C "$root" checkout main
+git -C "$root" checkout -b "$BRANCH"
+echo "[info] Current branch: $(git -C "$root" rev-parse --abbrev-ref HEAD)"
+
+"$sync_script"
 
 git -C "$root" add .
 git -C "$root" commit -m "Sync branch config"

--- a/dev/utils/sync-branch-config.sh
+++ b/dev/utils/sync-branch-config.sh
@@ -3,9 +3,12 @@
 # sync-branch-config.sh — Update fleet.user.js for the current git branch
 #
 # Usage:
-#   ./sync-branch-config.sh        # use current git branch
-#   ./sync-branch-config.sh -m     # update as if on main (ignore actual branch)
-#   ./sync-branch-config.sh -c     # after sync, commit fleet.user.js if it changed
+#   ./sync-branch-config.sh              # use current git branch, default fleet path
+#   ./sync-branch-config.sh -m           # update as if on main (ignore actual branch)
+#   ./sync-branch-config.sh -c           # after sync, commit fleet.user.js if it changed
+#   ./sync-branch-config.sh --dry-run    # print planned changes; do not write or commit
+#   ./sync-branch-config.sh --fleet PATH # read/write this file instead of <root>/fleet.user.js
+#   ./sync-branch-config.sh --branch NAME # use NAME instead of git HEAD (ignored if -m)
 #
 # Run from repo root (or anywhere; uses git to find root). Updates fleet.user.js:
 #   - @name: add "[branch] " prefix when not main, remove when main
@@ -13,30 +16,60 @@
 #   - GITHUB_CONFIG.branch: set to current branch
 #   - const VERSION: set from header @version
 #
-# Used by test.sh (after creating a branch) and by release.sh (inlined for main after merge).
+# Used by checkout.sh and test.sh; may be run directly.
 #
 
 set -euo pipefail
 
 use_main=false
 commit_after=false
-while getopts "mc" opt; do
-  case "$opt" in
-    m) use_main=true ;;
-    c) commit_after=true ;;
-    *) echo "Usage: $0 [-m] [-c]" >&2; exit 1 ;;
+dry_run=false
+fleet_path_arg=""
+branch_override=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m) use_main=true; shift ;;
+    -c) commit_after=true; shift ;;
+    -mc|-cm) use_main=true; commit_after=true; shift ;;
+    --dry-run) dry_run=true; shift ;;
+    --fleet)
+      if [[ $# -lt 2 ]]; then
+        echo "[error] --fleet requires a path" >&2
+        exit 1
+      fi
+      fleet_path_arg="$2"
+      shift 2
+      ;;
+    --branch)
+      if [[ $# -lt 2 ]]; then
+        echo "[error] --branch requires a name" >&2
+        exit 1
+      fi
+      branch_override="$2"
+      shift 2
+      ;;
+    *)
+      echo "Usage: $0 [-m] [-c] [--dry-run] [--fleet PATH] [--branch NAME]" >&2
+      exit 1
+      ;;
   esac
 done
-shift $((OPTIND - 1))
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(git -C "$script_dir" rev-parse --show-toplevel)"
-file_path="$root/fleet.user.js"
+file_path="${fleet_path_arg:-$root/fleet.user.js}"
 
 if [[ "$use_main" == true ]]; then
   branch="main"
+elif [[ -n "$branch_override" ]]; then
+  branch="$branch_override"
 else
   branch="$(git -C "$root" rev-parse --abbrev-ref HEAD)"
+fi
+
+if [[ "$dry_run" == true ]]; then
+  commit_after=false
 fi
 
 if [[ ! -f "$file_path" ]]; then
@@ -64,17 +97,111 @@ new_content="$(printf "%s" "$content" | BRANCH="$branch" HEADER_VERSION="$header
   s{(const VERSION\s*=\s*[\"\x27])([^\"\x27]+)([\"\x27])}{$1.$ENV{HEADER_VERSION}.$3}ge;
 ')"
 
-changed=false
+needs_name_change() {
+  BRANCH="$branch" perl -0ne '
+    if (/^\/\/ \@name\s+(\[[^\]]+\]\s+)?(.+?)(?:\r?\n|\z)/m) {
+      my ($tag, $name) = ($1, $2);
+      $name =~ s/^\s+|\s+$//g;
+      if ($ENV{BRANCH} eq "main") {
+        print($tag ? "1" : "0");
+      } else {
+        my $expected = "[" . $ENV{BRANCH} . "] ";
+        print((!defined $tag || $tag ne $expected) ? "1" : "0");
+      }
+    }
+  ' "$file_path"
+}
+needs_download_url_change() {
+  BRANCH="$branch" perl -0ne '
+    if (/^\/\/ @downloadURL\s+https:\/\/raw\.githubusercontent\.com\/[^\/]+\/[^\/]+\/([^\/]+)\/fleet\.user\.js/m) {
+      print($1 ne $ENV{BRANCH} ? "1" : "0");
+    }
+  ' "$file_path"
+}
+needs_update_url_change() {
+  BRANCH="$branch" perl -0ne '
+    if (/^\/\/ @updateURL\s+https:\/\/raw\.githubusercontent\.com\/[^\/]+\/[^\/]+\/([^\/]+)\/fleet\.user\.js/m) {
+      print($1 ne $ENV{BRANCH} ? "1" : "0");
+    }
+  ' "$file_path"
+}
+needs_github_config_change() {
+  BRANCH="$branch" perl -0ne '
+    if (/branch:\s*[\"\x27]([^\"\x27]+)[\"\x27]/) {
+      print($1 ne $ENV{BRANCH} ? "1" : "0");
+    }
+  ' "$file_path"
+}
+needs_version_constant_change() {
+  HEADER_VERSION="$header_version" perl -0ne '
+    if (/const VERSION\s*=\s*[\"\x27]([^\"\x27]+)[\"\x27]/) {
+      print($1 ne $ENV{HEADER_VERSION} ? "1" : "0");
+    }
+  ' "$file_path"
+}
+
+print_fleet_changes() {
+  local c="$1" n="$2"
+  local cur new
+  if [[ "$name_change" == "1" ]]; then
+    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@name\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@name\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    echo "  fleet.user.js: @name: \"$cur\" -> \"$new\""
+  fi
+  if [[ "$download_change" == "1" ]]; then
+    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@downloadURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@downloadURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    echo "  fleet.user.js: @downloadURL: \"$cur\" -> \"$new\""
+  fi
+  if [[ "$update_change" == "1" ]]; then
+    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@updateURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@updateURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    echo "  fleet.user.js: @updateURL: \"$cur\" -> \"$new\""
+  fi
+  if [[ "$github_change" == "1" ]]; then
+    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /branch:\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /branch:\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    echo "  fleet.user.js: GITHUB_CONFIG.branch: \"$cur\" -> \"$new\""
+  fi
+  if [[ "$version_change" == "1" ]]; then
+    cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /const VERSION\s*=\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    new="$(printf '%s' "$n" | perl -0ne 'print $1 if /const VERSION\s*=\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    echo "  fleet.user.js: const VERSION: \"$cur\" -> \"$new\""
+  fi
+}
+
+if [[ "$dry_run" == true ]]; then
+  name_change="$(needs_name_change)"
+  download_change="$(needs_download_url_change)"
+  update_change="$(needs_update_url_change)"
+  github_change="$(needs_github_config_change)"
+  version_change="$(needs_version_constant_change)"
+  changed=()
+  [[ "$name_change" == "1" ]] && changed+=("@name")
+  [[ "$download_change" == "1" ]] && changed+=("@downloadURL")
+  [[ "$update_change" == "1" ]] && changed+=("@updateURL")
+  [[ "$github_change" == "1" ]] && changed+=("GITHUB_CONFIG.branch")
+  [[ "$version_change" == "1" ]] && changed+=("VERSION constant")
+  if [[ "${#changed[@]}" -gt 0 ]]; then
+    echo "[dry-run] Would update fleet.user.js:"
+    print_fleet_changes "$content" "$new_content"
+  else
+    echo "[dry-run] fleet.user.js: no changes (all values already in sync for branch $branch)"
+  fi
+  exit 0
+fi
+
+changed_write=false
 if [[ "$new_content" != "$content" ]]; then
   printf "%s" "$new_content" > "$file_path"
-  changed=true
+  changed_write=true
   echo "[info] Synced fleet.user.js for branch: $branch"
 else
   echo "[info] fleet.user.js already in sync for branch: $branch"
 fi
 
 if [[ "$commit_after" == true ]]; then
-  if [[ "$changed" == true ]]; then
+  if [[ "$changed_write" == true ]]; then
     git -C "$root" add -- "$file_path"
     git -C "$root" commit -m "Sync fleet.user.js branch config to $branch"
     echo "[info] Committed fleet.user.js for branch: $branch"

--- a/dev/utils/sync-branch-config.sh
+++ b/dev/utils/sync-branch-config.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   ./sync-branch-config.sh        # use current git branch
 #   ./sync-branch-config.sh -m     # update as if on main (ignore actual branch)
+#   ./sync-branch-config.sh -c     # after sync, commit fleet.user.js if it changed
 #
 # Run from repo root (or anywhere; uses git to find root). Updates fleet.user.js:
 #   - @name: add "[branch] " prefix when not main, remove when main
@@ -18,10 +19,12 @@
 set -euo pipefail
 
 use_main=false
-while getopts "m" opt; do
+commit_after=false
+while getopts "mc" opt; do
   case "$opt" in
     m) use_main=true ;;
-    *) echo "Usage: $0 [-m]" >&2; exit 1 ;;
+    c) commit_after=true ;;
+    *) echo "Usage: $0 [-m] [-c]" >&2; exit 1 ;;
   esac
 done
 shift $((OPTIND - 1))
@@ -61,9 +64,21 @@ new_content="$(printf "%s" "$content" | BRANCH="$branch" HEADER_VERSION="$header
   s{(const VERSION\s*=\s*[\"\x27])([^\"\x27]+)([\"\x27])}{$1.$ENV{HEADER_VERSION}.$3}ge;
 ')"
 
+changed=false
 if [[ "$new_content" != "$content" ]]; then
   printf "%s" "$new_content" > "$file_path"
+  changed=true
   echo "[info] Synced fleet.user.js for branch: $branch"
 else
   echo "[info] fleet.user.js already in sync for branch: $branch"
+fi
+
+if [[ "$commit_after" == true ]]; then
+  if [[ "$changed" == true ]]; then
+    git -C "$root" add -- "$file_path"
+    git -C "$root" commit -m "Sync fleet.user.js branch config to $branch"
+    echo "[info] Committed fleet.user.js for branch: $branch"
+  else
+    echo "[info] No commit (-c): fleet.user.js was already in sync"
+  fi
 fi

--- a/dev/utils/test.sh
+++ b/dev/utils/test.sh
@@ -38,6 +38,11 @@ set -euo pipefail
 # Repo root from script location (use git so scripts in utils/ or dev/utils/ both work)
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+sync_script="$script_dir/sync-branch-config.sh"
+if [[ ! -f "$sync_script" ]]; then
+  echo "[error] sync-branch-config.sh not found: $sync_script" >&2
+  exit 1
+fi
 
 usage() {
   cat <<'EOF'
@@ -99,88 +104,16 @@ if [[ "$dry_run" == true ]]; then
     echo "[error] fleet.user.js not found on origin/main"
     exit 1
   fi
-  content="$(git -C "$root" show origin/main:fleet.user.js)"
-  header_version="$(printf '%s' "$content" | awk '/^\/\/ @version[[:space:]]+/ {print $3; exit}')"
-  if [[ -z "$header_version" ]]; then
-    echo "[error] Could not find @version in header of main's fleet.user.js"
-    exit 1
-  fi
-  needs_name_change() {
-    printf '%s' "$content" | BRANCH="$branch" perl -0ne '
-      if (/^\/\/ \@name\s+(\[[^\]]+\]\s+)?(.+?)(?:\r?\n|\z)/m) {
-        my ($tag, $name) = ($1, $2);
-        $name =~ s/^\s+|\s+$//g;
-        if ($ENV{BRANCH} eq "main") { print($tag ? "1" : "0"); } else {
-          my $expected = "[" . $ENV{BRANCH} . "] ";
-          print((!defined $tag || $tag ne $expected) ? "1" : "0");
-        }
-      }
-    '
-  }
-  needs_download_url_change() { printf '%s' "$content" | BRANCH="$branch" perl -0ne 'if (/^\/\/ @downloadURL\s+https:\/\/raw\.githubusercontent\.com\/[^\/]+\/[^\/]+\/([^\/]+)\/fleet\.user\.js/m) { print($1 ne $ENV{BRANCH} ? "1" : "0"); }'; }
-  needs_update_url_change() { printf '%s' "$content" | BRANCH="$branch" perl -0ne 'if (/^\/\/ @updateURL\s+https:\/\/raw\.githubusercontent\.com\/[^\/]+\/[^\/]+\/([^\/]+)\/fleet\.user\.js/m) { print($1 ne $ENV{BRANCH} ? "1" : "0"); }'; }
-  needs_github_config_change() { printf '%s' "$content" | BRANCH="$branch" perl -0ne 'if (/branch:\s*[\"\x27]([^\"\x27]+)[\"\x27]/) { print($1 ne $ENV{BRANCH} ? "1" : "0"); }'; }
-  needs_version_constant_change() { printf '%s' "$content" | HEADER_VERSION="$header_version" perl -0ne 'if (/const VERSION\s*=\s*[\"\x27]([^\"\x27]+)[\"\x27]/) { print($1 ne $ENV{HEADER_VERSION} ? "1" : "0"); }'; }
-  name_change="$(needs_name_change)"
-  download_change="$(needs_download_url_change)"
-  update_change="$(needs_update_url_change)"
-  github_change="$(needs_github_config_change)"
-  version_change="$(needs_version_constant_change)"
-  new_content="$(printf "%s" "$content" | BRANCH="$branch" HEADER_VERSION="$header_version" perl -0pe '
-    s{(// \@name\s+)(\[[^\]]+\]\s+)?(.+?)(\r?\n|\z)}{
-      my ($p, $tag, $name, $eol) = ($1, $2, $3, $4);
-      $name =~ s/^\s+|\s+$//g;
-      ($ENV{BRANCH} eq "main" ? $p . $name : $p . "[" . $ENV{BRANCH} . "] " . $name) . $eol
-    }mge;
-    s{(// @(?:download|update)URL\s+https://raw\.githubusercontent\.com/[^/]+/[^/]+/)([^/]+)(/fleet\.user\.js)}{$1.$ENV{BRANCH}.$3}ge;
-    s{(branch:\s*[\"\x27])([^\"\x27]+)([\"\x27])}{$1.$ENV{BRANCH}.$3}ge;
-    s{(const VERSION\s*=\s*[\"\x27])([^\"\x27]+)([\"\x27])}{$1.$ENV{HEADER_VERSION}.$3}ge;
-  ')"
-  print_fleet_changes() {
-    local c="$1" n="$2"
-    if [[ "$name_change" == "1" ]]; then
-      cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@name\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@name\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      echo "  fleet.user.js: @name: \"$cur\" -> \"$new\""
-    fi
-    if [[ "$download_change" == "1" ]]; then
-      cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@downloadURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@downloadURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      echo "  fleet.user.js: @downloadURL: \"$cur\" -> \"$new\""
-    fi
-    if [[ "$update_change" == "1" ]]; then
-      cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /^\/\/ \@updateURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      new="$(printf '%s' "$n" | perl -0ne 'print $1 if /^\/\/ \@updateURL\s+(.+?)(?:\r?\n|\z)/m' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      echo "  fleet.user.js: @updateURL: \"$cur\" -> \"$new\""
-    fi
-    if [[ "$github_change" == "1" ]]; then
-      cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /branch:\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      new="$(printf '%s' "$n" | perl -0ne 'print $1 if /branch:\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      echo "  fleet.user.js: GITHUB_CONFIG.branch: \"$cur\" -> \"$new\""
-    fi
-    if [[ "$version_change" == "1" ]]; then
-      cur="$(printf '%s' "$c" | perl -0ne 'print $1 if /const VERSION\s*=\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      new="$(printf '%s' "$n" | perl -0ne 'print $1 if /const VERSION\s*=\s*["\x27]([^"\x27]+)["\x27]/' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      echo "  fleet.user.js: const VERSION: \"$cur\" -> \"$new\""
-    fi
-  }
-  changed=()
-  [[ "$name_change" == "1" ]] && changed+=("@name")
-  [[ "$download_change" == "1" ]] && changed+=("@downloadURL")
-  [[ "$update_change" == "1" ]] && changed+=("@updateURL")
-  [[ "$github_change" == "1" ]] && changed+=("GITHUB_CONFIG.branch")
-  [[ "$version_change" == "1" ]] && changed+=("VERSION constant")
+  tmp_fleet="$(mktemp)"
+  trap 'rm -f "$tmp_fleet"' EXIT
+  git -C "$root" show origin/main:fleet.user.js >"$tmp_fleet"
   current_branch="$(git -C "$root" branch --show-current)"
   echo "[dry-run] Would create branch: $branch from current branch ($current_branch); would replace fleet.user.js with main's, then update fleet.user.js:"
-  if [[ "${#changed[@]}" -gt 0 ]]; then
-    print_fleet_changes "$content" "$new_content"
-  else
-    echo "  (no changes - already in sync for branch $branch)"
-  fi
+  "$sync_script" --dry-run --fleet "$tmp_fleet" --branch "$branch"
   echo "[dry-run] Would run: git fetch origin main"
   echo "[dry-run] Would run: git checkout -b $branch"
   echo "[dry-run] Would run: git checkout origin/main -- fleet.user.js"
-  echo "[dry-run] Would run: sync-branch-config.sh (or apply above fleet.user.js changes)"
+  echo "[dry-run] Would run: $sync_script"
   echo "[dry-run] Would run: git add ."
   echo "[dry-run] Would run: git commit -m \"Sync branch config for $branch\""
   echo "[dry-run] Would run: git push -u origin $branch"
@@ -198,7 +131,7 @@ echo "[info] Replacing fleet.user.js with main's version..."
 git -C "$root" checkout origin/main -- fleet.user.js
 
 echo "[info] Syncing branch config in fleet.user.js..."
-(cd "$root" && "$script_dir/sync-branch-config.sh")
+(cd "$root" && "$sync_script")
 
 git -C "$root" add .
 if git -C "$root" diff --cached --quiet; then

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-dispute-sync-improvements] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-sync-improvements/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-sync-improvements/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-dispute-sync-improvements',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-dispute-sync-improvements] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-sync-improvements/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-sync-improvements/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-dispute-sync-improvements',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
+++ b/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
@@ -1,0 +1,351 @@
+// ============= copy-verifier-output.js =============
+// Adds a copy button in the verifier output area: after "Stdout" (classic output) or after "Score: #" (checklist verifier).
+// Same behavior as QA archetypes; shared verifier panel DOM (see verifier-diff-highlight-improved.js).
+
+const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
+
+const plugin = {
+    id: 'copyVerifierOutput',
+    name: 'Copy Verifier Output',
+    description:
+        'Add a copy button after Stdout or Score in the verifier output panel. Click copies formatted verifier text to the clipboard',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        buttonAdded: false,
+        verifierTargetMissingLogged: false
+    },
+
+    onMutation(state, context) {
+        const scoreRow = this.findScoreRow();
+        const stdoutRow = scoreRow ? null : this.findStdoutRow();
+        const anchorRow = scoreRow || stdoutRow;
+        if (!anchorRow) {
+            if (!state.verifierTargetMissingLogged) {
+                Logger.debug('Copy Verifier Output: Stdout/Score row not found');
+                state.verifierTargetMissingLogged = true;
+            }
+            return;
+        }
+        state.verifierTargetMissingLogged = false;
+
+        if (anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
+            return;
+        }
+
+        let container;
+        if (scoreRow) {
+            container = scoreRow.closest('div.p-3');
+            if (!container) {
+                Logger.debug('Copy Verifier Output: Score card container not found');
+                return;
+            }
+        } else {
+            container = stdoutRow.closest('div.text-xs.w-full');
+            if (!container) {
+                Logger.debug('Copy Verifier Output: Stdout container not found');
+                return;
+            }
+        }
+
+        const button = this.createCopyButton(container);
+        anchorRow.appendChild(button);
+        if (!anchorRow.classList.contains('flex')) {
+            anchorRow.classList.add('flex', 'items-center', 'gap-2');
+        }
+        state.buttonAdded = true;
+        Logger.log('Copy Verifier Output: Copy button added');
+    },
+
+    getGradingPanelRoot() {
+        const reportGradingBtn = Array.from(document.querySelectorAll('button')).find(
+            (btn) => btn.textContent && btn.textContent.trim().includes('Report Grading Issues')
+        );
+        if (reportGradingBtn) {
+            const panel = reportGradingBtn.closest('[data-panel]');
+            if (panel) return panel;
+        }
+        const instanceContent = document.querySelector('[data-ui="qa-instance-content"]');
+        if (instanceContent) {
+            const instancePanel = instanceContent.closest('[data-panel]');
+            if (instancePanel && instancePanel.parentElement) {
+                const sibling = instancePanel.nextElementSibling || instancePanel.previousElementSibling;
+                if (sibling && sibling.getAttribute?.('data-panel')) return sibling;
+            }
+        }
+        // Dispute detail: no "Report Grading Issues"; scope search to the panel that contains the verifier labels
+        const stdoutCandidates = document.querySelectorAll('div.text-sm.text-muted-foreground.font-medium.mb-1');
+        for (const el of stdoutCandidates) {
+            if (el.textContent.trim() === 'Stdout') {
+                const panel = el.closest('[data-panel]');
+                if (panel) return panel;
+            }
+        }
+        const scoreRowCandidates = document.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+        for (const el of scoreRowCandidates) {
+            for (const s of el.querySelectorAll('span')) {
+                if (s.textContent.trim() === 'Score:') {
+                    const panel = el.closest('[data-panel]');
+                    if (panel) return panel;
+                }
+            }
+        }
+        return null;
+    },
+
+    findScoreRow() {
+        const gradingPanel = this.getGradingPanelRoot();
+        const roots = gradingPanel ? [gradingPanel, document] : [document];
+        for (const root of roots) {
+            const candidates = root.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+            for (const el of candidates) {
+                for (const s of el.querySelectorAll('span')) {
+                    if (s.textContent.trim() === 'Score:') {
+                        return el;
+                    }
+                }
+            }
+        }
+        return null;
+    },
+
+    findStdoutRow() {
+        const gradingPanel = this.getGradingPanelRoot();
+        const roots = gradingPanel ? [gradingPanel, document] : [document];
+        for (const root of roots) {
+            const candidates = root.querySelectorAll('div.text-sm.text-muted-foreground.font-medium.mb-1');
+            for (const el of candidates) {
+                if (el.textContent.trim() === 'Stdout') {
+                    return el;
+                }
+            }
+        }
+        return null;
+    },
+
+    buildScoreVerifierMarkdown(container) {
+        const list = container.querySelector('div.text-xs.mb-3.space-y-0\\.5');
+        if (!list) {
+            return null;
+        }
+        const rows = list.querySelectorAll(':scope > div.flex.items-start');
+        const successes = [];
+        const failures = [];
+        for (const row of rows) {
+            const svg = row.querySelector(':scope > svg');
+            if (!svg) continue;
+            const cls = svg.getAttribute('class') || '';
+            const span = row.querySelector(':scope > span');
+            const text = span ? span.textContent.trim() : '';
+            if (!text) continue;
+            if (cls.includes('text-emerald')) {
+                successes.push(text);
+            } else if (cls.includes('text-red')) {
+                failures.push(text);
+            }
+        }
+        if (successes.length === 0 && failures.length === 0) {
+            return null;
+        }
+        const lines = ['## Verifier'];
+        if (successes.length > 0) {
+            lines.push('#### Successes');
+            for (const t of successes) {
+                lines.push(`> ✅ ${t}`);
+            }
+        }
+        if (failures.length > 0) {
+            lines.push('');
+            lines.push('#### Failures');
+            for (const t of failures) {
+                lines.push(`> ❌ ${t}`);
+            }
+        }
+        return lines.join('\n');
+    },
+
+    getVerifierOutputText(container) {
+        const scoreMd = this.buildScoreVerifierMarkdown(container);
+        if (scoreMd) {
+            return scoreMd;
+        }
+        const pre = container.querySelector('div.overflow-x-auto.bg-background.border.rounded pre');
+        if (pre && pre.textContent.trim()) {
+            return pre.textContent.trim();
+        }
+        return null;
+    },
+
+    ensureWindowCopyCapture() {
+        if (this._copyVerifierWindowCaptureInstalled) {
+            return;
+        }
+        this._copyVerifierWindowCaptureInstalled = true;
+        const win = typeof Context !== 'undefined' && Context.getPageWindow ? Context.getPageWindow() : window;
+        const handler = (e) => {
+            const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
+            if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
+                return;
+            }
+            const cont = btn._fleetCopyVerifierContainer;
+            if (!cont) {
+                return;
+            }
+            if (btn._fleetCopyHandledAt && Date.now() - btn._fleetCopyHandledAt < 150) {
+                return;
+            }
+            btn._fleetCopyHandledAt = Date.now();
+            e.stopImmediatePropagation();
+            e.stopPropagation();
+            e.preventDefault();
+            const text = this.getVerifierOutputText(cont);
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No verifier output to copy');
+                this.showVerifierCopyFailurePulse(btn);
+                return;
+            }
+            this.copyVerifierTextWithFeedback(btn, text);
+        };
+        win.addEventListener('pointerdown', handler, true);
+        win.addEventListener('click', handler, true);
+    },
+
+    clearVerifierCopyButtonFeedback(button) {
+        if (button._fleetCopyFeedbackTimeoutId) {
+            clearTimeout(button._fleetCopyFeedbackTimeoutId);
+            button._fleetCopyFeedbackTimeoutId = null;
+        }
+        if (button._fleetCopyFailureTimeoutId) {
+            clearTimeout(button._fleetCopyFailureTimeoutId);
+            button._fleetCopyFailureTimeoutId = null;
+        }
+        button.style.transition = '';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+    },
+
+    showVerifierCopyFailurePulse(button) {
+        this.clearVerifierCopyButtonFeedback(button);
+        const prevTransition = button.style.transition;
+        button.style.transition = 'none';
+        button.style.backgroundColor = 'rgb(239, 68, 68)';
+        button.style.color = '#ffffff';
+        void button.offsetHeight;
+        button.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
+        button.style.backgroundColor = '';
+        button.style.color = '';
+        button._fleetCopyFailureTimeoutId = setTimeout(() => {
+            button.style.transition = prevTransition || '';
+            button._fleetCopyFailureTimeoutId = null;
+        }, 500);
+    },
+
+    copyVerifierTextWithFeedback(button, text) {
+        const showOk = () => {
+            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            this.clearVerifierCopyButtonFeedback(button);
+            button.style.backgroundColor = 'rgb(34, 197, 94)';
+            button.style.color = 'white';
+            button._fleetCopyFeedbackTimeoutId = setTimeout(() => {
+                button.style.backgroundColor = '';
+                button.style.color = '';
+                button._fleetCopyFeedbackTimeoutId = null;
+            }, 1000);
+        };
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard
+                .writeText(text)
+                .then(showOk)
+                .catch((err) => {
+                    Logger.warn('Copy Verifier Output: Clipboard API failed, trying fallback', err);
+                    if (this.copyVerifierTextFallback(text)) {
+                        showOk();
+                    } else {
+                        Logger.error('Copy Verifier Output: Failed to copy to clipboard', err);
+                        this.showVerifierCopyFailurePulse(button);
+                    }
+                });
+        } else if (this.copyVerifierTextFallback(text)) {
+            showOk();
+        } else {
+            Logger.error('Copy Verifier Output: Failed to copy to clipboard');
+            this.showVerifierCopyFailurePulse(button);
+        }
+    },
+
+    copyVerifierTextFallback(text) {
+        try {
+            const temp = document.createElement('textarea');
+            temp.value = text;
+            temp.style.position = 'fixed';
+            temp.style.top = '-1000px';
+            document.body.appendChild(temp);
+            temp.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(temp);
+            return ok;
+        } catch (e) {
+            return false;
+        }
+    },
+
+    createCopyButton(container) {
+        this.ensureWindowCopyCapture();
+
+        const button = document.createElement('button');
+        button.setAttribute(COPY_BUTTON_MARKER, 'true');
+        button.setAttribute('data-fleet-plugin', this.id);
+        button.type = 'button';
+        button.className =
+            'relative z-50 inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        button.setAttribute('data-state', 'closed');
+        button.title = 'Copy verifier output to clipboard';
+        button.setAttribute('aria-label', 'Copy verifier output to clipboard');
+        button._fleetCopyVerifierContainer = container;
+
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('width', '12');
+        svg.setAttribute('height', '12');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        svg.className = 'fill-current h-3 w-3 text-muted-foreground pointer-events-none';
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('fill', 'currentColor');
+        path.setAttribute('fill-rule', 'evenodd');
+        path.setAttribute('clip-rule', 'evenodd');
+        path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
+        svg.appendChild(path);
+        button.appendChild(svg);
+
+        const doCopy = () => {
+            if (button._fleetCopyHandledAt && Date.now() - button._fleetCopyHandledAt < 200) {
+                return;
+            }
+            button._fleetCopyHandledAt = Date.now();
+            const text = this.getVerifierOutputText(container);
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No verifier output to copy');
+                this.showVerifierCopyFailurePulse(button);
+                return;
+            }
+            this.copyVerifierTextWithFeedback(button, text);
+        };
+
+        button.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        return button;
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
+++ b/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
@@ -1,15 +1,18 @@
 // ============= copy-verifier-output.js =============
 // Adds a copy button in the verifier output area: after "Stdout" (classic output) or after "Score: #" (checklist verifier).
 // Same behavior as QA archetypes; shared verifier panel DOM (see verifier-diff-highlight-improved.js).
+// Checklist cards: when "Raw Output" is expanded, a second copy icon copies only the <pre> body.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
+const COPY_RAW_OUTPUT_MARKER = 'data-fleet-copy-verifier-raw-output';
+const RAW_OUTPUT_ROW_MARKER = 'data-fleet-copy-verifier-raw-row';
 
 const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
     description:
-        'Add a copy button after Stdout or Score in the verifier output panel. Click copies formatted verifier text to the clipboard',
-    _version: '1.0',
+        'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -31,10 +34,6 @@ const plugin = {
         }
         state.verifierTargetMissingLogged = false;
 
-        if (anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
-            return;
-        }
-
         let container;
         if (scoreRow) {
             container = scoreRow.closest('div.p-3');
@@ -50,13 +49,75 @@ const plugin = {
             }
         }
 
-        const button = this.createCopyButton(container);
-        anchorRow.appendChild(button);
-        if (!anchorRow.classList.contains('flex')) {
-            anchorRow.classList.add('flex', 'items-center', 'gap-2');
+        if (!anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
+            const button = this.createCopyButton(container);
+            anchorRow.appendChild(button);
+            if (!anchorRow.classList.contains('flex')) {
+                anchorRow.classList.add('flex', 'items-center', 'gap-2');
+            }
+            if (!state.buttonAdded) {
+                state.buttonAdded = true;
+                Logger.log('Copy Verifier Output: Copy button added');
+            }
         }
-        state.buttonAdded = true;
-        Logger.log('Copy Verifier Output: Copy button added');
+
+        if (scoreRow) {
+            this.syncRawOutputCopyButton(container);
+        }
+    },
+
+    findRawOutputBlock(scoreContainer) {
+        for (const block of scoreContainer.querySelectorAll(':scope > div.text-xs.mb-3')) {
+            if (block.classList.contains('space-y-0.5')) continue;
+            const hasRaw = Array.from(block.querySelectorAll('button')).some((b) =>
+                (b.textContent || '').includes('Raw Output')
+            );
+            if (hasRaw) return block;
+        }
+        return null;
+    },
+
+    findRawOutputPre(block) {
+        return block.querySelector(':scope > div.overflow-x-auto.bg-background.border.rounded pre');
+    },
+
+    unwrapRawOutputCopyRow(block) {
+        const wrapper = block.querySelector(`:scope > [${RAW_OUTPUT_ROW_MARKER}="true"]`);
+        if (!wrapper) return;
+        const toggleBtn = wrapper.querySelector(`button:not([${COPY_RAW_OUTPUT_MARKER}="true"])`);
+        if (toggleBtn && (toggleBtn.textContent || '').includes('Raw Output')) {
+            block.insertBefore(toggleBtn, wrapper);
+            if (!toggleBtn.classList.contains('mb-1')) toggleBtn.classList.add('mb-1');
+        }
+        wrapper.remove();
+    },
+
+    syncRawOutputCopyButton(scoreContainer) {
+        const block = this.findRawOutputBlock(scoreContainer);
+        if (!block) return;
+        const pre = this.findRawOutputPre(block);
+        if (!pre || !pre.textContent.trim()) {
+            this.unwrapRawOutputCopyRow(block);
+            return;
+        }
+        let copyBtn = block.querySelector(`[${COPY_RAW_OUTPUT_MARKER}="true"]`);
+        if (copyBtn) {
+            copyBtn._fleetCopyRawPre = pre;
+            return;
+        }
+        const toggleBtn = Array.from(block.querySelectorAll('button')).find(
+            (b) => (b.textContent || '').includes('Raw Output') && !b.hasAttribute(COPY_RAW_OUTPUT_MARKER)
+        );
+        if (!toggleBtn) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flex items-center gap-2 mb-1';
+        wrapper.setAttribute(RAW_OUTPUT_ROW_MARKER, 'true');
+        toggleBtn.classList.remove('mb-1');
+        toggleBtn.parentNode.insertBefore(wrapper, toggleBtn);
+        wrapper.appendChild(toggleBtn);
+        copyBtn = this.createRawOutputCopyButton(pre);
+        wrapper.appendChild(copyBtn);
+        Logger.debug('Copy Verifier Output: Raw Output copy control added');
     },
 
     getGradingPanelRoot() {
@@ -185,6 +246,26 @@ const plugin = {
         this._copyVerifierWindowCaptureInstalled = true;
         const win = typeof Context !== 'undefined' && Context.getPageWindow ? Context.getPageWindow() : window;
         const handler = (e) => {
+            const rawBtn = e.target.closest(`[${COPY_RAW_OUTPUT_MARKER}="true"]`);
+            if (rawBtn && rawBtn.getAttribute('data-fleet-plugin') === this.id) {
+                const pre = rawBtn._fleetCopyRawPre;
+                if (rawBtn._fleetCopyHandledAt && Date.now() - rawBtn._fleetCopyHandledAt < 150) {
+                    return;
+                }
+                rawBtn._fleetCopyHandledAt = Date.now();
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                e.preventDefault();
+                const rawText = pre && pre.textContent.trim();
+                if (!rawText) {
+                    Logger.warn('Copy Verifier Output: No raw output to copy');
+                    this.showVerifierCopyFailurePulse(rawBtn);
+                    return;
+                }
+                this.copyVerifierTextWithFeedback(rawBtn, rawText, ' (raw output)');
+                return;
+            }
+
             const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
             if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
                 return;
@@ -242,9 +323,9 @@ const plugin = {
         }, 500);
     },
 
-    copyVerifierTextWithFeedback(button, text) {
+    copyVerifierTextWithFeedback(button, text, logSuffix = '') {
         const showOk = () => {
-            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard${logSuffix}`);
             this.clearVerifierCopyButtonFeedback(button);
             button.style.backgroundColor = 'rgb(34, 197, 94)';
             button.style.color = 'white';
@@ -332,6 +413,63 @@ const plugin = {
                 return;
             }
             this.copyVerifierTextWithFeedback(button, text);
+        };
+
+        button.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        return button;
+    },
+
+    createRawOutputCopyButton(pre) {
+        this.ensureWindowCopyCapture();
+
+        const button = document.createElement('button');
+        button.setAttribute(COPY_RAW_OUTPUT_MARKER, 'true');
+        button.setAttribute('data-fleet-plugin', this.id);
+        button.type = 'button';
+        button.className =
+            'relative z-50 inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        button.setAttribute('data-state', 'closed');
+        button.title = 'Copy raw verifier output to clipboard';
+        button.setAttribute('aria-label', 'Copy raw verifier output to clipboard');
+        button._fleetCopyRawPre = pre;
+
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('width', '12');
+        svg.setAttribute('height', '12');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        svg.className = 'fill-current h-3 w-3 text-muted-foreground pointer-events-none';
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('fill', 'currentColor');
+        path.setAttribute('fill-rule', 'evenodd');
+        path.setAttribute('clip-rule', 'evenodd');
+        path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
+        svg.appendChild(path);
+        button.appendChild(svg);
+
+        const doCopy = () => {
+            if (button._fleetCopyHandledAt && Date.now() - button._fleetCopyHandledAt < 200) {
+                return;
+            }
+            button._fleetCopyHandledAt = Date.now();
+            const text = pre && pre.textContent.trim();
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No raw output to copy');
+                this.showVerifierCopyFailurePulse(button);
+                return;
+            }
+            this.copyVerifierTextWithFeedback(button, text, ' (raw output)');
         };
 
         button.addEventListener('pointerdown', (e) => {

--- a/plugins/archetypes/dispute-detail/main/create-instance-autoclick.js
+++ b/plugins/archetypes/dispute-detail/main/create-instance-autoclick.js
@@ -1,0 +1,86 @@
+// ============= create-instance-autoclick.js =============
+// Clicks "Create Instance" once when the control is visible and clickable.
+
+const plugin = {
+    id: 'createInstanceAutoclick',
+    name: 'Create Instance Autoclick',
+    description:
+        'Automatically clicks the "Create Instance" button once when it becomes visible.',
+    _version: '1.1',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        clicked: false,
+        visibilityObserverAttached: false,
+        missingLogged: false,
+        notClickableLogged: false
+    },
+
+    onMutation(state) {
+        if (state.clicked) return;
+
+        const button = this.findCreateInstanceButton();
+        if (!button) {
+            if (!state.missingLogged) {
+                Logger.debug('Create Instance Autoclick: "Create Instance" button not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        if (!this.isButtonClickable(button)) {
+            if (!state.notClickableLogged) {
+                Logger.debug('Create Instance Autoclick: "Create Instance" not clickable yet');
+                state.notClickableLogged = true;
+            }
+            return;
+        }
+
+        if (state.visibilityObserverAttached) return;
+        state.visibilityObserverAttached = true;
+
+        const io = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (!entry.isIntersecting || state.clicked) continue;
+                    try {
+                        button.click();
+                        state.clicked = true;
+                        Logger.log('✓ Create Instance Autoclick: clicked "Create Instance"');
+                    } catch (error) {
+                        Logger.error('Create Instance Autoclick: failed to click "Create Instance"', error);
+                        state.clicked = true;
+                    }
+                    io.disconnect();
+                }
+            },
+            { threshold: 0 }
+        );
+
+        io.observe(button);
+        CleanupRegistry.registerObserver(io);
+    },
+
+    findCreateInstanceButton() {
+        const options = { context: `${this.id}.findCreateInstanceButton` };
+        const buttons =
+            typeof Context !== 'undefined' && Context.dom
+                ? Context.dom.queryAll('button', options)
+                : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+            if (text === 'Create Instance') {
+                return btn;
+            }
+        }
+
+        return null;
+    },
+
+    isButtonClickable(button) {
+        if (button.disabled) return false;
+        if (button.getAttribute('aria-disabled') === 'true') return false;
+        return true;
+    }
+};

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -1,13 +1,17 @@
 // ============= copy-verifier-output.js =============
 // Adds a copy button in the Grading/verifier panel: after "Stdout" (classic output) or after "Score: #" (checklist verifier). Click copies formatted verifier text to the clipboard.
+// Checklist cards: when "Raw Output" is expanded, a second copy icon copies only the <pre> body.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
+const COPY_RAW_OUTPUT_MARKER = 'data-fleet-copy-verifier-raw-output';
+const RAW_OUTPUT_ROW_MARKER = 'data-fleet-copy-verifier-raw-row';
 
 const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
-    description: 'Add a copy button after Stdout or Score in the Grading panel. Click copies the verifier output to the clipboard',
-    _version: '1.8',
+    description:
+        'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
+    _version: '1.9',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -29,10 +33,6 @@ const plugin = {
         }
         state.verifierTargetMissingLogged = false;
 
-        if (anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
-            return;
-        }
-
         let container;
         if (scoreRow) {
             container = scoreRow.closest('div.p-3');
@@ -48,13 +48,75 @@ const plugin = {
             }
         }
 
-        const button = this.createCopyButton(container);
-        anchorRow.appendChild(button);
-        if (!anchorRow.classList.contains('flex')) {
-            anchorRow.classList.add('flex', 'items-center', 'gap-2');
+        if (!anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
+            const button = this.createCopyButton(container);
+            anchorRow.appendChild(button);
+            if (!anchorRow.classList.contains('flex')) {
+                anchorRow.classList.add('flex', 'items-center', 'gap-2');
+            }
+            if (!state.buttonAdded) {
+                state.buttonAdded = true;
+                Logger.log('Copy Verifier Output: Copy button added');
+            }
         }
-        state.buttonAdded = true;
-        Logger.log('Copy Verifier Output: Copy button added');
+
+        if (scoreRow) {
+            this.syncRawOutputCopyButton(container);
+        }
+    },
+
+    findRawOutputBlock(scoreContainer) {
+        for (const block of scoreContainer.querySelectorAll(':scope > div.text-xs.mb-3')) {
+            if (block.classList.contains('space-y-0.5')) continue;
+            const hasRaw = Array.from(block.querySelectorAll('button')).some((b) =>
+                (b.textContent || '').includes('Raw Output')
+            );
+            if (hasRaw) return block;
+        }
+        return null;
+    },
+
+    findRawOutputPre(block) {
+        return block.querySelector(':scope > div.overflow-x-auto.bg-background.border.rounded pre');
+    },
+
+    unwrapRawOutputCopyRow(block) {
+        const wrapper = block.querySelector(`:scope > [${RAW_OUTPUT_ROW_MARKER}="true"]`);
+        if (!wrapper) return;
+        const toggleBtn = wrapper.querySelector(`button:not([${COPY_RAW_OUTPUT_MARKER}="true"])`);
+        if (toggleBtn && (toggleBtn.textContent || '').includes('Raw Output')) {
+            block.insertBefore(toggleBtn, wrapper);
+            if (!toggleBtn.classList.contains('mb-1')) toggleBtn.classList.add('mb-1');
+        }
+        wrapper.remove();
+    },
+
+    syncRawOutputCopyButton(scoreContainer) {
+        const block = this.findRawOutputBlock(scoreContainer);
+        if (!block) return;
+        const pre = this.findRawOutputPre(block);
+        if (!pre || !pre.textContent.trim()) {
+            this.unwrapRawOutputCopyRow(block);
+            return;
+        }
+        let copyBtn = block.querySelector(`[${COPY_RAW_OUTPUT_MARKER}="true"]`);
+        if (copyBtn) {
+            copyBtn._fleetCopyRawPre = pre;
+            return;
+        }
+        const toggleBtn = Array.from(block.querySelectorAll('button')).find(
+            (b) => (b.textContent || '').includes('Raw Output') && !b.hasAttribute(COPY_RAW_OUTPUT_MARKER)
+        );
+        if (!toggleBtn) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flex items-center gap-2 mb-1';
+        wrapper.setAttribute(RAW_OUTPUT_ROW_MARKER, 'true');
+        toggleBtn.classList.remove('mb-1');
+        toggleBtn.parentNode.insertBefore(wrapper, toggleBtn);
+        wrapper.appendChild(toggleBtn);
+        copyBtn = this.createRawOutputCopyButton(pre);
+        wrapper.appendChild(copyBtn);
+        Logger.debug('Copy Verifier Output: Raw Output copy control added');
     },
 
     getGradingPanelRoot() {
@@ -166,6 +228,26 @@ const plugin = {
         this._copyVerifierWindowCaptureInstalled = true;
         const win = typeof Context !== 'undefined' && Context.getPageWindow ? Context.getPageWindow() : window;
         const handler = (e) => {
+            const rawBtn = e.target.closest(`[${COPY_RAW_OUTPUT_MARKER}="true"]`);
+            if (rawBtn && rawBtn.getAttribute('data-fleet-plugin') === this.id) {
+                const pre = rawBtn._fleetCopyRawPre;
+                if (rawBtn._fleetCopyHandledAt && Date.now() - rawBtn._fleetCopyHandledAt < 150) {
+                    return;
+                }
+                rawBtn._fleetCopyHandledAt = Date.now();
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                e.preventDefault();
+                const rawText = pre && pre.textContent.trim();
+                if (!rawText) {
+                    Logger.warn('Copy Verifier Output: No raw output to copy');
+                    this.showVerifierCopyFailurePulse(rawBtn);
+                    return;
+                }
+                this.copyVerifierTextWithFeedback(rawBtn, rawText, ' (raw output)');
+                return;
+            }
+
             const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
             if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
                 return;
@@ -223,9 +305,9 @@ const plugin = {
         }, 500);
     },
 
-    copyVerifierTextWithFeedback(button, text) {
+    copyVerifierTextWithFeedback(button, text, logSuffix = '') {
         const showOk = () => {
-            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard${logSuffix}`);
             this.clearVerifierCopyButtonFeedback(button);
             button.style.backgroundColor = 'rgb(34, 197, 94)';
             button.style.color = 'white';
@@ -313,6 +395,63 @@ const plugin = {
                 return;
             }
             this.copyVerifierTextWithFeedback(button, text);
+        };
+
+        button.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        return button;
+    },
+
+    createRawOutputCopyButton(pre) {
+        this.ensureWindowCopyCapture();
+
+        const button = document.createElement('button');
+        button.setAttribute(COPY_RAW_OUTPUT_MARKER, 'true');
+        button.setAttribute('data-fleet-plugin', this.id);
+        button.type = 'button';
+        button.className =
+            'relative z-50 inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        button.setAttribute('data-state', 'closed');
+        button.title = 'Copy raw verifier output to clipboard';
+        button.setAttribute('aria-label', 'Copy raw verifier output to clipboard');
+        button._fleetCopyRawPre = pre;
+
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('width', '12');
+        svg.setAttribute('height', '12');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        svg.className = 'fill-current h-3 w-3 text-muted-foreground pointer-events-none';
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('fill', 'currentColor');
+        path.setAttribute('fill-rule', 'evenodd');
+        path.setAttribute('clip-rule', 'evenodd');
+        path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
+        svg.appendChild(path);
+        button.appendChild(svg);
+
+        const doCopy = () => {
+            if (button._fleetCopyHandledAt && Date.now() - button._fleetCopyHandledAt < 200) {
+                return;
+            }
+            button._fleetCopyHandledAt = Date.now();
+            const text = pre && pre.textContent.trim();
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No raw output to copy');
+                this.showVerifierCopyFailurePulse(button);
+                return;
+            }
+            this.copyVerifierTextWithFeedback(button, text, ' (raw output)');
         };
 
         button.addEventListener('pointerdown', (e) => {

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -1,13 +1,17 @@
 // ============= copy-verifier-output.js =============
 // Adds a copy button in the Verifier Output panel: after "Stdout" (classic output) or after "Score: #" (checklist verifier). Click copies formatted verifier text to the clipboard.
+// Checklist cards: when "Raw Output" is expanded, a second copy icon copies only the <pre> body.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
+const COPY_RAW_OUTPUT_MARKER = 'data-fleet-copy-verifier-raw-output';
+const RAW_OUTPUT_ROW_MARKER = 'data-fleet-copy-verifier-raw-row';
 
 const plugin = {
     id: 'copyVerifierOutput',
     name: 'Copy Verifier Output',
-    description: 'Add a copy button after Stdout or Score in the Verifier Output panel. Click copies the verifier output to the clipboard',
-    _version: '1.9',
+    description:
+        'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
+    _version: '2.0',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -29,10 +33,6 @@ const plugin = {
         }
         state.verifierTargetMissingLogged = false;
 
-        if (anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
-            return;
-        }
-
         let container;
         if (scoreRow) {
             container = scoreRow.closest('div.p-3');
@@ -48,13 +48,75 @@ const plugin = {
             }
         }
 
-        const button = this.createCopyButton(container);
-        anchorRow.appendChild(button);
-        if (!anchorRow.classList.contains('flex')) {
-            anchorRow.classList.add('flex', 'items-center', 'gap-2');
+        if (!anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
+            const button = this.createCopyButton(container);
+            anchorRow.appendChild(button);
+            if (!anchorRow.classList.contains('flex')) {
+                anchorRow.classList.add('flex', 'items-center', 'gap-2');
+            }
+            if (!state.buttonAdded) {
+                state.buttonAdded = true;
+                Logger.log('Copy Verifier Output: Copy button added');
+            }
         }
-        state.buttonAdded = true;
-        Logger.log('Copy Verifier Output: Copy button added');
+
+        if (scoreRow) {
+            this.syncRawOutputCopyButton(container);
+        }
+    },
+
+    findRawOutputBlock(scoreContainer) {
+        for (const block of scoreContainer.querySelectorAll(':scope > div.text-xs.mb-3')) {
+            if (block.classList.contains('space-y-0.5')) continue;
+            const hasRaw = Array.from(block.querySelectorAll('button')).some((b) =>
+                (b.textContent || '').includes('Raw Output')
+            );
+            if (hasRaw) return block;
+        }
+        return null;
+    },
+
+    findRawOutputPre(block) {
+        return block.querySelector(':scope > div.overflow-x-auto.bg-background.border.rounded pre');
+    },
+
+    unwrapRawOutputCopyRow(block) {
+        const wrapper = block.querySelector(`:scope > [${RAW_OUTPUT_ROW_MARKER}="true"]`);
+        if (!wrapper) return;
+        const toggleBtn = wrapper.querySelector(`button:not([${COPY_RAW_OUTPUT_MARKER}="true"])`);
+        if (toggleBtn && (toggleBtn.textContent || '').includes('Raw Output')) {
+            block.insertBefore(toggleBtn, wrapper);
+            if (!toggleBtn.classList.contains('mb-1')) toggleBtn.classList.add('mb-1');
+        }
+        wrapper.remove();
+    },
+
+    syncRawOutputCopyButton(scoreContainer) {
+        const block = this.findRawOutputBlock(scoreContainer);
+        if (!block) return;
+        const pre = this.findRawOutputPre(block);
+        if (!pre || !pre.textContent.trim()) {
+            this.unwrapRawOutputCopyRow(block);
+            return;
+        }
+        let copyBtn = block.querySelector(`[${COPY_RAW_OUTPUT_MARKER}="true"]`);
+        if (copyBtn) {
+            copyBtn._fleetCopyRawPre = pre;
+            return;
+        }
+        const toggleBtn = Array.from(block.querySelectorAll('button')).find(
+            (b) => (b.textContent || '').includes('Raw Output') && !b.hasAttribute(COPY_RAW_OUTPUT_MARKER)
+        );
+        if (!toggleBtn) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'flex items-center gap-2 mb-1';
+        wrapper.setAttribute(RAW_OUTPUT_ROW_MARKER, 'true');
+        toggleBtn.classList.remove('mb-1');
+        toggleBtn.parentNode.insertBefore(wrapper, toggleBtn);
+        wrapper.appendChild(toggleBtn);
+        copyBtn = this.createRawOutputCopyButton(pre);
+        wrapper.appendChild(copyBtn);
+        Logger.debug('Copy Verifier Output: Raw Output copy control added');
     },
 
     getGradingPanelRoot() {
@@ -166,6 +228,26 @@ const plugin = {
         this._copyVerifierWindowCaptureInstalled = true;
         const win = typeof Context !== 'undefined' && Context.getPageWindow ? Context.getPageWindow() : window;
         const handler = (e) => {
+            const rawBtn = e.target.closest(`[${COPY_RAW_OUTPUT_MARKER}="true"]`);
+            if (rawBtn && rawBtn.getAttribute('data-fleet-plugin') === this.id) {
+                const pre = rawBtn._fleetCopyRawPre;
+                if (rawBtn._fleetCopyHandledAt && Date.now() - rawBtn._fleetCopyHandledAt < 150) {
+                    return;
+                }
+                rawBtn._fleetCopyHandledAt = Date.now();
+                e.stopImmediatePropagation();
+                e.stopPropagation();
+                e.preventDefault();
+                const rawText = pre && pre.textContent.trim();
+                if (!rawText) {
+                    Logger.warn('Copy Verifier Output: No raw output to copy');
+                    this.showVerifierCopyFailurePulse(rawBtn);
+                    return;
+                }
+                this.copyVerifierTextWithFeedback(rawBtn, rawText, ' (raw output)');
+                return;
+            }
+
             const btn = e.target.closest(`[${COPY_BUTTON_MARKER}="true"]`);
             if (!btn || btn.getAttribute('data-fleet-plugin') !== this.id) {
                 return;
@@ -223,9 +305,9 @@ const plugin = {
         }, 500);
     },
 
-    copyVerifierTextWithFeedback(button, text) {
+    copyVerifierTextWithFeedback(button, text, logSuffix = '') {
         const showOk = () => {
-            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard`);
+            Logger.log(`Copy Verifier Output: Copied ${text.length} chars to clipboard${logSuffix}`);
             this.clearVerifierCopyButtonFeedback(button);
             button.style.backgroundColor = 'rgb(34, 197, 94)';
             button.style.color = 'white';
@@ -313,6 +395,63 @@ const plugin = {
                 return;
             }
             this.copyVerifierTextWithFeedback(button, text);
+        };
+
+        button.addEventListener('pointerdown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        button.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            doCopy();
+        }, true);
+
+        return button;
+    },
+
+    createRawOutputCopyButton(pre) {
+        this.ensureWindowCopyCapture();
+
+        const button = document.createElement('button');
+        button.setAttribute(COPY_RAW_OUTPUT_MARKER, 'true');
+        button.setAttribute('data-fleet-plugin', this.id);
+        button.type = 'button';
+        button.className =
+            'relative z-50 inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground size-7 h-6 w-6';
+        button.setAttribute('data-state', 'closed');
+        button.title = 'Copy raw verifier output to clipboard';
+        button.setAttribute('aria-label', 'Copy raw verifier output to clipboard');
+        button._fleetCopyRawPre = pre;
+
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('width', '12');
+        svg.setAttribute('height', '12');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        svg.className = 'fill-current h-3 w-3 text-muted-foreground pointer-events-none';
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('fill', 'currentColor');
+        path.setAttribute('fill-rule', 'evenodd');
+        path.setAttribute('clip-rule', 'evenodd');
+        path.setAttribute('d', 'M2 5C2 3.34315 3.34315 2 5 2H12C13.6569 2 15 3.34315 15 5C15 5.55228 14.5523 6 14 6C13.4477 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4H5C4.44772 4 4 4.44772 4 5V13C4 13.5523 4.44772 14 5 14H6C6.55228 14 7 14.4477 7 15C7 15.5523 6.55228 16 6 16H5C3.34315 16 2 14.6569 2 13V5ZM9 10.8462C9 9.20041 10.42 8 12 8H19C20.58 8 22 9.20041 22 10.8462V19.1538C22 20.7996 20.58 22 19 22H12C10.42 22 9 20.7996 9 19.1538V10.8462ZM12 10C11.3708 10 11 10.4527 11 10.8462V19.1538C11 19.5473 11.3708 20 12 20H19C19.6292 20 20 19.5473 20 19.1538V10.8462C20 10.4527 19.6292 10 19 10H12Z');
+        svg.appendChild(path);
+        button.appendChild(svg);
+
+        const doCopy = () => {
+            if (button._fleetCopyHandledAt && Date.now() - button._fleetCopyHandledAt < 200) {
+                return;
+            }
+            button._fleetCopyHandledAt = Date.now();
+            const text = pre && pre.textContent.trim();
+            if (!text) {
+                Logger.warn('Copy Verifier Output: No raw output to copy');
+                this.showVerifierCopyFailurePulse(button);
+                return;
+            }
+            this.copyVerifierTextWithFeedback(button, text, ' (raw output)');
         };
 
         button.addEventListener('pointerdown', (e) => {


### PR DESCRIPTION
## Summary

Brings dispute-detail UX closer to QA workflows with copy-verifier-output and Create Instance auto-click, refines shared copy-verifier-output behavior for expanded Raw Output, and consolidates Fleet branch sync into `sync-branch-config.sh` with a commit option—simplifying checkout and test helpers.

## Changes

- **dispute-detail**: New Copy Verifier Output plugin aligned with QA patterns; auto-clicks Create Instance when that control appears.
- **copy-verifier-output** (shared): Copy affordance for expanded Raw Output pre blocks; parallel updates in `qa-comp-use` and `qa-tool-use`.
- **Dev tooling**: Fleet sync logic moved into `sync-branch-config.sh`; `-c` commits `fleet.user.js` after sync; `checkout.sh` and `test.sh` lean on the centralized flow; `module-workflow.md` documents the workflow.
- **archetypes.json**: Plugin entries and hashes updated for the new and changed plugins.

## New plugins

| Archetype | Plugin | Description |
|-----------|--------|-------------|
| dispute-detail | copy-verifier-output | Copy verifier output from the page (QA parity) |
| dispute-detail | create-instance-autoclick | Auto-click Create Instance when visible |

## Commit history

- `05d1048` refactor(utils): centralize fleet sync in sync-branch-config.sh
- `2c6a70d` Sync fleet.user.js branch config to main
- `76980e6` feat(dev): add -c to sync-branch-config to commit fleet.user.js
- `eba5402` feat(copy-verifier-output): copy icon for expanded Raw Output pre
- `4ed9448` feat(dispute-detail): add Copy Verifier Output plugin (QA parity)
- `3a5b598` feat(dispute-detail): auto-click Create Instance when visible

## Stats

```
 archetypes.json                                    |  20 +-
 dev/module-workflow.md                             |   8 +-
 dev/utils/checkout.sh                              | 151 +------
 dev/utils/sync-branch-config.sh                    | 160 ++++++-
 dev/utils/test.sh                                  |  89 +---
 .../dispute-detail/main/copy-verifier-output.js    | 489 +++++++++++++++++++++
 .../main/create-instance-autoclick.js              |  86 ++++
 .../qa-comp-use/main/copy-verifier-output.js       | 167 ++++++-
 .../qa-tool-use/main/copy-verifier-output.js       | 167 ++++++-
 9 files changed, 1076 insertions(+), 261 deletions(-)
```
