### PR TITLE
Verifier copy: card layout score row and p-2; dev checkout/delete-branch

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.79",
+  "archetypesVersion": "6.80",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "2.0",
-          "hash": "sha256-1b13b3bdc92749882de73ad3d7304cdccae2d00f54a745c7401fa79994e20158"
+          "version": "2.1",
+          "hash": "sha256-dd6c6aaa6243d1858bdc41b9d2a7c1efd39051288ddbbf200d6e1233de4db181"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -426,8 +426,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "5.1",
-          "hash": "sha256-c83c990f595c20c1e010700077c0d0263da4d9ced46944daa0a8e5697d8cac2e"
+          "version": "5.2",
+          "hash": "sha256-4318f2eec2c9aa5d0816d3030bedc2a5703767c8b1908b76e60aafb2436bb0aa"
         },
         {
           "name": "prompt-diff-highlight.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.9",
-          "hash": "sha256-bdbecbdf73ac1ccd439306cb4a8981f5e4bd4b6fb965d06afa2b40964ec0a061"
+          "version": "1.10",
+          "hash": "sha256-668dc5e1fb58550f460399273e298c86af2619ce9e0a4068c75da07f4096f3e6"
         },
         {
           "name": "copy-result-params.js",
@@ -510,8 +510,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "4.1",
-          "hash": "sha256-ca2d864fc92f72f2a481e69fef3dad5ad442a64c72fbdf30a76beb092a41c1ca"
+          "version": "4.2",
+          "hash": "sha256-d7eb46b8245703dd1a37129d4ee7c497dde218e956f3b9779a6171e44c36fa71"
         },
         {
           "name": "qa-scratchpad.js",
@@ -612,8 +612,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.1",
-          "hash": "sha256-4969571a31d8dda112975bffa8d42c30c570812e49d7e7f30cc07d79130554f0"
+          "version": "1.2",
+          "hash": "sha256-668a6f255b4d3042cb277eca0f94ed080c3e8e0138b2e95ee7c5151a0c6b043d"
         },
         {
           "name": "verifier-diff-highlight-improved.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.1.2",
-  "archetypesVersion": "6.80",
+  "archetypesVersion": "6.81",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -391,8 +391,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "2.1",
-          "hash": "sha256-dd6c6aaa6243d1858bdc41b9d2a7c1efd39051288ddbbf200d6e1233de4db181"
+          "version": "2.2",
+          "hash": "sha256-342b609c73d59ef5775320488f0cc3182a8d37a4d38b9fb6b7c6d5a1243d3097"
         },
         {
           "name": "remember-layout-proportions.js",
@@ -495,8 +495,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.10",
-          "hash": "sha256-668dc5e1fb58550f460399273e298c86af2619ce9e0a4068c75da07f4096f3e6"
+          "version": "1.11",
+          "hash": "sha256-4e0365560103973d433ece5ab9c1b2847cd44c11ee8cae626bd0ae2e3de06831"
         },
         {
           "name": "copy-result-params.js",
@@ -612,8 +612,8 @@
         },
         {
           "name": "copy-verifier-output.js",
-          "version": "1.2",
-          "hash": "sha256-668a6f255b4d3042cb277eca0f94ed080c3e8e0138b2e95ee7c5151a0c6b043d"
+          "version": "1.3",
+          "hash": "sha256-aa22295f5e6d8116220eec20c79dfd0b53fa34ca08bdd11f40f84054bcf62104"
         },
         {
           "name": "verifier-diff-highlight-improved.js",

--- a/dev/utils/checkout.sh
+++ b/dev/utils/checkout.sh
@@ -85,7 +85,7 @@ RAW_INSTALL_URL="https://raw.githubusercontent.com/$ghuser/$ghrepo/$BRANCH/fleet
 BLOB_URL="https://github.com/$ghuser/$ghrepo/blob/$BRANCH/fleet.user.js"
 
 echo "You MUST test and develop using this $BRANCH specific userscript."
-echo "Install it at (raw):"
-echo "$RAW_INSTALL_URL"
 echo "View on GitHub:"
 echo "$BLOB_URL"
+echo "Install it at (raw):"
+echo "$RAW_INSTALL_URL"

--- a/dev/utils/delete-branch.sh
+++ b/dev/utils/delete-branch.sh
@@ -9,9 +9,10 @@
 #   branch   Name of the branch to delete.
 #
 # Effects:
-#   Deletes the branch locally (git branch -D) and on origin (git push --delete).
-#   Errors are ignored; both deletions are attempted even if the branch does
-#   not exist in one or both places.
+#   Checks out main, deletes the branch locally (git branch -D) and on origin
+#   (git push --delete), then runs git pull on main. Deletion errors are
+#   ignored; both deletions are attempted even if the branch does not exist in
+#   one or both places. Pull failures exit non-zero (set -e).
 #
 # Safety:
 #   The script refuses to delete the branch "main" (any casing) and exits with
@@ -32,3 +33,4 @@ fi
 git checkout main
 git branch -D "$branch" 2>/dev/null || true
 git push origin --delete "$branch" 2>/dev/null || true
+git pull

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix-update-verifier-copy] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-update-verifier-copy/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-update-verifier-copy/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix-update-verifier-copy',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix-update-verifier-copy] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-update-verifier-copy/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-update-verifier-copy/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix-update-verifier-copy',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
+++ b/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
@@ -13,7 +13,7 @@ const plugin = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '1.2',
+    _version: '1.3',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -50,11 +50,12 @@ const plugin = {
             }
         }
 
