### PR TITLE
Gate SPA reloads on archetype plugins; QA hide grading; logger and diff UX

### DIFF
--- a/.github/workflows/update-plugin-hashes.yml
+++ b/.github/workflows/update-plugin-hashes.yml
@@ -22,9 +22,36 @@ jobs:
 
       - name: Commit updated hashes
         run: |
-          git diff --quiet archetypes.json && echo "No hash changes" && exit 0
+          if git diff --quiet archetypes.json; then
+            echo "No hash changes"
+            exit 0
+          fi
+
+          OLD="$(mktemp)"
+          trap 'rm -f "$OLD"' EXIT
+          git show HEAD:archetypes.json > "$OLD"
+
+          LIST="$(jq -r -n --slurpfile o "$OLD" --slurpfile n archetypes.json '($o[0]) as $O | ($n[0]) as $N | def bm(a): (a // []) | map({(.name): .hash}) | add // {}; def plugins_for($archetypes; $aid): ($archetypes // [] | map(select(.id == $aid)) | if length > 0 then .[0].plugins // [] else [] end); ((bm($O.corePlugins)) as $oc | (bm($N.corePlugins)) as $nc | ($nc | keys_unsorted[]) as $k | select(($oc[$k] // "") != ($nc[$k] // "")) | "plugins/core/main/\($k)"), ((bm($O.devPlugins)) as $oc | (bm($N.devPlugins)) as $nc | ($nc | keys_unsorted[]) as $k | select(($oc[$k] // "") != ($nc[$k] // "")) | "plugins/core/dev/\($k)"), (($N.archetypes // [])[] as $na | $na.id as $aid | (bm(plugins_for($O.archetypes; $aid))) as $oc | (bm($na.plugins)) as $nc | ($nc | keys_unsorted[]) as $k | select(($oc[$k] // "") != ($nc[$k] // "")) | "plugins/archetypes/\($aid)/main/\($k)"), (($N.devArchetypes // [])[] as $na | $na.id as $aid | (bm(plugins_for($O.devArchetypes; $aid))) as $oc | (bm($na.plugins)) as $nc | ($nc | keys_unsorted[]) as $k | select(($oc[$k] // "") != ($nc[$k] // "")) | "plugins/archetypes/\($aid)/dev/\($k)")' | sort -u)"
+
+          echo "Plugins with updated hashes:"
+          if [[ -n "$LIST" ]]; then
+            echo "$LIST" | sed 's/^/- /'
+            {
+              echo "### Plugins with updated hashes"
+              echo ""
+              echo "$LIST" | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
+            BODY="Updated hashes for:"$'\n'"$(echo "$LIST" | sed 's/^/- /')"
+          else
+            echo "(none detected by hash diff; see archetypes.json changes)"
+            echo "### archetypes.json changed" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Plugin list could not be derived from hash field diffs; inspect the commit diff." >> "$GITHUB_STEP_SUMMARY"
+            BODY="archetypes.json updated; inspect diff for details."
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add archetypes.json
-          git commit -m "CI: update plugin hashes"
+          git commit -m "CI: update plugin hashes" -m "$BODY"
           git push

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.85",
+  "archetypesVersion": "6.86",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -378,6 +378,11 @@
           "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37"
         },
         {
+          "name": "hide-grading-panel-button.js",
+          "version": "1.0",
+          "hash": "sha256-51691284c97e8ea6018d57362192fb1b30f1fe36939134f309c78a63f67b1dfb"
+        },
+        {
           "name": "clear-search.js",
           "version": "2.1",
           "hash": "sha256-1c909857b79e8a369bd2e9a1767445fbfc0f77ae50c40b2c6fb09e879c7357f3"
@@ -490,6 +495,11 @@
           "name": "hide-grading-autoclick.js",
           "version": "1.0",
           "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37"
+        },
+        {
+          "name": "hide-grading-panel-button.js",
+          "version": "1.0",
+          "hash": "sha256-51691284c97e8ea6018d57362192fb1b30f1fe36939134f309c78a63f67b1dfb"
         },
         {
           "name": "bug-report-expand.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.88",
+  "archetypesVersion": "6.89",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -16,8 +16,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.7",
-      "hash": "sha256-bbfcb6423e97512f1afa26a6aeb0bcc0380fa0cc01f47819966acdfe73d1ad0d"
+      "version": "2.8",
+      "hash": "sha256-f61da8733fe9d961e169d66445bf0fe372295f15dd667152353ced6675ff5825"
     }
   ],
   "settingsModalDocs": [

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.86",
+  "archetypesVersion": "6.87",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -379,8 +379,8 @@
         },
         {
           "name": "hide-grading-panel-button.js",
-          "version": "1.0",
-          "hash": "sha256-51691284c97e8ea6018d57362192fb1b30f1fe36939134f309c78a63f67b1dfb"
+          "version": "1.1",
+          "hash": "sha256-1dc570e2137afa59627bc0ce6a4adfb37487b346b5317ddd629db7ce84aa6f88"
         },
         {
           "name": "clear-search.js",
@@ -498,8 +498,8 @@
         },
         {
           "name": "hide-grading-panel-button.js",
-          "version": "1.0",
-          "hash": "sha256-51691284c97e8ea6018d57362192fb1b30f1fe36939134f309c78a63f67b1dfb"
+          "version": "1.1",
+          "hash": "sha256-1dc570e2137afa59627bc0ce6a4adfb37487b346b5317ddd629db7ce84aa6f88"
         },
         {
           "name": "bug-report-expand.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
-  "version": "6.1.2",
-  "archetypesVersion": "6.81",
+  "version": "6.2.0",
+  "archetypesVersion": "6.83",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,11 +1,11 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.87",
+  "archetypesVersion": "6.88",
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.1",
-      "hash": "sha256-b73eddefd35b3053f0256f00f05e664029aced364948f8824836eea0d2566286"
+      "version": "6.2",
+      "hash": "sha256-eac152cd0dbcf5c97bff3ddc17c3ccc65a2fadfbca2af55e0f89f62b4febf07c"
     },
     {
       "name": "extension-ping.js",
@@ -16,8 +16,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.6",
-      "hash": "sha256-c3ed59d35a36fb23fd7982ed3144a68f1bdd18d05086788fd4c8d249eab2b848"
+      "version": "2.7",
+      "hash": "sha256-bbfcb6423e97512f1afa26a6aeb0bcc0380fa0cc01f47819966acdfe73d1ad0d"
     }
   ],
   "settingsModalDocs": [
@@ -686,13 +686,13 @@
       "plugins": [
         {
           "name": "prompt-and-notes-areas.js",
-          "version": "3.1",
-          "hash": "sha256-6139e763f20b96517308fd3c9c2960c92534de686c618a408d205518bdc598ed"
+          "version": "3.2",
+          "hash": "sha256-d9a54732ae808069a93f5be524b2d3327de24532e33c07be57d9747dd7d8dcb5"
         },
         {
           "name": "tool-description-truncate.js",
-          "version": "2.1",
-          "hash": "sha256-3062ae5abb6df57a519dc08c43e04db1f852c9f7359304c01eeebece158b14d4"
+          "version": "2.2",
+          "hash": "sha256-39e3660beef1dc7e6aefbc03c512fdfe28f8b87d25edb187c71cb86eb712826c"
         }
       ]
     },
