### PR TITLE
Refactor core-only mode configuration and sync branch settings

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "6.4.0",
-  "coreOnlyMode": false,
-  "archetypesVersion": "6.93",
+  "coreOnlyMode": true,
+  "archetypesVersion": "6.94",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,6 +1,7 @@
 {
-  "version": "6.2.0",
-  "archetypesVersion": "6.90",
+  "version": "6.4.0",
+  "coreOnlyMode": false,
+  "archetypesVersion": "6.93",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [disable] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.2.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/disable/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/disable/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'disable',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [disable] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.4.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/disable/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/disable/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'disable',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [disable] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      6.2.0
+// @version      6.4.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '6.2.0';
+    const VERSION = '6.4.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -64,6 +64,8 @@
         outdatedPlugins: [],
         isOutdated: false,
         latestVersion: null,
+        /** When true (from archetypes.json coreOnlyMode), skip archetype plugins and SPA full reload; core plugins (e.g. settings UI) still run. */
+        coreOnlyMode: false,
         isDevBranch: DEV_SCRIPTS_ENABLED,
         githubBranch: GITHUB_CONFIG.branch,
         githubOwner: GITHUB_CONFIG.owner,
@@ -878,7 +880,11 @@
                                 
                                 // Always log archetypes version (cannot be disabled)
                                 Context.archetypesVersion = config.archetypesVersion || null;
+                                Context.coreOnlyMode = config.coreOnlyMode === true;
                                 console.log(`${LOG_PREFIX} archetypes v${config.archetypesVersion || 'unknown'}`);
+                                if (Context.coreOnlyMode) {
+                                    Logger.log('coreOnlyMode is enabled: archetype UX plugins and SPA auto-reload are off; core plugins remain active.');
+                                }
                                 
                                 Logger.log(`✓ Loaded ${this.archetypes.length} archetypes from branch: ${GITHUB_CONFIG.branch}`);
                                 resolve(config);
@@ -2131,6 +2137,11 @@
                 Logger.warn('Script is outdated. Archetype plugins are disabled. Please update the script to continue using page-specific features. Open Settings to see the update banner.');
                 return;
             }
+
+            if (Context.coreOnlyMode) {
+                Logger.log('coreOnlyMode: archetype UX plugins are not loaded (settings and update checks remain active).');
+                return;
+            }
             
             // Detect archetype using URL + optional disambiguation
             const archetype = await ArchetypeManager.detectArchetype();
@@ -2302,12 +2313,15 @@
                 );
             }
 
-            if (warrantsFullReload) {
+            if (warrantsFullReload && !Context.coreOnlyMode) {
                 Logger.log('Navigation target has configured archetype plugins; refreshing page...');
                 Storage.delete('workflow-cache-latest');
                 Storage.delete('workflow-cache-latest-url');
                 location.reload();
                 return;
+            }
+            if (warrantsFullReload && Context.coreOnlyMode) {
+                Logger.log('coreOnlyMode: skipping full page reload on SPA navigation (archetype UX is inactive).');
             }
         } catch (error) {
             Logger.error('Failed to check archetype match on navigation:', error);


### PR DESCRIPTION
## Summary

Adds a **`coreOnlyMode` flag** in `archetypes.json` that the userscript reads after loading config. When enabled, Fleet runs **core plugins only** (settings, update checks, etc.), **skips archetype UX plugins**, and **suppresses the SPA full reload** that normally fires when navigating between pages with different plugin sets. This branch turns the flag **on** and bumps bundle/archetypes versions accordingly.

## Changes

- **`archetypes.json`**: Introduces `coreOnlyMode: true`, bumps top-level `version` and `archetypesVersion` to match propagated releases.
- **`fleet.user.js`**: Extends `Context` with `coreOnlyMode`, sets it from `config.coreOnlyMode === true` when archetypes load, logs when active, short-circuits archetype plugin loading, and gates `warrantsFullReload` so in-app navigation does not force a refresh while core-only mode is on.

**Note:** `./dev/utils/sync-features-to-md.py` is not present in this repository, so the README align step was skipped; version/hash scripts were run and reported no further changes.

## Commit history

- `d7b6a65` Enable coreOnlyMode
- `5f837c2` refactor: drive core-only mode from archetypes.json coreOnlyMode

## Stats

```
 archetypes.json |  5 +++--
 fleet.user.js   | 20 +++++++++++++++++---
 2 files changed, 20 insertions(+), 5 deletions(-)
```