+        const copyButtonHost = scoreRow ? this.getScoreRowButtonHost(scoreRow) : anchorRow;
         if (!anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
             const button = this.createCopyButton(container);
-            anchorRow.appendChild(button);
-            if (!anchorRow.classList.contains('flex')) {
-                anchorRow.classList.add('flex', 'items-center', 'gap-2');
+            copyButtonHost.appendChild(button);
+            if (!copyButtonHost.classList.contains('flex')) {
+                copyButtonHost.classList.add('flex', 'items-center', 'gap-2');
             }
             if (!state.buttonAdded) {
                 state.buttonAdded = true;
@@ -155,6 +156,17 @@ const plugin = {
             }
         }
         return null;
+    },
+
+    /** When the score lives in an inner flex group and timing is a sibling (`justify-between`), append the copy control there so it stays beside the score. */
+    getScoreRowButtonHost(scoreRow) {
+        for (const s of scoreRow.querySelectorAll('span')) {
+            if (s.textContent.trim() !== 'Score:') continue;
+            const p = s.parentElement;
+            if (p && p !== scoreRow) return p;
+            return scoreRow;
+        }
+        return scoreRow;
     },
 
     findScoreRow() {

--- a/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
+++ b/plugins/archetypes/dispute-detail/main/copy-verifier-output.js
@@ -1,5 +1,6 @@
 // ============= copy-verifier-output.js =============
 // Adds a copy button in the verifier output area: after "Stdout" (classic output) or after "Score: #" (checklist verifier).
+// Checklist score row: legacy `gap-2` header or card layout (`justify-between`, sticky) inside `div.p-3` or `div.p-2`.
 // Same behavior as QA archetypes; shared verifier panel DOM (see verifier-diff-highlight-improved.js).
 // Checklist cards: when "Raw Output" is expanded, a second copy icon copies only the <pre> body.
 
@@ -12,7 +13,7 @@ const plugin = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '1.1',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -36,7 +37,7 @@ const plugin = {
 
         let container;
         if (scoreRow) {
-            container = scoreRow.closest('div.p-3');
+            container = scoreRow.closest('div.p-3') || scoreRow.closest('div.p-2');
             if (!container) {
                 Logger.debug('Copy Verifier Output: Score card container not found');
                 return;
@@ -144,7 +145,7 @@ const plugin = {
                 if (panel) return panel;
             }
         }
-        const scoreRowCandidates = document.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+        const scoreRowCandidates = document.querySelectorAll('div.flex.items-center.text-sm.mb-3');
         for (const el of scoreRowCandidates) {
             for (const s of el.querySelectorAll('span')) {
                 if (s.textContent.trim() === 'Score:') {
@@ -160,7 +161,7 @@ const plugin = {
         const gradingPanel = this.getGradingPanelRoot();
         const roots = gradingPanel ? [gradingPanel, document] : [document];
         for (const root of roots) {
-            const candidates = root.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+            const candidates = root.querySelectorAll('div.flex.items-center.text-sm.mb-3');
             for (const el of candidates) {
                 for (const s of el.querySelectorAll('span')) {
                     if (s.textContent.trim() === 'Score:') {
@@ -199,7 +200,7 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? span.textContent.trim() : '';
+            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -1,5 +1,6 @@
 // ============= copy-verifier-output.js =============
 // Adds a copy button in the Grading/verifier panel: after "Stdout" (classic output) or after "Score: #" (checklist verifier). Click copies formatted verifier text to the clipboard.
+// Checklist score row: legacy `gap-2` header or card layout (`justify-between`, sticky) inside `div.p-3` or `div.p-2`.
 // Checklist cards: when "Raw Output" is expanded, a second copy icon copies only the <pre> body.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
@@ -11,7 +12,7 @@ const plugin = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '1.9',
+    _version: '1.10',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -35,7 +36,7 @@ const plugin = {
 
         let container;
         if (scoreRow) {
-            container = scoreRow.closest('div.p-3');
+            container = scoreRow.closest('div.p-3') || scoreRow.closest('div.p-2');
             if (!container) {
                 Logger.debug('Copy Verifier Output: Score card container not found');
                 return;
@@ -142,7 +143,7 @@ const plugin = {
         const gradingPanel = this.getGradingPanelRoot();
         const roots = gradingPanel ? [gradingPanel, document] : [document];
         for (const root of roots) {
-            const candidates = root.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+            const candidates = root.querySelectorAll('div.flex.items-center.text-sm.mb-3');
             for (const el of candidates) {
                 for (const s of el.querySelectorAll('span')) {
                     if (s.textContent.trim() === 'Score:') {
@@ -181,7 +182,7 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? span.textContent.trim() : '';
+            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);

--- a/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-comp-use/main/copy-verifier-output.js
@@ -12,7 +12,7 @@ const plugin = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '1.10',
+    _version: '1.11',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -49,11 +49,12 @@ const plugin = {
             }
         }
 
+        const copyButtonHost = scoreRow ? this.getScoreRowButtonHost(scoreRow) : anchorRow;
         if (!anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
             const button = this.createCopyButton(container);
-            anchorRow.appendChild(button);
-            if (!anchorRow.classList.contains('flex')) {
-                anchorRow.classList.add('flex', 'items-center', 'gap-2');
+            copyButtonHost.appendChild(button);
+            if (!copyButtonHost.classList.contains('flex')) {
+                copyButtonHost.classList.add('flex', 'items-center', 'gap-2');
             }
             if (!state.buttonAdded) {
                 state.buttonAdded = true;
@@ -137,6 +138,17 @@ const plugin = {
             }
         }
         return null;
+    },
+
+    /** When the score lives in an inner flex group and timing is a sibling (`justify-between`), append the copy control there so it stays beside the score. */
+    getScoreRowButtonHost(scoreRow) {
+        for (const s of scoreRow.querySelectorAll('span')) {
+            if (s.textContent.trim() !== 'Score:') continue;
+            const p = s.parentElement;
+            if (p && p !== scoreRow) return p;
+            return scoreRow;
+        }
+        return scoreRow;
     },
 
     findScoreRow() {

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -23,7 +23,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '4.1',
+    _version: '4.2',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -578,7 +578,7 @@ const plugin = {
 
     // Same search logic as copy-verifier-output.js (qa-comp-use)
     findScoreRow() {
-        const candidates = document.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+        const candidates = document.querySelectorAll('div.flex.items-center.text-sm.mb-3');
         for (const el of candidates) {
             for (const s of el.querySelectorAll('span')) {
                 if (s.textContent.trim() === 'Score:') {
@@ -612,7 +612,7 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? span.textContent.trim() : '';
+            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);
@@ -648,7 +648,7 @@ const plugin = {
     tryCaptureVerifierOutput() {
         const scoreRow = this.findScoreRow();
         if (scoreRow) {
-            const container = scoreRow.closest('div.p-3');
+            const container = scoreRow.closest('div.p-3') || scoreRow.closest('div.p-2');
             if (container) {
                 const md = this.buildScoreVerifierMarkdown(container);
                 if (md && md.length > 0) {

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -12,7 +12,7 @@ const plugin = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '2.1',
+    _version: '2.2',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -49,11 +49,12 @@ const plugin = {
             }
         }
 
+        const copyButtonHost = scoreRow ? this.getScoreRowButtonHost(scoreRow) : anchorRow;
         if (!anchorRow.querySelector(`[${COPY_BUTTON_MARKER}="true"]`)) {
             const button = this.createCopyButton(container);
-            anchorRow.appendChild(button);
-            if (!anchorRow.classList.contains('flex')) {
-                anchorRow.classList.add('flex', 'items-center', 'gap-2');
+            copyButtonHost.appendChild(button);
+            if (!copyButtonHost.classList.contains('flex')) {
+                copyButtonHost.classList.add('flex', 'items-center', 'gap-2');
             }
             if (!state.buttonAdded) {
                 state.buttonAdded = true;
@@ -137,6 +138,17 @@ const plugin = {
             }
         }
         return null;
+    },
+
+    /** When the score lives in an inner flex group and timing is a sibling (`justify-between`), append the copy control there so it stays beside the score. */
+    getScoreRowButtonHost(scoreRow) {
+        for (const s of scoreRow.querySelectorAll('span')) {
+            if (s.textContent.trim() !== 'Score:') continue;
+            const p = s.parentElement;
+            if (p && p !== scoreRow) return p;
+            return scoreRow;
+        }
+        return scoreRow;
     },
 
     findScoreRow() {

--- a/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
+++ b/plugins/archetypes/qa-tool-use/main/copy-verifier-output.js
@@ -1,5 +1,6 @@
 // ============= copy-verifier-output.js =============
 // Adds a copy button in the Verifier Output panel: after "Stdout" (classic output) or after "Score: #" (checklist verifier). Click copies formatted verifier text to the clipboard.
+// Checklist score row: legacy `gap-2` header or card layout (`justify-between`, sticky) inside `div.p-3` or `div.p-2`.
 // Checklist cards: when "Raw Output" is expanded, a second copy icon copies only the <pre> body.
 
 const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
@@ -11,7 +12,7 @@ const plugin = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -35,7 +36,7 @@ const plugin = {
 
         let container;
         if (scoreRow) {
-            container = scoreRow.closest('div.p-3');
+            container = scoreRow.closest('div.p-3') || scoreRow.closest('div.p-2');
             if (!container) {
                 Logger.debug('Copy Verifier Output: Score card container not found');
                 return;
@@ -142,7 +143,7 @@ const plugin = {
         const gradingPanel = this.getGradingPanelRoot();
         const roots = gradingPanel ? [gradingPanel, document] : [document];
         for (const root of roots) {
-            const candidates = root.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+            const candidates = root.querySelectorAll('div.flex.items-center.text-sm.mb-3');
             for (const el of candidates) {
                 for (const s of el.querySelectorAll('span')) {
                     if (s.textContent.trim() === 'Score:') {
@@ -181,7 +182,7 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? span.textContent.trim() : '';
+            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -23,7 +23,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '5.1',
+    _version: '5.2',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -472,7 +472,7 @@ const plugin = {
 
     // Same search logic as copy-verifier-output.js
     findScoreRow() {
-        const candidates = document.querySelectorAll('div.text-sm.flex.items-center.gap-2.mb-3');
+        const candidates = document.querySelectorAll('div.flex.items-center.text-sm.mb-3');
         for (const el of candidates) {
             for (const s of el.querySelectorAll('span')) {
                 if (s.textContent.trim() === 'Score:') {
@@ -506,7 +506,7 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? span.textContent.trim() : '';
+            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);
@@ -542,7 +542,7 @@ const plugin = {
     tryCaptureVerifierOutput() {
         const scoreRow = this.findScoreRow();
         if (scoreRow) {
-            const container = scoreRow.closest('div.p-3');
+            const container = scoreRow.closest('div.p-3') || scoreRow.closest('div.p-2');
             if (container) {
                 const md = this.buildScoreVerifierMarkdown(container);
                 if (md && md.length > 0) {


### PR DESCRIPTION
## Summary

Aligns verifier-related UX plugins with an updated UI where the checklist score row uses a card-style layout (`justify-between`), optional `p-2` wrappers, and class order that no longer always includes `gap-2`. Copy-verifier-output and matching score-row logic in request-revisions are updated across dispute-detail and QA archetypes. Developer scripts print the GitHub blob link before the raw install URL, and delete-branch now leaves you on an up-to-date `main` after cleanup. `archetypes.json` reflects propagated plugin versions and hashes.

## Changes

- **Copy verifier output** (dispute-detail, qa-comp-use, qa-tool-use): Broader score-row discovery (`div.flex.items-center.text-sm.mb-3`), support for `p-2` card containers, and `getScoreRowButtonHost` so the copy control attaches next to the score when timing is a sibling in a `justify-between` row.
- **Request revisions** (qa-comp-use, qa-tool-use): Same score-row selector and container matching; normalize span text with whitespace collapse when parsing checklist rows.
- **Dev tooling**: `checkout.sh` shows the blob URL before the raw install URL; `delete-branch.sh` checks out `main`, deletes the branch, then runs `git pull`.
- **Branch config / userscript**: Fleet branch config synced with `main` where applicable.

## New plugins

_None — existing plugins versioned and hashed in `archetypes.json`._

## Commit history

- `e62a696` feat(dev): pull main after delete-branch workflow
- `40a6729` Sync fleet.user.js branch config to main
- `1d5fb8b` Hi @channel, we will be hosting a team huddle tomorrow morning at 11am EST.
- `6b9ef86` checkout.sh: show GitHub blob link before raw install URL
- `ce26ebc` feat(verifier-copy): support card layout score row and p-2 wrapper

_(Omitted: `3c249a8` Sync branch config.)_

## Stats

```
 archetypes.json                                    | 22 ++++++++--------
 dev/utils/checkout.sh                              |  6 ++---
 dev/utils/delete-branch.sh                         |  8 +++---
 .../dispute-detail/main/copy-verifier-output.js    | 29 ++++++++++++++++------
 .../qa-comp-use/main/copy-verifier-output.js       | 27 ++++++++++++++------
 .../qa-comp-use/main/request-revisions.js          |  8 +++---
 .../qa-tool-use/main/copy-verifier-output.js       | 27 ++++++++++++++------
 .../qa-tool-use/main/request-revisions.js          |  8 +++---
 8 files changed, 88 insertions(+), 47 deletions(-)
```