@@ -768,8 +768,8 @@
       "plugins": [
         {
           "name": "dispute-ids-enhancer.js",
-          "version": "3.1",
-          "hash": "sha256-4c885d4706a1b1a367213b45dea7842424a124a7db38f457e4d5bad9cc80d1d7"
+          "version": "3.2",
+          "hash": "sha256-4be4922a61174e06e13a16e0840d38f53e8e2861199cf7d256c8f08ff926ef3e"
         }
       ]
     }

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.83",
+  "archetypesVersion": "6.84",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -264,8 +264,8 @@
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "3.3",
-          "hash": "sha256-d226b94bccd038122217639d34bafc2417f4b573afe3c9b373b63c3bdee8d9af"
+          "version": "3.4",
+          "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997"
         }
       ]
     },
@@ -431,8 +431,8 @@
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "2.3",
-          "hash": "sha256-3f354b0619991574f9718b2a2607278bf2711a354a9f9f24a6cd03a15ebfc4eb"
+          "version": "2.4",
+          "hash": "sha256-a3dc5ca34efb8e988da115e7528b381790fa7cea7ff50267e8f7582fc603b234"
         },
         {
           "name": "tool-results-resize-handle.js",
@@ -520,13 +520,13 @@
         },
         {
           "name": "prompt-diff-highlight.js",
-          "version": "2.3",
-          "hash": "sha256-3f354b0619991574f9718b2a2607278bf2711a354a9f9f24a6cd03a15ebfc4eb"
+          "version": "2.4",
+          "hash": "sha256-a3dc5ca34efb8e988da115e7528b381790fa7cea7ff50267e8f7582fc603b234"
         },
         {
           "name": "verifier-diff-highlight-improved.js",
-          "version": "1.4",
-          "hash": "sha256-d8c9f49082a3d7fef6f85daa5e806041fdde49746064f74ff66336772fa91978"
+          "version": "1.5",
+          "hash": "sha256-70e886f9378a8ac6c5bea333b75e2d6a66d510eae03fbd7af3d8eff3a0e687f6"
         },
         {
           "name": "accept-task-modal-improvements.js",
@@ -617,8 +617,8 @@
         },
         {
           "name": "verifier-diff-highlight-improved.js",
-          "version": "1.4",
-          "hash": "sha256-e0ef7a8f1f8b53aa0ac26661d5d2f0024b3739c43e9f673a6ec982474a8239f8"
+          "version": "1.5",
+          "hash": "sha256-42fe5f4290fc72eda17ecfc93176ea0c078017a52abeede23ed26ef59dccaf62"
         }
       ]
     },
@@ -631,8 +631,8 @@
       "plugins": [
         {
           "name": "prompt-diff-highlight.js",
-          "version": "3.3",
-          "hash": "sha256-d226b94bccd038122217639d34bafc2417f4b573afe3c9b373b63c3bdee8d9af"
+          "version": "3.4",
+          "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997"
         }
       ]
     }

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.89",
+  "archetypesVersion": "6.90",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -16,8 +16,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.8",
-      "hash": "sha256-f61da8733fe9d961e169d66445bf0fe372295f15dd667152353ced6675ff5825"
+      "version": "2.9",
+      "hash": "sha256-d7283f301f13c35707de9fc645d42abe7a63ddfdd4dd0b29edf2abf07e8b1867"
     }
   ],
   "settingsModalDocs": [

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,6 @@
 {
   "version": "6.2.0",
-  "archetypesVersion": "6.84",
+  "archetypesVersion": "6.85",
   "corePlugins": [
     {
       "name": "settings-ui.js",
@@ -268,6 +268,14 @@
           "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997"
         }
       ]
+    },
+    {
+      "id": "create-task-project-selection",
+      "name": "Create Task Project Selection",
+      "description": "Screen for choosing a project before creating a task",
+      "urlPattern": "work/problems/create-instance",
+      "disambiguationSelectors": [],
+      "plugins": []
     },
     {
       "id": "comp-use-task-creation",
@@ -708,6 +716,14 @@
           "hash": "sha256-1f7708627f64c04c6f92a33c49c783a79ff144ea7485cf4a285d805d758ed72d"
         }
       ]
+    },
+    {
+      "id": "create-task-project-selection",
+      "name": "Create Task Project Selection",
+      "description": "Screen for choosing a project before creating a task",
+      "urlPattern": "work/problems/create-instance",
+      "disambiguationSelectors": [],
+      "plugins": []
     },
     {
       "id": "comp-use-task-creation",

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1860,8 +1860,8 @@
             this.cleanupDeprecatedCache(pluginList, archetypeId, 'dev');
             
             Logger.log('Dev archetype plugin loading complete');
-            // Dev archetype plugins respect dev-global default off same as core dev plugins.
-            if (!Storage.get('dev-global-plugins-enabled', false)) {
+            // Dev archetype plugins: when dev-global is off, disable all; on dev builds default is on (see Storage.get default).
+            if (!Storage.get('dev-global-plugins-enabled', DEV_SCRIPTS_ENABLED)) {
                 PluginManager.getDevPlugins().forEach(p => PluginManager.setEnabled(p.id, false));
             }
         },
@@ -2103,8 +2103,8 @@
         if (DEV_SCRIPTS_ENABLED) {
             const devPlugins = ArchetypeManager.getDevPlugins();
             await PluginLoader.loadPluginsFromConfig(devPlugins, 'dev');
-            // Dev tools default off regardless of per-plugin enabledByDefault; enforce before runCorePlugins.
-            if (!Storage.get('dev-global-plugins-enabled', false)) {
+            // When dev-global is off, disable all dev plugins before runCorePlugins. On dev builds the default is on (logger + optional archetype dev).
+            if (!Storage.get('dev-global-plugins-enabled', DEV_SCRIPTS_ENABLED)) {
                 PluginManager.getDevPlugins().forEach(p => PluginManager.setEnabled(p.id, false));
             }
         }

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-fix-partial-arch-match] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-fix-partial-arch-match/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-fix-partial-arch-match/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-fix-partial-arch-match',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-fix-partial-arch-match] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      6.1.2
+// @version      6.2.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '6.1.2';
+    const VERSION = '6.2.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -2217,6 +2217,37 @@
             return null;
         }
     }
+
+    /**
+     * Whether SPA navigation to this path should trigger a full reload (archetype plugins
+     * are listed in archetypes.json for the main archetype and/or devArchetypes when dev is on).
+     */
+    function navigationTargetHasConfiguredPlugins(newPath) {
+        const mainHasPlugins = ArchetypeManager.archetypes.some((archetype) => {
+            if (!archetype.urlPattern) {
+                return false;
+            }
+            if (!UrlMatcher.matches(newPath, archetype.urlPattern)) {
+                return false;
+            }
+            return (archetype.plugins || []).length > 0;
+        });
+        if (mainHasPlugins) {
+            return true;
+        }
+        if (DEV_SCRIPTS_ENABLED) {
+            return ArchetypeManager.devArchetypes.some((devArchetype) => {
+                if (!devArchetype.urlPattern) {
+                    return false;
+                }
+                if (!UrlMatcher.matches(newPath, devArchetype.urlPattern)) {
+                    return false;
+                }
+                return (devArchetype.plugins || []).length > 0;
+            });
+        }
+        return false;
+    }
     
     async function handleNavigation(newUrl, previousUrl) {
         Logger.log('Handling navigation, checking URL diff...');
@@ -2257,15 +2288,22 @@
             }
 
             const newPath = UrlMatcher.getPathFromUrl(newUrl);
-            const matchesArchetype = ArchetypeManager.archetypes.some(archetype => {
+            const matchesMainArchetypePath = ArchetypeManager.archetypes.some((archetype) => {
                 if (!archetype.urlPattern) {
                     return false;
                 }
                 return UrlMatcher.matches(newPath, archetype.urlPattern);
             });
+            const warrantsFullReload = navigationTargetHasConfiguredPlugins(newPath);
 
-            if (matchesArchetype) {
-                Logger.log('Navigation target matches archetype; refreshing page...');
+            if (matchesMainArchetypePath && !warrantsFullReload) {
+                Logger.log(
+                    'Navigation matches an archetype URL pattern but no configured main/dev plugins warrant a full reload; skipping reload...'
+                );
+            }
+
+            if (warrantsFullReload) {
+                Logger.log('Navigation target has configured archetype plugins; refreshing page...');
                 Storage.delete('workflow-cache-latest');
                 Storage.delete('workflow-cache-latest-url');
                 location.reload();

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-fix-partial-arch-match] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.2.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-fix-partial-arch-match/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-fix-partial-arch-match/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-fix-partial-arch-match',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/verifier-diff-highlight-improved.js
+++ b/plugins/archetypes/dispute-detail/main/verifier-diff-highlight-improved.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'verifierDiffHighlightImproved',
     name: 'Verifier Diff Highlight (Improved)',
     description: 'Custom side-by-side diff viewer for Expected vs Your Answer in verifier output',
-    _version: '1.4',
+    _version: '1.5',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -69,7 +69,6 @@ const plugin = {
             .verifier-diff-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -81,7 +80,6 @@ const plugin = {
             .verifier-diff-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -923,8 +921,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
 

--- a/plugins/archetypes/disputes/dev/dispute-ids-enhancer.js
+++ b/plugins/archetypes/disputes/dev/dispute-ids-enhancer.js
@@ -5,8 +5,8 @@ const plugin = {
     id: 'disputeIdsEnhancer',
     name: 'Dispute IDs Enhancer',
     description: 'Surface Dispute and Task IDs at top of dispute cards.',
-    _version: '3.1',
-    enabledByDefault: true,
+    _version: '3.2',
+    enabledByDefault: false,
     phase: 'mutation',
 
     initialState: {

--- a/plugins/archetypes/qa-comp-use/deprecated/verifier-diff-highlight.js
+++ b/plugins/archetypes/qa-comp-use/deprecated/verifier-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'verifierDiffHighlightV1',
     name: 'Verifier Diff Highlighting',
     description: 'Character-level diff between Expected and Your Answer in verifier output',
-    _version: '3.0',
+    _version: '3.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -51,7 +51,6 @@ const plugin = {
             .verifier-diff-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -63,7 +62,6 @@ const plugin = {
             .verifier-diff-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -421,8 +419,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
 

--- a/plugins/archetypes/qa-comp-use/main/hide-grading-panel-button.js
+++ b/plugins/archetypes/qa-comp-use/main/hide-grading-panel-button.js
@@ -9,7 +9,7 @@ const plugin = {
     name: 'Hide Grading Panel Button',
     description:
         'Adds Hide Grading in the Grading panel header; delegates to the top Hide Grading control when grading is open.',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -65,6 +65,7 @@ const plugin = {
                 : Array.from(document.querySelectorAll('button'));
 
         for (const btn of buttons) {
+            if (btn.getAttribute(BTN_ATTR) === 'true') continue;
             const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
             if (text === 'Hide Grading') {
                 return btn;
@@ -79,13 +80,47 @@ const plugin = {
         return true;
     },
 
+    /** Lucide eye-off icon (matches native Hide Grading control). */
+    createHideGradingIcon() {
+        const ns = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(ns, 'svg');
+        svg.setAttribute('width', '24');
+        svg.setAttribute('height', '24');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('stroke-width', '2');
+        svg.setAttribute('stroke-linecap', 'round');
+        svg.setAttribute('stroke-linejoin', 'round');
+        svg.setAttribute('class', 'size-3.5');
+
+        const pathDs = [
+            'M9.88 9.88a3 3 0 1 0 4.24 4.24',
+            'M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68',
+            'M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61'
+        ];
+        for (const d of pathDs) {
+            const path = document.createElementNS(ns, 'path');
+            path.setAttribute('d', d);
+            svg.appendChild(path);
+        }
+        const line = document.createElementNS(ns, 'line');
+        line.setAttribute('x1', '2');
+        line.setAttribute('x2', '22');
+        line.setAttribute('y1', '2');
+        line.setAttribute('y2', '22');
+        svg.appendChild(line);
+        return svg;
+    },
+
     createButton() {
         const button = document.createElement('button');
         button.type = 'button';
         button.setAttribute(BTN_ATTR, 'true');
         button.className =
             'inline-flex items-center justify-center whitespace-nowrap rounded-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground h-7 text-xs pl-2 pr-2 py-1 gap-1.5 shrink-0';
-        button.textContent = 'Hide Grading';
+        button.appendChild(this.createHideGradingIcon());
+        button.appendChild(document.createTextNode('Hide Grading'));
         button.setAttribute('aria-label', 'Hide Grading');
         button.addEventListener('click', () => {
             const native = this.findNativeHideGradingButton();

--- a/plugins/archetypes/qa-comp-use/main/hide-grading-panel-button.js
+++ b/plugins/archetypes/qa-comp-use/main/hide-grading-panel-button.js
@@ -1,0 +1,111 @@
+
+// ============= hide-grading-panel-button.js =============
+// Adds "Hide Grading" on the right side of the bottom Grading panel tab bar. Clicks the page's native toggle only when its label is "Hide Grading" (grading is visible).
+
+const BTN_ATTR = 'data-fleet-hide-grading-panel-btn';
+
+const plugin = {
+    id: 'hideGradingPanelButton',
+    name: 'Hide Grading Panel Button',
+    description:
+        'Adds Hide Grading in the Grading panel header; delegates to the top Hide Grading control when grading is open.',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        addedLogged: false,
+        toolbarMissingLogged: false
+    },
+
+    onMutation(state) {
+        const row = this.findGradingTabToolbarRow();
+        if (!row) {
+            if (!state.toolbarMissingLogged) {
+                Logger.debug('Hide Grading Panel Button: Grading tab toolbar row not found');
+                state.toolbarMissingLogged = true;
+            }
+            return;
+        }
+        state.toolbarMissingLogged = false;
+
+        if (row.querySelector(`[${BTN_ATTR}="true"]`)) {
+            return;
+        }
+
+        row.appendChild(this.createButton());
+        if (!state.addedLogged) {
+            state.addedLogged = true;
+            Logger.log('Hide Grading Panel Button: control added to Grading panel header');
+        }
+    },
+
+    findGradingTabToolbarRow() {
+        const tab = document.querySelector(
+            'button[role="tab"][aria-controls*="verifier-output"]'
+        );
+        if (!tab) return null;
+        const tablist = tab.closest('[role="tablist"]');
+        if (!tablist) return null;
+        const row = tablist.parentElement;
+        if (
+            !row ||
+            !row.classList.contains('flex') ||
+            !row.classList.contains('justify-between')
+        ) {
+            return null;
+        }
+        return row;
+    },
+
+    findNativeHideGradingButton() {
+        const options = { context: `${this.id}.findNativeHideGradingButton` };
+        const buttons =
+            typeof Context !== 'undefined' && Context.dom
+                ? Context.dom.queryAll('button', options)
+                : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+            if (text === 'Hide Grading') {
+                return btn;
+            }
+        }
+        return null;
+    },
+
+    isButtonClickable(button) {
+        if (button.disabled) return false;
+        if (button.getAttribute('aria-disabled') === 'true') return false;
+        return true;
+    },
+
+    createButton() {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.setAttribute(BTN_ATTR, 'true');
+        button.className =
+            'inline-flex items-center justify-center whitespace-nowrap rounded-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground h-7 text-xs pl-2 pr-2 py-1 gap-1.5 shrink-0';
+        button.textContent = 'Hide Grading';
+        button.setAttribute('aria-label', 'Hide Grading');
+        button.addEventListener('click', () => {
+            const native = this.findNativeHideGradingButton();
+            if (!native) {
+                Logger.debug(
+                    'Hide Grading Panel Button: native control not in Hide Grading state (skipping)'
+                );
+                return;
+            }
+            if (!this.isButtonClickable(native)) {
+                Logger.debug('Hide Grading Panel Button: native Hide Grading not clickable');
+                return;
+            }
+            try {
+                native.click();
+                Logger.debug('Hide Grading Panel Button: triggered native Hide Grading');
+            } catch (error) {
+                Logger.error('Hide Grading Panel Button: failed to click native control', error);
+            }
+        });
+        return button;
+    }
+};

--- a/plugins/archetypes/qa-comp-use/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/qa-comp-use/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '2.3',
+    _version: '2.4',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -37,7 +37,6 @@ const plugin = {
             pre .diff-highlight-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -49,7 +48,6 @@ const plugin = {
             pre .diff-highlight-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -723,8 +721,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
     

--- a/plugins/archetypes/qa-comp-use/main/verifier-diff-highlight-improved.js
+++ b/plugins/archetypes/qa-comp-use/main/verifier-diff-highlight-improved.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'verifierDiffHighlightImproved',
     name: 'Verifier Diff Highlight (Improved)',
     description: 'Custom side-by-side diff viewer for Expected vs Your Answer in verifier output',
-    _version: '1.4',
+    _version: '1.5',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -68,7 +68,6 @@ const plugin = {
             .verifier-diff-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -80,7 +79,6 @@ const plugin = {
             .verifier-diff-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -922,8 +920,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
 

--- a/plugins/archetypes/qa-tool-use/main/hide-grading-panel-button.js
+++ b/plugins/archetypes/qa-tool-use/main/hide-grading-panel-button.js
@@ -9,7 +9,7 @@ const plugin = {
     name: 'Hide Grading Panel Button',
     description:
         'Adds Hide Grading in the Grading panel header; delegates to the top Hide Grading control when grading is open.',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -65,6 +65,7 @@ const plugin = {
                 : Array.from(document.querySelectorAll('button'));
 
         for (const btn of buttons) {
+            if (btn.getAttribute(BTN_ATTR) === 'true') continue;
             const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
             if (text === 'Hide Grading') {
                 return btn;
@@ -79,13 +80,47 @@ const plugin = {
         return true;
     },
 
+    /** Lucide eye-off icon (matches native Hide Grading control). */
+    createHideGradingIcon() {
+        const ns = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(ns, 'svg');
+        svg.setAttribute('width', '24');
+        svg.setAttribute('height', '24');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('stroke-width', '2');
+        svg.setAttribute('stroke-linecap', 'round');
+        svg.setAttribute('stroke-linejoin', 'round');
+        svg.setAttribute('class', 'size-3.5');
+
+        const pathDs = [
+            'M9.88 9.88a3 3 0 1 0 4.24 4.24',
+            'M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68',
+            'M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61'
+        ];
+        for (const d of pathDs) {
+            const path = document.createElementNS(ns, 'path');
+            path.setAttribute('d', d);
+            svg.appendChild(path);
+        }
+        const line = document.createElementNS(ns, 'line');
+        line.setAttribute('x1', '2');
+        line.setAttribute('x2', '22');
+        line.setAttribute('y1', '2');
+        line.setAttribute('y2', '22');
+        svg.appendChild(line);
+        return svg;
+    },
+
     createButton() {
         const button = document.createElement('button');
         button.type = 'button';
         button.setAttribute(BTN_ATTR, 'true');
         button.className =
             'inline-flex items-center justify-center whitespace-nowrap rounded-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground h-7 text-xs pl-2 pr-2 py-1 gap-1.5 shrink-0';
-        button.textContent = 'Hide Grading';
+        button.appendChild(this.createHideGradingIcon());
+        button.appendChild(document.createTextNode('Hide Grading'));
         button.setAttribute('aria-label', 'Hide Grading');
         button.addEventListener('click', () => {
             const native = this.findNativeHideGradingButton();

--- a/plugins/archetypes/qa-tool-use/main/hide-grading-panel-button.js
+++ b/plugins/archetypes/qa-tool-use/main/hide-grading-panel-button.js
@@ -1,0 +1,111 @@
+
+// ============= hide-grading-panel-button.js =============
+// Adds "Hide Grading" on the right side of the bottom Grading panel tab bar. Clicks the page's native toggle only when its label is "Hide Grading" (grading is visible).
+
+const BTN_ATTR = 'data-fleet-hide-grading-panel-btn';
+
+const plugin = {
+    id: 'hideGradingPanelButton',
+    name: 'Hide Grading Panel Button',
+    description:
+        'Adds Hide Grading in the Grading panel header; delegates to the top Hide Grading control when grading is open.',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        addedLogged: false,
+        toolbarMissingLogged: false
+    },
+
+    onMutation(state) {
+        const row = this.findGradingTabToolbarRow();
+        if (!row) {
+            if (!state.toolbarMissingLogged) {
+                Logger.debug('Hide Grading Panel Button: Grading tab toolbar row not found');
+                state.toolbarMissingLogged = true;
+            }
+            return;
+        }
+        state.toolbarMissingLogged = false;
+
+        if (row.querySelector(`[${BTN_ATTR}="true"]`)) {
+            return;
+        }
+
+        row.appendChild(this.createButton());
+        if (!state.addedLogged) {
+            state.addedLogged = true;
+            Logger.log('Hide Grading Panel Button: control added to Grading panel header');
+        }
+    },
+
+    findGradingTabToolbarRow() {
+        const tab = document.querySelector(
+            'button[role="tab"][aria-controls*="verifier-output"]'
+        );
+        if (!tab) return null;
+        const tablist = tab.closest('[role="tablist"]');
+        if (!tablist) return null;
+        const row = tablist.parentElement;
+        if (
+            !row ||
+            !row.classList.contains('flex') ||
+            !row.classList.contains('justify-between')
+        ) {
+            return null;
+        }
+        return row;
+    },
+
+    findNativeHideGradingButton() {
+        const options = { context: `${this.id}.findNativeHideGradingButton` };
+        const buttons =
+            typeof Context !== 'undefined' && Context.dom
+                ? Context.dom.queryAll('button', options)
+                : Array.from(document.querySelectorAll('button'));
+
+        for (const btn of buttons) {
+            const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+            if (text === 'Hide Grading') {
+                return btn;
+            }
+        }
+        return null;
+    },
+
+    isButtonClickable(button) {
+        if (button.disabled) return false;
+        if (button.getAttribute('aria-disabled') === 'true') return false;
+        return true;
+    },
+
+    createButton() {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.setAttribute(BTN_ATTR, 'true');
+        button.className =
+            'inline-flex items-center justify-center whitespace-nowrap rounded-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground h-7 text-xs pl-2 pr-2 py-1 gap-1.5 shrink-0';
+        button.textContent = 'Hide Grading';
+        button.setAttribute('aria-label', 'Hide Grading');
+        button.addEventListener('click', () => {
+            const native = this.findNativeHideGradingButton();
+            if (!native) {
+                Logger.debug(
+                    'Hide Grading Panel Button: native control not in Hide Grading state (skipping)'
+                );
+                return;
+            }
+            if (!this.isButtonClickable(native)) {
+                Logger.debug('Hide Grading Panel Button: native Hide Grading not clickable');
+                return;
+            }
+            try {
+                native.click();
+                Logger.debug('Hide Grading Panel Button: triggered native Hide Grading');
+            } catch (error) {
+                Logger.error('Hide Grading Panel Button: failed to click native control', error);
+            }
+        });
+        return button;
+    }
+};

--- a/plugins/archetypes/qa-tool-use/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/qa-tool-use/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '2.3',
+    _version: '2.4',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -37,7 +37,6 @@ const plugin = {
             pre .diff-highlight-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -49,7 +48,6 @@ const plugin = {
             pre .diff-highlight-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -723,8 +721,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
     

--- a/plugins/archetypes/task-view/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/task-view/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '3.3',
+    _version: '3.4',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -37,7 +37,6 @@ const plugin = {
             pre .diff-highlight-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -49,7 +48,6 @@ const plugin = {
             pre .diff-highlight-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -723,8 +721,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
     

--- a/plugins/archetypes/tool-use-revision/main/prompt-diff-highlight.js
+++ b/plugins/archetypes/tool-use-revision/main/prompt-diff-highlight.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'promptDiffHighlightV1',
     name: 'Prompt Diff Highlighting',
     description: 'Highlights word-level and character-level changes in the Prompt Changes modal',
-    _version: '3.3',
+    _version: '3.4',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -37,7 +37,6 @@ const plugin = {
             pre .diff-highlight-remove {
                 background-color: rgba(239, 68, 68, 0.35) !important;
                 color: rgb(127, 29, 29) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -49,7 +48,6 @@ const plugin = {
             pre .diff-highlight-add {
                 background-color: rgba(16, 185, 129, 0.35) !important;
                 color: rgb(6, 78, 59) !important;
-                padding: 0 0.125rem;
                 border-radius: 3px;
                 box-decoration-break: clone;
                 -webkit-box-decoration-break: clone;
@@ -723,8 +721,8 @@ const plugin = {
         const removeBg = isDark ? 'rgba(239, 68, 68, 0.25)' : 'rgba(239, 68, 68, 0.3)';
         const addBg = isDark ? 'rgba(16, 185, 129, 0.25)' : 'rgba(16, 185, 129, 0.3)';
         return {
-            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`,
-            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;padding:0 0.125rem;`
+            remove: `background-color:${removeBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`,
+            add: `background-color:${addBg};border-radius:3px;box-decoration-break:clone;-webkit-box-decoration-break:clone;`
         };
     },
     

--- a/plugins/archetypes/tool-use-task-creation-openclaw/dev/prompt-and-notes-areas.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/dev/prompt-and-notes-areas.js
@@ -6,8 +6,8 @@ const plugin = {
     id: 'promptAndNotesAreas',
     name: 'Prompt and Notes Areas Layout',
     description: 'Anchors scratchpad to bottom and makes prompt handle control both areas',
-    _version: '3.1',
-    enabledByDefault: true,
+    _version: '3.2',
+    enabledByDefault: false,
     phase: 'mutation',
     
     // ========== SUB-OPTIONS ==========

--- a/plugins/archetypes/tool-use-task-creation-openclaw/dev/tool-description-truncate.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/dev/tool-description-truncate.js
@@ -30,8 +30,8 @@ const plugin = {
     id: 'toolDescriptionTruncate',
     name: 'Tool Description Truncation',
     description: 'Limits the length tool descriptions to make the tool picker more manageable',
-    _version: '2.1',
-    enabledByDefault: true,
+    _version: '2.2',
+    enabledByDefault: false,
     phase: 'mutation',
     initialState: {},
 

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.8',
+    _version: '2.9',
     enabledByDefault: true,
     phase: 'core',
 
@@ -616,14 +616,19 @@ const plugin = {
     },
 
     async _copyAll(state) {
-        const text = state.logs.map((log) => log.text).join('\n');
+        const visibleLogs = state.logs.filter(
+            (log) => log.node && log.node.style.display !== 'none'
+        );
+        const text = visibleLogs.map((log) => log.text).join('\n');
         const ui = state.ui;
         const btn = ui && ui.copyButton;
         const ok = await this._copyToClipboard(text);
         if (btn) {
             this._flashDevLoggerCopyFeedback(btn, ok);
         }
-        if (!ok && text) {
+        if (!text && state.logs.length > 0) {
+            Logger.warn('Dev logger: copy skipped (no visible logs for current filter)');
+        } else if (!ok && text) {
             Logger.warn('Dev logger: copy all to clipboard failed');
         }
     },

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.7',
+    _version: '2.8',
     enabledByDefault: true,
     phase: 'core',
 
@@ -154,6 +154,18 @@ const plugin = {
         copyButton.style.color = 'inherit';
         copyButton.style.cursor = 'pointer';
 
+        const refreshButton = document.createElement('button');
+        refreshButton.type = 'button';
+        refreshButton.textContent = 'Refresh';
+        refreshButton.title = 'Reload the page';
+        refreshButton.style.fontSize = '11px';
+        refreshButton.style.padding = '2px 6px';
+        refreshButton.style.borderRadius = '6px';
+        refreshButton.style.border = '1px solid rgba(255,255,255,0.2)';
+        refreshButton.style.background = 'transparent';
+        refreshButton.style.color = 'inherit';
+        refreshButton.style.cursor = 'pointer';
+
         const minimizeButton = document.createElement('button');
         minimizeButton.type = 'button';
         minimizeButton.textContent = 'Minimize';
@@ -270,6 +282,7 @@ const plugin = {
 
         headerActions.appendChild(clearButton);
         headerActions.appendChild(copyButton);
+        headerActions.appendChild(refreshButton);
         headerActions.appendChild(minimizeButton);
         header.appendChild(headerTitle);
         header.appendChild(headerActions);
@@ -301,6 +314,7 @@ const plugin = {
             headerActions,
             clearButton,
             copyButton,
+            refreshButton,
             minimizeButton,
             searchInput,
             bodyWrapper,
@@ -375,6 +389,10 @@ const plugin = {
                 void this._copyAll(state);
             },
             onMinimize: () => this._updateVisibility(state, false),
+            onRefresh: () => {
+                Logger.log('✓ Dev logger: refresh page requested');
+                window.location.reload();
+            },
             onSearch: (event) => {
                 state.searchQuery = event.target.value.trim().toLowerCase();
                 this._applySearchFilter(state);
@@ -419,6 +437,7 @@ const plugin = {
         ui.toggleButton.addEventListener('click', state.handlers.onToggle);
         ui.clearButton.addEventListener('click', state.handlers.onClear);
         ui.copyButton.addEventListener('click', state.handlers.onCopyAll);
+        ui.refreshButton.addEventListener('click', state.handlers.onRefresh);
         ui.minimizeButton.addEventListener('click', state.handlers.onMinimize);
         ui.searchInput.addEventListener('input', state.handlers.onSearch);
         ui.resizeHandle.addEventListener('mousedown', state.handlers.onResizeStart);

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,8 +5,8 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.6',
-    enabledByDefault: false,
+    _version: '2.7',
+    enabledByDefault: true,
     phase: 'core',
 
     storageKeys: {

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '6.1',
+    _version: '6.2',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
     
@@ -1604,8 +1604,8 @@ const plugin = {
     },
 
     _getDevGlobalEnabled() {
-        // Default off: dev tools disabled until explicitly enabled (overrides per-plugin enabledByDefault).
-        return Storage.get('dev-global-plugins-enabled', false);
+        // Main-like builds: default off. Dev branches: default on so dev archetype plugins load; per-plugin defaults still apply.
+        return Storage.get('dev-global-plugins-enabled', Context.isDevBranch);
     },
 
     _setDevGlobalEnabled(enabled) {


### PR DESCRIPTION
## Summary

Tightens when Fleet reloads the page on in-app navigation so partial archetype matches do not trigger unnecessary full reloads; extends archetypes and tooling for QA grading UX, diff highlighting polish, create-task flows, logger panel behavior, and dev default plugin toggles. CI workflow output is clearer when archetype hashes are auto-updated.

## Changes

- **Navigation / fleet bootstrap**: SPA navigations trigger a reload only when the active archetype’s plugin list in `archetypes.json` warrants it, avoiding reloads for routes that only partially match an archetype pattern.
- **Archetypes**: Registers `create-task-project-selection` for `/work/problems/create-instance` and updates hashes / listings across affected archetypes.
- **Diff highlights**: Removes horizontal padding from diff highlight spans in verifier/prompt diff plugins (main, QA, task-view, tool-use-task-creation) for cleaner alignment.
- **QA grading**: Adds a “Hide Grading” control in the grading panel header (qa-comp-use and qa-tool-use), with proxy handling that excludes the script’s own UI and uses an eye-off affordance on the button.
- **Logger panel**: Adds a Refresh control to reload the page; copy-to-clipboard respects the active search filter so only visible lines are copied.
- **Dev defaults**: Default-on for dev global and logger; other dev plugins default off. Settings UI text adjusted accordingly.
- **CI**: `update-plugin-hashes` workflow lists plugins when updating archetype hashes for easier review in logs.
- **Misc**: Small tweaks to dispute/prompt plugins and `fleet.user.js` branch config sync with main.

## New plugins

| Archetype(s) | Plugin | Role |
|--------------|--------|------|
| qa-comp-use, qa-tool-use | `hide-grading-panel-button.js` | Toggle to hide the grading panel from the panel header |

## Commit history

- `be07688` Sync fleet.user.js branch config to main
- `9e35012` fix(logger-panel): Copy respects search — only visible log lines
- `884a455` feat(logger-panel): add Refresh button to reload the page
- `beec4b8` feat(dev): default dev global + logger on; other dev plugins off
- `63ce33a` fix(qa): eye-off icon on Hide Grading panel button; exclude self from proxy
- `94a8c0b` feat(qa): add Hide Grading control in Grading panel header
- `c7ee21d` ci(workflows): list plugins when auto-updating archetypes hashes
- `26d7cfb` archetypes: add create-task-project-selection for /work/problems/create-instance
- `ff0eed8` fix(diff): remove horizontal padding from diff highlight spans
- `00afefc` fix(navigation): reload SPA navigations only when archetypes.json lists plugins

## Stats

```
 .github/workflows/update-plugin-hashes.yml         |  31 ++++-
 archetypes.json                                    |  74 +++++++----
 fleet.user.js                                      |  56 ++++++--
 .../main/verifier-diff-highlight-improved.js       |   8 +-
 .../disputes/dev/dispute-ids-enhancer.js           |   4 +-
 .../deprecated/verifier-diff-highlight.js          |   8 +-
 .../qa-comp-use/main/hide-grading-panel-button.js  | 146 +++++++++++++++++++++
 .../qa-comp-use/main/prompt-diff-highlight.js      |   8 +-
 .../main/verifier-diff-highlight-improved.js       |   8 +-
 .../qa-tool-use/main/hide-grading-panel-button.js  | 146 +++++++++++++++++++++
 .../qa-tool-use/main/prompt-diff-highlight.js      |   8 +-
 .../task-view/main/prompt-diff-highlight.js        |   8 +-
 .../main/prompt-diff-highlight.js                  |   8 +-
 .../dev/prompt-and-notes-areas.js                  |   4 +-
 .../dev/tool-description-truncate.js               |   4 +-
 plugins/core/dev/logger-panel.js                   |  32 ++++-
 plugins/core/main/settings-ui.js                   |   6 +-
 17 files changed, 476 insertions(+), 83 deletions(-)
```
