### PR TITLE
Improve SPA navigation, extension ping, archetypes logging and dev tooling

### DIFF
--- a/.github/workflows/archetypes-boolean-apply.yml
+++ b/.github/workflows/archetypes-boolean-apply.yml
@@ -1,0 +1,62 @@
+name: Apply archetypes boolean patch
+
+on:
+  workflow_dispatch:
+    inputs:
+      patch_json:
+        description: JSON array of {op,set_boolean,path,value} records (see dev/utils/apply-archetypes-boolean-patch.sh)
+        required: true
+        type: string
+      base_ref:
+        description: Branch to check out, branch from, and target with the PR
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.base_ref }}
+
+      - name: Merge patch into archetypes.json
+        id: merge
+        env:
+          PATCH_JSON: ${{ inputs.patch_json }}
+        run: |
+          set -euo pipefail
+          chmod +x dev/utils/apply-archetypes-boolean-patch.sh
+          python3 -c "import os, pathlib; p=pathlib.Path(os.environ['RUNNER_TEMP'])/'patch.json'; p.write_text(os.environ['PATCH_JSON'], encoding='utf-8')"
+          ./dev/utils/apply-archetypes-boolean-patch.sh archetypes.json "$RUNNER_TEMP/patch.json" > "$RUNNER_TEMP/merged.json"
+          if cmp -s <(jq -cS . archetypes.json) <(jq -cS . "$RUNNER_TEMP/merged.json"); then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No effective changes to archetypes.json (patch was empty or no-ops)."
+          else
+            cp "$RUNNER_TEMP/merged.json" archetypes.json
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create branch, commit, and open pull request
+        if: steps.merge.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="bot/archetypes-booleans-${{ github.run_id }}-${{ github.run_attempt }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add archetypes.json
+          git commit -m "chore(archetypes): apply boolean flag patches" -m "Applied via workflow_dispatch archetypes-boolean-apply.yml (run ${{ github.run_id }})."
+          git push origin "$BRANCH"
+          gh pr create \
+            --base "${{ inputs.base_ref }}" \
+            --head "$BRANCH" \
+            --title "chore(archetypes): boolean flag updates" \
+            --body "Automated PR from **Apply archetypes boolean patch** workflow.\n\nReview the \`archetypes.json\` diff (including \`archetypesVersion\`) before merging."

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.0",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": true,
-  "archetypesVersion": "6.102",
+  "archetypesVersion": "6.103",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -17,8 +17,8 @@
     },
     {
       "name": "extension-ping.js",
-      "version": "1.4",
-      "hash": "sha256-2a74b0178daf7ee190d8a61ed8e73ec0ae5244a9527cf12c2d253a18af42d000",
+      "version": "1.5",
+      "hash": "sha256-18e51f29fb3a2ff70a7cca03e72a5178158b1e6b8327bde39ccf1cc2ca9ff2ca",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "6.4.0",
+  "version": "7.0.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "6.95",
+  "archetypesVersion": "6.96",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.1.0",
   "coreOnlyMode": false,
-  "extensionPingEveryLoad": false,
+  "extensionPingEveryLoad": true,
   "archetypesVersion": "6.102",
   "logs": {
     "debug": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "6.4.0",
-  "coreOnlyMode": true,
-  "archetypesVersion": "6.94",
+  "coreOnlyMode": false,
+  "archetypesVersion": "6.95",
   "corePlugins": [
     {
       "name": "settings-ui.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,24 +1,32 @@
 {
-  "version": "7.0.0",
+  "version": "7.1.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "6.96",
+  "archetypesVersion": "6.99",
+  "logs": {
+    "debug": false,
+    "verbose": false,
+    "submodule": false
+  },
   "corePlugins": [
     {
       "name": "settings-ui.js",
       "version": "6.2",
-      "hash": "sha256-eac152cd0dbcf5c97bff3ddc17c3ccc65a2fadfbca2af55e0f89f62b4febf07c"
+      "hash": "sha256-eac152cd0dbcf5c97bff3ddc17c3ccc65a2fadfbca2af55e0f89f62b4febf07c",
+      "log": false
     },
     {
       "name": "extension-ping.js",
       "version": "1.1",
-      "hash": "sha256-faae51a719082c75e025528766152ab23715701ed6f4b029acc717c6fc1b11d3"
+      "hash": "sha256-faae51a719082c75e025528766152ab23715701ed6f4b029acc717c6fc1b11d3",
+      "log": false
     }
   ],
   "devPlugins": [
     {
       "name": "logger-panel.js",
       "version": "2.9",
-      "hash": "sha256-d7283f301f13c35707de9fc645d42abe7a63ddfdd4dd0b29edf2abf07e8b1867"
+      "hash": "sha256-d7283f301f13c35707de9fc645d42abe7a63ddfdd4dd0b29edf2abf07e8b1867",
+      "log": false
     }
   ],
   "settingsModalDocs": [
@@ -42,22 +50,26 @@
         {
           "name": "progress-prompt-expand.js",
           "version": "1.8",
-          "hash": "sha256-2d499f17881a9c1335ad4b37ac695ccf19ab37747b02e0bc10fb05e29d8cd0f0"
+          "hash": "sha256-2d499f17881a9c1335ad4b37ac695ccf19ab37747b02e0bc10fb05e29d8cd0f0",
+          "log": false
         },
         {
           "name": "feedback-given-stats.js",
           "version": "3.0",
-          "hash": "sha256-a8043a6868f582525604584b2081ce30cd1d3c6670000a9f51ba886d992343a6"
+          "hash": "sha256-a8043a6868f582525604584b2081ce30cd1d3c6670000a9f51ba886d992343a6",
+          "log": false
         },
         {
           "name": "task-creation-today-env.js",
           "version": "3.0",
-          "hash": "sha256-9ab03fd598a5046a1fcee023f30296dc3b11408e96ac64d74c6c08cb09980f53"
+          "hash": "sha256-9ab03fd598a5046a1fcee023f30296dc3b11408e96ac64d74c6c08cb09980f53",
+          "log": false
         },
         {
           "name": "disputes-reviewed-today.js",
           "version": "3.0",
-          "hash": "sha256-eece62dc245e0482ca91851b53460142fd5f2bb0dc00d8953ed233c479aff158"
+          "hash": "sha256-eece62dc245e0482ca91851b53460142fd5f2bb0dc00d8953ed233c479aff158",
+          "log": false
         }
       ]
     },
@@ -71,67 +83,80 @@
         {
           "name": "clear-search.js",
           "version": "2.0",
-          "hash": "sha256-26456ceb6951f47c4ac23fa933c135e110c7506d6b3a0dd4249c3daf26c08063"
+          "hash": "sha256-26456ceb6951f47c4ac23fa933c135e110c7506d6b3a0dd4249c3daf26c08063",
+          "log": false
         },
         {
           "name": "json-editor-online.js",
           "version": "2.1",
-          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180"
+          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180",
+          "log": false
         },
         {
           "name": "guideline-buttons.js",
           "version": "2.1",
-          "hash": "sha256-22fa7eae954c71a89c0f8dfa3742b0c4b8aa8d0f26d121ffcb610d3387fe84ac"
+          "hash": "sha256-22fa7eae954c71a89c0f8dfa3742b0c4b8aa8d0f26d121ffcb610d3387fe84ac",
+          "log": false
         },
         {
           "name": "favorites.js",
           "version": "4.0",
-          "hash": "sha256-3d479c21ea95d0b320ed742289f6b716e632c85dbde6b0ca17e9fca518d712af"
+          "hash": "sha256-3d479c21ea95d0b320ed742289f6b716e632c85dbde6b0ca17e9fca518d712af",
+          "log": false
         },
         {
           "name": "remove-textarea-gradient.js",
           "version": "2.2",
-          "hash": "sha256-4d0f26a20e6ffaf5f943ad07aeafc6e26edeeca0e200198c23b1b88f6ed28c3e"
+          "hash": "sha256-4d0f26a20e6ffaf5f943ad07aeafc6e26edeeca0e200198c23b1b88f6ed28c3e",
+          "log": false
         },
         {
           "name": "remember-layout-proportions.js",
           "version": "2.0",
-          "hash": "sha256-1a76da94eca1432764ddc9de9acadc7aaae19606f54bcb5060a4ab80eb32c200"
+          "hash": "sha256-1a76da94eca1432764ddc9de9acadc7aaae19606f54bcb5060a4ab80eb32c200",
+          "log": false
         },
         {
           "name": "prompt-and-notes-areas.js",
           "version": "3.1",
-          "hash": "sha256-6139e763f20b96517308fd3c9c2960c92534de686c618a408d205518bdc598ed"
+          "hash": "sha256-6139e763f20b96517308fd3c9c2960c92534de686c618a408d205518bdc598ed",
+          "log": false
         },
         {
           "name": "execute-to-current-tool.js",
           "version": "2.0",
-          "hash": "sha256-c1366496dfa3747ebe7f8f1f82562b1dc79035bcb598f04e2a4f22cc6ee9a2cf"
+          "hash": "sha256-c1366496dfa3747ebe7f8f1f82562b1dc79035bcb598f04e2a4f22cc6ee9a2cf",
+          "log": false
         },
         {
           "name": "workflow-cache.js",
           "version": "2.0",
-          "hash": "sha256-cbe1b187968425d30a2bcd61f80cf187397d43b1e686d4db75c27186ceac19e9"
+          "hash": "sha256-cbe1b187968425d30a2bcd61f80cf187397d43b1e686d4db75c27186ceac19e9",
+          "log": false
         },
         {
           "name": "toggle-tool-parameters.js",
           "version": "2.3",
-          "hash": "sha256-91d127b2717d00ac5c0fe82f238d276f81b92e67d97200f560de7afb42c233ae"
+          "hash": "sha256-91d127b2717d00ac5c0fe82f238d276f81b92e67d97200f560de7afb42c233ae",
+          "log": false
         },
         {
           "name": "tool-results-resize-handle.js",
           "version": "2.0",
-          "hash": "sha256-c949a14b32c40af22a192941539ae09d36c14a3f908dce61eed13b7bcaa31af0"
+          "hash": "sha256-c949a14b32c40af22a192941539ae09d36c14a3f908dce61eed13b7bcaa31af0",
+          "log": false
         },
         {
           "name": "tool-description-truncate.js",
           "version": "2.0",
-          "hash": "sha256-f806767296a5ea148780c47656f14999b8103739363feb9cd1e528e1a4fca27e"
+          "hash": "sha256-f806767296a5ea148780c47656f14999b8103739363feb9cd1e528e1a4fca27e",
+          "log": false
         },
         {
           "name": "text-sanitizer.js",
           "version": "3.3",
-          "hash": "sha256-00fb0fa32015a92797b2c70a9e5e00a8a552670addee1aeb9b72cb2ce309a8b4"
+          "hash": "sha256-00fb0fa32015a92797b2c70a9e5e00a8a552670addee1aeb9b72cb2ce309a8b4",
+          "log": false
         }
       ]
     },
@@ -147,57 +172,68 @@
         {
           "name": "clear-search.js",
           "version": "2.1",
-          "hash": "sha256-a3f797c53cbc1b8ecfc5034a73400267987c2a9edc6219e856735e018b5755a5"
+          "hash": "sha256-a3f797c53cbc1b8ecfc5034a73400267987c2a9edc6219e856735e018b5755a5",
+          "log": false
         },
         {
           "name": "json-editor-online.js",
           "version": "2.1",
-          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180"
+          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180",
+          "log": false
         },
         {
           "name": "guideline-buttons.js",
           "version": "2.1",
-          "hash": "sha256-22fa7eae954c71a89c0f8dfa3742b0c4b8aa8d0f26d121ffcb610d3387fe84ac"
+          "hash": "sha256-22fa7eae954c71a89c0f8dfa3742b0c4b8aa8d0f26d121ffcb610d3387fe84ac",
+          "log": false
         },
         {
           "name": "favorites.js",
           "version": "4.0",
-          "hash": "sha256-3d479c21ea95d0b320ed742289f6b716e632c85dbde6b0ca17e9fca518d712af"
+          "hash": "sha256-3d479c21ea95d0b320ed742289f6b716e632c85dbde6b0ca17e9fca518d712af",
+          "log": false
         },
         {
           "name": "remove-textarea-gradient.js",
           "version": "2.2",
-          "hash": "sha256-4d0f26a20e6ffaf5f943ad07aeafc6e26edeeca0e200198c23b1b88f6ed28c3e"
+          "hash": "sha256-4d0f26a20e6ffaf5f943ad07aeafc6e26edeeca0e200198c23b1b88f6ed28c3e",
+          "log": false
         },
         {
           "name": "remember-layout-proportions.js",
           "version": "2.0",
-          "hash": "sha256-1a76da94eca1432764ddc9de9acadc7aaae19606f54bcb5060a4ab80eb32c200"
+          "hash": "sha256-1a76da94eca1432764ddc9de9acadc7aaae19606f54bcb5060a4ab80eb32c200",
+          "log": false
         },
         {
           "name": "execute-to-current-tool.js",
           "version": "2.0",
-          "hash": "sha256-c1366496dfa3747ebe7f8f1f82562b1dc79035bcb598f04e2a4f22cc6ee9a2cf"
+          "hash": "sha256-c1366496dfa3747ebe7f8f1f82562b1dc79035bcb598f04e2a4f22cc6ee9a2cf",
+          "log": false
         },
         {
           "name": "workflow-cache.js",
           "version": "2.1",
-          "hash": "sha256-46ab5c6741a7d67dad4ef348353d4f1f4cf25d5fb5e746b8759077bdfc30e0bd"
+          "hash": "sha256-46ab5c6741a7d67dad4ef348353d4f1f4cf25d5fb5e746b8759077bdfc30e0bd",
+          "log": false
         },
         {
           "name": "toggle-tool-parameters.js",
           "version": "2.3",
-          "hash": "sha256-91d127b2717d00ac5c0fe82f238d276f81b92e67d97200f560de7afb42c233ae"
+          "hash": "sha256-91d127b2717d00ac5c0fe82f238d276f81b92e67d97200f560de7afb42c233ae",
+          "log": false
         },
         {
           "name": "tool-results-resize-handle.js",
           "version": "2.0",
-          "hash": "sha256-c949a14b32c40af22a192941539ae09d36c14a3f908dce61eed13b7bcaa31af0"
+          "hash": "sha256-c949a14b32c40af22a192941539ae09d36c14a3f908dce61eed13b7bcaa31af0",
+          "log": false
         },
         {
           "name": "text-sanitizer.js",
           "version": "3.3",
-          "hash": "sha256-00fb0fa32015a92797b2c70a9e5e00a8a552670addee1aeb9b72cb2ce309a8b4"
+          "hash": "sha256-00fb0fa32015a92797b2c70a9e5e00a8a552670addee1aeb9b72cb2ce309a8b4",
+          "log": false
         }
       ]
     },
@@ -211,62 +247,74 @@
         {
           "name": "clear-search.js",
           "version": "2.0",
-          "hash": "sha256-1a0622c93b663b7e64b5e3a3c29f0ddd06eb7e464cb655f47c491b5c24a53aed"
+          "hash": "sha256-1a0622c93b663b7e64b5e3a3c29f0ddd06eb7e464cb655f47c491b5c24a53aed",
+          "log": false
         },
         {
           "name": "favorites.js",
           "version": "5.0",
-          "hash": "sha256-e8b53a6643768475e3f975d89805da88cd0fdde8152625003da406e3180d5060"
+          "hash": "sha256-e8b53a6643768475e3f975d89805da88cd0fdde8152625003da406e3180d5060",
+          "log": false
         },
         {
           "name": "guideline-buttons.js",
           "version": "1.6",
-          "hash": "sha256-3aefd5135a7621e6c9d63261d46e6d87b91cb455cc1f93f65d9f71dd97525d2a"
+          "hash": "sha256-3aefd5135a7621e6c9d63261d46e6d87b91cb455cc1f93f65d9f71dd97525d2a",
+          "log": false
         },
         {
           "name": "bug-report-expand.js",
           "version": "1.3",
-          "hash": "sha256-0638eeaea59ff4cecffc2ca1a6e19c922e98c974ced1f54c018130313a2771d2"
+          "hash": "sha256-0638eeaea59ff4cecffc2ca1a6e19c922e98c974ced1f54c018130313a2771d2",
+          "log": false
         },
         {
           "name": "prompt-scratchpad.js",
           "version": "2.1",
-          "hash": "sha256-6ab9d874928c74166fd43aadac8c5538a52268aa751acd30020d318ed415d9d9"
+          "hash": "sha256-6ab9d874928c74166fd43aadac8c5538a52268aa751acd30020d318ed415d9d9",
+          "log": false
         },
         {
           "name": "execute-to-current-tool.js",
           "version": "3.0",
-          "hash": "sha256-ff34686d136205e519afdfc017deb48012e9f2dc116a4d375987a83b36c932a2"
+          "hash": "sha256-ff34686d136205e519afdfc017deb48012e9f2dc116a4d375987a83b36c932a2",
+          "log": false
         },
         {
           "name": "workflow-cache.js",
           "version": "2.0",
-          "hash": "sha256-3cf51593be8e4acb29476964fd74fa078a937e1bc691d144dacd622dcde39873"
+          "hash": "sha256-3cf51593be8e4acb29476964fd74fa078a937e1bc691d144dacd622dcde39873",
+          "log": false
         },
         {
           "name": "toggle-tool-parameters.js",
           "version": "3.1",
-          "hash": "sha256-e842744b2c05fd5d11b3e1fc5f2ecb476fc5deb4dfca2ce7d22acd985d629331"
+          "hash": "sha256-e842744b2c05fd5d11b3e1fc5f2ecb476fc5deb4dfca2ce7d22acd985d629331",
+          "log": false
         },
         {
           "name": "tool-results-resize-handle.js",
           "version": "3.0",
-          "hash": "sha256-052a9388e4afa5d2deb1815cf89bd35bfc4af400def565b18aa60f917a72b5f5"
+          "hash": "sha256-052a9388e4afa5d2deb1815cf89bd35bfc4af400def565b18aa60f917a72b5f5",
+          "log": false
         },
         {
           "name": "tool-description-truncate.js",
           "version": "2.0",
-          "hash": "sha256-53bbb4926e5939a3bfd64152cdeb9ea12689250dbb074e0e79e8ddc22371d60a"
+          "hash": "sha256-53bbb4926e5939a3bfd64152cdeb9ea12689250dbb074e0e79e8ddc22371d60a",
+          "log": false
         },
         {
           "name": "text-sanitizer.js",
           "version": "3.1",
-          "hash": "sha256-e8d44bc528ecfb602f8b684a52a534ab0eea28ef75f58f3b997db3917f310be9"
+          "hash": "sha256-e8d44bc528ecfb602f8b684a52a534ab0eea28ef75f58f3b997db3917f310be9",
+          "log": false
         },
         {
           "name": "prompt-diff-highlight.js",
           "version": "3.4",
-          "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997"
+          "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997",
+          "log": false
         }
       ]
     },
@@ -288,32 +336,38 @@
         {
           "name": "auto-toggle-fullscreen-mode.js",
           "version": "1.1",
-          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227"
+          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227",
+          "log": false
         },
         {
           "name": "remove-textarea-gradient.js",
           "version": "1.3",
-          "hash": "sha256-c4b179cd62b8816a34e00f727d4d3780836bd67cd69441ac5f2f74b0d9656f60"
+          "hash": "sha256-c4b179cd62b8816a34e00f727d4d3780836bd67cd69441ac5f2f74b0d9656f60",
+          "log": false
         },
         {
           "name": "hide-testing-environment-banner.js",
           "version": "1.0",
-          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
+          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333",
+          "log": false
         },
         {
           "name": "guideline-buttons.js",
           "version": "1.4",
-          "hash": "sha256-4481551aecbebfdc15450bbad9cedd2d4a3acfc624b64d7796292d90261b4025"
+          "hash": "sha256-4481551aecbebfdc15450bbad9cedd2d4a3acfc624b64d7796292d90261b4025",
+          "log": false
         },
         {
           "name": "prompt-scratchpad.js",
           "version": "2.1",
-          "hash": "sha256-f15fc7a63ee2f7fd9219793423b0bc0173b18596ea23570960bdf5a253e528be"
+          "hash": "sha256-f15fc7a63ee2f7fd9219793423b0bc0173b18596ea23570960bdf5a253e528be",
+          "log": false
         },
         {
           "name": "remember-layout-proportions.js",
           "version": "1.0",
-          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
+          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719",
+          "log": false
         }
       ]
     },
@@ -327,37 +381,44 @@
         {
           "name": "auto-toggle-fullscreen-mode.js",
           "version": "1.1",
-          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227"
+          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227",
+          "log": false
         },
         {
           "name": "remove-textarea-gradient.js",
           "version": "1.3",
-          "hash": "sha256-c4b179cd62b8816a34e00f727d4d3780836bd67cd69441ac5f2f74b0d9656f60"
+          "hash": "sha256-c4b179cd62b8816a34e00f727d4d3780836bd67cd69441ac5f2f74b0d9656f60",
+          "log": false
         },
         {
           "name": "hide-testing-environment-banner.js",
           "version": "1.0",
-          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
+          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333",
+          "log": false
         },
         {
           "name": "guideline-buttons.js",
           "version": "1.4",
-          "hash": "sha256-533bd516613590d019c13093f0edd6b30a624e38916573ad29411c8e21cf8f50"
+          "hash": "sha256-533bd516613590d019c13093f0edd6b30a624e38916573ad29411c8e21cf8f50",
+          "log": false
         },
         {
           "name": "bug-report-expand.js",
           "version": "1.3",
-          "hash": "sha256-0638eeaea59ff4cecffc2ca1a6e19c922e98c974ced1f54c018130313a2771d2"
+          "hash": "sha256-0638eeaea59ff4cecffc2ca1a6e19c922e98c974ced1f54c018130313a2771d2",
+          "log": false
         },
         {
           "name": "prompt-scratchpad.js",
           "version": "2.1",
-          "hash": "sha256-64f89a9a1b7f2b2fc211a39ca811bff49dd4c2764c320f0a5906f9beb97845e7"
+          "hash": "sha256-64f89a9a1b7f2b2fc211a39ca811bff49dd4c2764c320f0a5906f9beb97845e7",
+          "log": false
         },
         {
           "name": "remember-layout-proportions.js",
           "version": "1.0",
-          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
+          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719",
+          "log": false
         }
       ]
     },
@@ -371,102 +432,122 @@
         {
           "name": "auto-start-recording.js",
           "version": "1.0",
-          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
+          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143",
+          "log": false
         },
         {
           "name": "hide-grading-autoclick.js",
           "version": "1.0",
-          "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37"
+          "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37",
+          "log": false
         },
         {
           "name": "hide-grading-panel-button.js",
           "version": "1.1",
-          "hash": "sha256-1dc570e2137afa59627bc0ce6a4adfb37487b346b5317ddd629db7ce84aa6f88"
+          "hash": "sha256-1dc570e2137afa59627bc0ce6a4adfb37487b346b5317ddd629db7ce84aa6f88",
+          "log": false
         },
         {
           "name": "clear-search.js",
           "version": "2.1",
-          "hash": "sha256-1c909857b79e8a369bd2e9a1767445fbfc0f77ae50c40b2c6fb09e879c7357f3"
+          "hash": "sha256-1c909857b79e8a369bd2e9a1767445fbfc0f77ae50c40b2c6fb09e879c7357f3",
+          "log": false
         },
         {
           "name": "favorites.js",
           "version": "4.0",
-          "hash": "sha256-dd991aa618b4f49abf7890a69e99a826eaaa897a250bb204d3b54e434382eb53"
+          "hash": "sha256-dd991aa618b4f49abf7890a69e99a826eaaa897a250bb204d3b54e434382eb53",
+          "log": false
         },
         {
           "name": "bug-report-expand.js",
           "version": "1.3",
-          "hash": "sha256-ebd685e61af47b6510bb1949d48135a33e9b5dd6e98765f3267e310377239d32"
+          "hash": "sha256-ebd685e61af47b6510bb1949d48135a33e9b5dd6e98765f3267e310377239d32",
+          "log": false
         },
         {
           "name": "copy-prompt.js",
           "version": "1.6",
-          "hash": "sha256-e9fd5dfa0043ac0249b21407483e0f3985eebcb8c3ac1fed66f10cacc148a650"
+          "hash": "sha256-e9fd5dfa0043ac0249b21407483e0f3985eebcb8c3ac1fed66f10cacc148a650",
+          "log": false
         },
         {
           "name": "copy-verifier-output.js",
           "version": "2.2",
-          "hash": "sha256-342b609c73d59ef5775320488f0cc3182a8d37a4d38b9fb6b7c6d5a1243d3097"
+          "hash": "sha256-342b609c73d59ef5775320488f0cc3182a8d37a4d38b9fb6b7c6d5a1243d3097",
+          "log": false
         },
         {
           "name": "remember-layout-proportions.js",
           "version": "2.2",
-          "hash": "sha256-bc06d024d1e9c6e0c201f511e28feb8db83ee2f561e03624a970614df01e4fd8"
+          "hash": "sha256-bc06d024d1e9c6e0c201f511e28feb8db83ee2f561e03624a970614df01e4fd8",
+          "log": false
         },
         {
           "name": "qa-scratchpad.js",
           "version": "2.2",
-          "hash": "sha256-bc86c47ce2a79a9d662606bb7b198193cd0a1d80cc249d036330795bc1de4e9f"
+          "hash": "sha256-bc86c47ce2a79a9d662606bb7b198193cd0a1d80cc249d036330795bc1de4e9f",
+          "log": false
         },
         {
           "name": "useful-links-buttons.js",
           "version": "2.1",
-          "hash": "sha256-92914ecd1790fa86c7054308c509d23e81defabfd98719f0c7b9720112339ff8"
+          "hash": "sha256-92914ecd1790fa86c7054308c509d23e81defabfd98719f0c7b9720112339ff8",
+          "log": false
         },
         {
           "name": "text-sanitizer.js",
           "version": "2.6",
-          "hash": "sha256-8b6df5ee1457423a55c22cf7beeb5780f23f15531e697bcc487ffde8b6a3be6b"
+          "hash": "sha256-8b6df5ee1457423a55c22cf7beeb5780f23f15531e697bcc487ffde8b6a3be6b",
+          "log": false
         },
         {
           "name": "execute-to-current-tool.js",
           "version": "2.0",
-          "hash": "sha256-430bec914ed32d755da7477788c34586d55a288d7b30dffdbb19a01ae0e45161"
+          "hash": "sha256-430bec914ed32d755da7477788c34586d55a288d7b30dffdbb19a01ae0e45161",
+          "log": false
         },
         {
           "name": "toggle-tool-parameters.js",
           "version": "2.1",
-          "hash": "sha256-76c9ebbf39700d8e38758021084cd4cb95a57152e78a980c7897decae767602e"
+          "hash": "sha256-76c9ebbf39700d8e38758021084cd4cb95a57152e78a980c7897decae767602e",
+          "log": false
         },
         {
           "name": "request-revisions.js",
           "version": "5.2",
-          "hash": "sha256-4318f2eec2c9aa5d0816d3030bedc2a5703767c8b1908b76e60aafb2436bb0aa"
+          "hash": "sha256-4318f2eec2c9aa5d0816d3030bedc2a5703767c8b1908b76e60aafb2436bb0aa",
+          "log": false
         },
         {
           "name": "prompt-diff-highlight.js",
           "version": "2.4",
-          "hash": "sha256-a3dc5ca34efb8e988da115e7528b381790fa7cea7ff50267e8f7582fc603b234"
+          "hash": "sha256-a3dc5ca34efb8e988da115e7528b381790fa7cea7ff50267e8f7582fc603b234",
+          "log": false
         },
         {
           "name": "tool-results-resize-handle.js",
           "version": "2.0",
-          "hash": "sha256-4222b6ccc3d55b2c996a37010868bd73b34f4b8a26438375a6ff152a89ab194b"
+          "hash": "sha256-4222b6ccc3d55b2c996a37010868bd73b34f4b8a26438375a6ff152a89ab194b",
+          "log": false
         },
         {
           "name": "tool-description-truncate.js",
           "version": "1.3",
-          "hash": "sha256-a9cbab9521fb434443a27faae81d41bf51ff6cfd41feb6e6491de0dbb8edc78b"
+          "hash": "sha256-a9cbab9521fb434443a27faae81d41bf51ff6cfd41feb6e6491de0dbb8edc78b",
+          "log": false
         },
         {
           "name": "workflow-cache.js",
           "version": "2.1",
-          "hash": "sha256-e8846babc1b9c74a93f4929c69313864d12b0c22f5cb3b36cbea317ddb53823c"
+          "hash": "sha256-e8846babc1b9c74a93f4929c69313864d12b0c22f5cb3b36cbea317ddb53823c",
+          "log": false
         },
         {
           "name": "accept-task-modal-improvements.js",
           "version": "1.7",
-          "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6"
+          "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6",
+          "log": false
         }
       ]
     },
@@ -480,82 +561,98 @@
         {
           "name": "auto-start-recording.js",
           "version": "1.0",
-          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143"
+          "hash": "sha256-39aed6bf3bdbdf92e4407b0e26a6f157cf1edac2cae5a513108a69b5d4bce143",
+          "log": false
         },
         {
           "name": "auto-toggle-fullscreen-mode.js",
           "version": "1.1",
-          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227"
+          "hash": "sha256-6317bcc51bc874b7df19da11d96fa8c2f5a33c0139f948246156c7b1211d5227",
+          "log": false
         },
         {
           "name": "hide-testing-environment-banner.js",
           "version": "1.0",
-          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333"
+          "hash": "sha256-6dd897a39ffe736497bb1678c5373548c55780245681b134842de91d96e9d333",
+          "log": false
         },
         {
           "name": "hide-grading-autoclick.js",
           "version": "1.0",
-          "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37"
+          "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37",
+          "log": false
         },
         {
           "name": "hide-grading-panel-button.js",
           "version": "1.1",
-          "hash": "sha256-1dc570e2137afa59627bc0ce6a4adfb37487b346b5317ddd629db7ce84aa6f88"
+          "hash": "sha256-1dc570e2137afa59627bc0ce6a4adfb37487b346b5317ddd629db7ce84aa6f88",
+          "log": false
         },
         {
           "name": "bug-report-expand.js",
           "version": "1.3",
-          "hash": "sha256-ebd685e61af47b6510bb1949d48135a33e9b5dd6e98765f3267e310377239d32"
+          "hash": "sha256-ebd685e61af47b6510bb1949d48135a33e9b5dd6e98765f3267e310377239d32",
+          "log": false
         },
         {
           "name": "copy-prompt.js",
           "version": "1.5",
-          "hash": "sha256-78603cee2124738aeb32db0ca503b5e9654d17d1ffdd0e564f626c6e5501f73a"
+          "hash": "sha256-78603cee2124738aeb32db0ca503b5e9654d17d1ffdd0e564f626c6e5501f73a",
+          "log": false
         },
         {
           "name": "copy-verifier-output.js",
           "version": "1.11",
-          "hash": "sha256-4e0365560103973d433ece5ab9c1b2847cd44c11ee8cae626bd0ae2e3de06831"
+          "hash": "sha256-4e0365560103973d433ece5ab9c1b2847cd44c11ee8cae626bd0ae2e3de06831",
+          "log": false
         },
         {
           "name": "copy-result-params.js",
           "version": "1.1",
-          "hash": "sha256-10b544d60b4eae9da833035e40ba4f43cc3b04e92d4e5447f463432c5b3e7bac"
+          "hash": "sha256-10b544d60b4eae9da833035e40ba4f43cc3b04e92d4e5447f463432c5b3e7bac",
+          "log": false
         },
         {
           "name": "guideline-buttons.js",
           "version": "2.3",
-          "hash": "sha256-038fb5954172425ed0530d776d78fbcb1f9b32f0e6036aaeda1786b2aed2732e"
+          "hash": "sha256-038fb5954172425ed0530d776d78fbcb1f9b32f0e6036aaeda1786b2aed2732e",
+          "log": false
         },
         {
           "name": "request-revisions.js",
           "version": "4.2",
-          "hash": "sha256-d7eb46b8245703dd1a37129d4ee7c497dde218e956f3b9779a6171e44c36fa71"
+          "hash": "sha256-d7eb46b8245703dd1a37129d4ee7c497dde218e956f3b9779a6171e44c36fa71",
+          "log": false
         },
         {
           "name": "qa-scratchpad.js",
           "version": "1.6",
-          "hash": "sha256-b219842987392a09692ea5f093331aef49477b8b25af8faff0272d273431d16a"
+          "hash": "sha256-b219842987392a09692ea5f093331aef49477b8b25af8faff0272d273431d16a",
+          "log": false
         },
         {
           "name": "prompt-diff-highlight.js",
           "version": "2.4",
-          "hash": "sha256-a3dc5ca34efb8e988da115e7528b381790fa7cea7ff50267e8f7582fc603b234"
+          "hash": "sha256-a3dc5ca34efb8e988da115e7528b381790fa7cea7ff50267e8f7582fc603b234",
+          "log": false
         },
         {
           "name": "verifier-diff-highlight-improved.js",
           "version": "1.5",
-          "hash": "sha256-70e886f9378a8ac6c5bea333b75e2d6a66d510eae03fbd7af3d8eff3a0e687f6"
+          "hash": "sha256-70e886f9378a8ac6c5bea333b75e2d6a66d510eae03fbd7af3d8eff3a0e687f6",
+          "log": false
         },
         {
           "name": "accept-task-modal-improvements.js",
           "version": "1.7",
-          "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6"
+          "hash": "sha256-e2730a6179222f9ad78d7aa4b206766115819a6cc2e24210bdbfaefe42a620a6",
+          "log": false
         },
         {
           "name": "remember-layout-proportions.js",
           "version": "1.0",
-          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719"
+          "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719",
+          "log": false
         }
       ]
     },
@@ -577,67 +674,80 @@
         {
           "name": "env-load-gate.js",
           "version": "1.0",
-          "hash": "sha256-84403bd9d0d3278966bc215c3eebec38c222feb277da52c0a7ff3625c2ec3ef3"
+          "hash": "sha256-84403bd9d0d3278966bc215c3eebec38c222feb277da52c0a7ff3625c2ec3ef3",
+          "log": false
         },
         {
           "name": "dispute-detail-task-id.js",
           "version": "1.1",
-          "hash": "sha256-c5f505ac2b5485867898c9901b8c4faa4420b42da68eda32166bdeed49af58c7"
+          "hash": "sha256-c5f505ac2b5485867898c9901b8c4faa4420b42da68eda32166bdeed49af58c7",
+          "log": false
         },
         {
           "name": "dispute-content-layout-fixes.js",
           "version": "1.2",
-          "hash": "sha256-8305f713adae4f30a51538972018542eedec9a7f63d7a4871014fd16ffef1a37"
+          "hash": "sha256-8305f713adae4f30a51538972018542eedec9a7f63d7a4871014fd16ffef1a37",
+          "log": false
         },
         {
           "name": "dispute-resolution-widgets-toggle.js",
           "version": "2.0",
-          "hash": "sha256-a6cab015e8efca7d041130598d2c551b55ee1a733e0a6eb1810cb01bd2fe96bb"
+          "hash": "sha256-a6cab015e8efca7d041130598d2c551b55ee1a733e0a6eb1810cb01bd2fe96bb",
+          "log": false
         },
         {
           "name": "clear-search.js",
           "version": "1.0",
-          "hash": "sha256-80b40af93a2889dc851f876b304f8dd015080f0d6c3acd2f3e5bc32a29795e23"
+          "hash": "sha256-80b40af93a2889dc851f876b304f8dd015080f0d6c3acd2f3e5bc32a29795e23",
+          "log": false
         },
         {
           "name": "create-instance-autoclick.js",
           "version": "1.1",
-          "hash": "sha256-347d7d13d41af849764a88acbcf392c3b2e0c5a487cf2c6e456c2fd930d3004f"
+          "hash": "sha256-347d7d13d41af849764a88acbcf392c3b2e0c5a487cf2c6e456c2fd930d3004f",
+          "log": false
         },
         {
           "name": "favorites.js",
           "version": "1.0",
-          "hash": "sha256-1d840f89b2dc12883cc22e15fa620c1141ad53289746d048c5e5fe00ef110af0"
+          "hash": "sha256-1d840f89b2dc12883cc22e15fa620c1141ad53289746d048c5e5fe00ef110af0",
+          "log": false
         },
         {
           "name": "execute-to-current-tool.js",
           "version": "1.0",
-          "hash": "sha256-edd3970d03416214ee6d948232316accb36d19853199f92ccf233d3bb9d0f80e"
+          "hash": "sha256-edd3970d03416214ee6d948232316accb36d19853199f92ccf233d3bb9d0f80e",
+          "log": false
         },
         {
           "name": "toggle-tool-parameters.js",
           "version": "1.0",
-          "hash": "sha256-13164379dd18ccc7afad0ce64a0f6be993359d0f1cffc7a0bc65d5bfec40d603"
+          "hash": "sha256-13164379dd18ccc7afad0ce64a0f6be993359d0f1cffc7a0bc65d5bfec40d603",
+          "log": false
         },
         {
           "name": "tool-results-resize-handle.js",
           "version": "1.0",
-          "hash": "sha256-0f8cfd666edeb33ca97796b097bafbdc1eabcf2a5a1524313edb6f7c259bbd70"
+          "hash": "sha256-0f8cfd666edeb33ca97796b097bafbdc1eabcf2a5a1524313edb6f7c259bbd70",
+          "log": false
         },
         {
           "name": "tool-description-truncate.js",
           "version": "1.0",
-          "hash": "sha256-0d5430a1eae172431ca9692c3809b478d58d2779ccb30ea4cb277a3845f2d2d1"
+          "hash": "sha256-0d5430a1eae172431ca9692c3809b478d58d2779ccb30ea4cb277a3845f2d2d1",
+          "log": false
         },
         {
           "name": "copy-verifier-output.js",
           "version": "1.3",
-          "hash": "sha256-aa22295f5e6d8116220eec20c79dfd0b53fa34ca08bdd11f40f84054bcf62104"
+          "hash": "sha256-aa22295f5e6d8116220eec20c79dfd0b53fa34ca08bdd11f40f84054bcf62104",
+          "log": false
         },
         {
           "name": "verifier-diff-highlight-improved.js",
           "version": "1.5",
-          "hash": "sha256-42fe5f4290fc72eda17ecfc93176ea0c078017a52abeede23ed26ef59dccaf62"
+          "hash": "sha256-42fe5f4290fc72eda17ecfc93176ea0c078017a52abeede23ed26ef59dccaf62",
+          "log": false
         }
       ]
     },
@@ -651,7 +761,8 @@
         {
           "name": "prompt-diff-highlight.js",
           "version": "3.4",
-          "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997"
+          "hash": "sha256-54e30cf2a6efb44e98da43db6cd8b609fd2fa1260c9cba283e66fca1d221e997",
+          "log": false
         }
       ]
     }
@@ -667,12 +778,14 @@
         {
           "name": "source-data-explorer.js",
           "version": "4.0",
-          "hash": "sha256-f8fff3deb0e23fc26053afe83da4da68b2f231f9c3961e1bdfb5ac0caa3a86f0"
+          "hash": "sha256-f8fff3deb0e23fc26053afe83da4da68b2f231f9c3961e1bdfb5ac0caa3a86f0",
+          "log": false
         },
         {
           "name": "workflow-integrity-check.js",
           "version": "2.0",
-          "hash": "sha256-73c0cfacead59b2325ac1d937bf27a2c8c07b82331ef9657c5e8003e4f4829f0"
+          "hash": "sha256-73c0cfacead59b2325ac1d937bf27a2c8c07b82331ef9657c5e8003e4f4829f0",
+          "log": false
         }
       ]
     },
@@ -688,12 +801,14 @@
         {
           "name": "prompt-and-notes-areas.js",
           "version": "3.2",
-          "hash": "sha256-d9a54732ae808069a93f5be524b2d3327de24532e33c07be57d9747dd7d8dcb5"
+          "hash": "sha256-d9a54732ae808069a93f5be524b2d3327de24532e33c07be57d9747dd7d8dcb5",
+          "log": false
         },
         {
           "name": "tool-description-truncate.js",
           "version": "2.2",
-          "hash": "sha256-39e3660beef1dc7e6aefbc03c512fdfe28f8b87d25edb187c71cb86eb712826c"
+          "hash": "sha256-39e3660beef1dc7e6aefbc03c512fdfe28f8b87d25edb187c71cb86eb712826c",
+          "log": false
         }
       ]
     },
@@ -714,17 +829,20 @@
         {
           "name": "source-data-explorer.js",
           "version": "1.3",
-          "hash": "sha256-8770f8edc00b55148e48267415c6804339e687dcee1a24f42a901df84eba1095"
+          "hash": "sha256-8770f8edc00b55148e48267415c6804339e687dcee1a24f42a901df84eba1095",
+          "log": false
         },
         {
           "name": "workflow-integrity-check.js",
           "version": "1.1",
-          "hash": "sha256-3e3478682d1f7379e40d933e399fcb234df7ee1e7dc52305fc61559d08835867"
+          "hash": "sha256-3e3478682d1f7379e40d933e399fcb234df7ee1e7dc52305fc61559d08835867",
+          "log": false
         },
         {
           "name": "reorganize-request-revisions.js",
           "version": "1.1",
-          "hash": "sha256-1f7708627f64c04c6f92a33c49c783a79ff144ea7485cf4a285d805d758ed72d"
+          "hash": "sha256-1f7708627f64c04c6f92a33c49c783a79ff144ea7485cf4a285d805d758ed72d",
+          "log": false
         }
       ]
     },
@@ -770,7 +888,8 @@
         {
           "name": "dispute-ids-enhancer.js",
           "version": "3.2",
-          "hash": "sha256-4be4922a61174e06e13a16e0840d38f53e8e2861199cf7d256c8f08ff926ef3e"
+          "hash": "sha256-4be4922a61174e06e13a16e0840d38f53e8e2861199cf7d256c8f08ff926ef3e",
+          "log": false
         }
       ]
     }

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.1.0",
   "coreOnlyMode": false,
-  "extensionPingEveryLoad": true,
+  "extensionPingEveryLoad": false,
   "archetypesVersion": "6.103",
   "logs": {
     "debug": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,8 @@
 {
   "version": "7.1.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "6.99",
+  "extensionPingEveryLoad": false,
+  "archetypesVersion": "6.102",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -16,8 +17,8 @@
     },
     {
       "name": "extension-ping.js",
-      "version": "1.1",
-      "hash": "sha256-faae51a719082c75e025528766152ab23715701ed6f4b029acc717c6fc1b11d3",
+      "version": "1.4",
+      "hash": "sha256-2a74b0178daf7ee190d8a61ed8e73ec0ae5244a9527cf12c2d253a18af42d000",
       "log": false
     }
   ],

--- a/dev/module-workflow.md
+++ b/dev/module-workflow.md
@@ -105,7 +105,7 @@ Scripts that touch `fleet.user.js` (checkout, release, test) ensure:
 - Interactive terminal UI (Python + Textual) to fuzzy-search and toggle boolean flags in `archetypes.json`, then confirm and dispatch that workflow on GitHub.
 - Setup: `cd dev/tools/archetypes-flags-tui && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` (keep `.venv/` local; it is not tracked.)
 - Run: `.venv/bin/python app.py` (repo root must contain `archetypes.json`; `gh auth login` needs **repo** and **workflow** scopes so `gh api` can trigger `workflow_dispatch`).
-- Shortcut keys (main screen): type to filter; **Backspace** removes last search token; **Ctrl+W** clears search; **Up/Down** move; **Space** toggles; **Enter** summary; **Esc** returns from the summary screen. On the summary, **Y** + **Enter** dispatches the workflow; **n** + **Enter** cancels.
+- Shortcut keys (main screen): type to filter; **Backspace** deletes last character; **Ctrl+W** deletes last word (token); **Ctrl+U** or **Ctrl+Backspace** clears search; **Up/Down** move; **Space** toggles; **Enter** summary; **Esc** returns from the summary screen. On the summary, **Y** + **Enter** dispatches the workflow; **n** + **Enter** cancels.
 
 **push.sh** — `./utils/push.sh [--dry-run] ["optional commit message"]`
 

--- a/dev/module-workflow.md
+++ b/dev/module-workflow.md
@@ -96,6 +96,17 @@ Scripts that touch `fleet.user.js` (checkout, release, test) ensure:
 
 - Aligns `fleet.user.js` with the current git branch (`-m` treats the branch as `main`). `-c` commits the file if it changed. `--dry-run` prints the planned field updates without writing. `--fleet` uses a specific file path (default: `<repo>/fleet.user.js`). `--branch` uses a branch name instead of `git` HEAD (ignored when `-m` is set). Used by `checkout.sh` and `test.sh`; safe to run by hand after switching branches.
 
+**apply-archetypes-boolean-patch.sh** — `./dev/utils/apply-archetypes-boolean-patch.sh <archetypes.json> <patch.json>`
+
+- Validates and merges **boolean-only** edits into `archetypes.json` (see header comments for the JSON patch shape). Bumps `archetypesVersion` by `0.1` when any boolean value actually changes. Prints the resulting file to stdout. Used by the **Apply archetypes boolean patch** GitHub Actions workflow.
+
+**archetypes-flags-tui** — `dev/tools/archetypes-flags-tui/`
+
+- Interactive terminal UI (Python + Textual) to fuzzy-search and toggle boolean flags in `archetypes.json`, then confirm and dispatch that workflow on GitHub.
+- Setup: `cd dev/tools/archetypes-flags-tui && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt` (keep `.venv/` local; it is not tracked.)
+- Run: `.venv/bin/python app.py` (repo root must contain `archetypes.json`; `gh auth login` needs **repo** and **workflow** scopes so `gh api` can trigger `workflow_dispatch`).
+- Shortcut keys (main screen): type to filter; **Backspace** removes last search token; **Ctrl+W** clears search; **Up/Down** move; **Space** toggles; **Enter** summary; **Esc** returns from the summary screen. On the summary, **Y** + **Enter** dispatches the workflow; **n** + **Enter** cancels.
+
 **push.sh** — `./utils/push.sh [--dry-run] ["optional commit message"]`
 
 - Lists uncommitted changes; for each changed versioned file (plugins, fleet.user.js, settings-modal docs), bumps version by 0.1 if working tree is not already higher than HEAD. Updates `archetypes.json` settingsModalDocs for .md changes.

--- a/dev/tools/archetypes-flags-tui/app.py
+++ b/dev/tools/archetypes-flags-tui/app.py
@@ -124,8 +124,6 @@ class ArchetypesFlagApp(App[None]):
         table = self.query_one("#flag_table", DataTable)
         self._filtered = self.compute_filtered()
         table.clear(columns=False)
-        if table.column_count == 0:
-            table.add_columns("On", "Setting")
         for _pos, row_i in enumerate(self._filtered):
             r = self._rows[row_i]
             on = self.effective(r)

--- a/dev/tools/archetypes-flags-tui/app.py
+++ b/dev/tools/archetypes-flags-tui/app.py
@@ -48,6 +48,53 @@ def token_backspace(query: str) -> str:
     return " ".join(parts[:-1])
 
 
+def lcs_length(a: str, b: str) -> int:
+    """Length of longest common subsequence over characters (classic DP)."""
+    if not a or not b:
+        return 0
+    m, n = len(a), len(b)
+    prev = [0] * (n + 1)
+    for i in range(1, m + 1):
+        curr = [0] * (n + 1)
+        ai = a[i - 1]
+        for j in range(1, n + 1):
+            if ai == b[j - 1]:
+                curr[j] = prev[j - 1] + 1
+            else:
+                curr[j] = max(prev[j], curr[j - 1])
+        prev = curr
+    return prev[n]
+
+
+def lcs_rank_parts(q: str, lab: str, blob: str) -> tuple[float, float, int]:
+    """
+    Return (coverage, normalized_lcs, substr_pos) for sorting.
+
+    coverage: max LCS length vs query / len(q) — order-preserving match strength.
+    normalized_lcs: 2 * lcs / (len(q) + len(text)) on the text that achieved max LCS.
+    substr_pos: start index of contiguous q in lab, else in blob, else 10**9 (fuzzy rows).
+    """
+    len_q = len(q)
+    if len_q == 0:
+        return (0.0, 0.0, 10**9)
+    l_lab = lcs_length(q, lab)
+    l_blob = lcs_length(q, blob)
+    if l_lab >= l_blob:
+        l_best, text = l_lab, lab
+    else:
+        l_best, text = l_blob, blob
+    coverage = l_best / len_q
+    denom = len_q + len(text)
+    norm = (2.0 * l_best / denom) if denom else 0.0
+    if q in lab:
+        pos = lab.find(q)
+    elif q in blob:
+        pos = blob.find(q)
+    else:
+        pos = 10**9
+    return (coverage, norm, pos)
+
+
 class ArchetypesFlagApp(App[None]):
     """Browse and toggle booleans, then dispatch the apply workflow."""
 
@@ -117,7 +164,9 @@ class ArchetypesFlagApp(App[None]):
         # Tier: 0 = query is contiguous substring of visible label (strongest)
         #       1 = substring of full search_blob but not label alone
         #       2 = fuzzy only (substring match never applied)
-        ranked: list[tuple[int, int, int]] = []
+        # Within each tier: LCS coverage + normalized LCS, then substring position,
+        # then token_set_ratio as a final tiebreaker.
+        ranked: list[tuple[int, float, float, int, int, int]] = []
         for i in range(n):
             row = self._rows[i]
             lab = row.label.lower()
@@ -128,10 +177,13 @@ class ArchetypesFlagApp(App[None]):
                 tier = 1
             else:
                 tier = 2
+            cov, norm, pos = lcs_rank_parts(q, lab, blob)
             fuzz_sc = fuzz.token_set_ratio(q, blob)
-            ranked.append((tier, fuzz_sc, i))
-        ranked.sort(key=lambda t: (t[0], -t[1], t[2]))
-        return [i for _, _, i in ranked]
+            ranked.append((tier, cov, norm, pos, fuzz_sc, i))
+        ranked.sort(
+            key=lambda t: (t[0], -t[1], -t[2], t[3], -t[4], t[5])
+        )
+        return [i for _, _, _, _, _, i in ranked]
 
     def refresh_table(self) -> None:
         table = self.query_one("#flag_table", DataTable)

--- a/dev/tools/archetypes-flags-tui/app.py
+++ b/dev/tools/archetypes-flags-tui/app.py
@@ -61,6 +61,7 @@ class ArchetypesFlagApp(App[None]):
     """
 
     BINDINGS = [
+        Binding("ctrl+c", "quit", "Quit", priority=True),
         Binding("q", "quit", "Quit"),
         Binding("escape", "maybe_leave_summary", "Back"),
     ]
@@ -134,7 +135,7 @@ class ArchetypesFlagApp(App[None]):
         self.query_one("#search_line", Static).update(
             "Search: "
             + repr(self.query_text)
-            + "  |  Backspace char  Ctrl+W word  Ctrl+U clear  |  Up/Down  Space  Enter  Esc"
+            + "  |  Backspace char  Ctrl+W word  Ctrl+U clear  |  Up/Down  Space  Enter  Esc  Ctrl+C quit"
         )
         if not self._filtered:
             return
@@ -177,6 +178,10 @@ class ArchetypesFlagApp(App[None]):
             self.view_mode = "edit"
 
     async def on_key(self, event: Key) -> None:
+        if event.key == "ctrl+c":
+            event.prevent_default()
+            self.exit()
+            return
         if self.view_mode == "summary":
             return
         key = event.key

--- a/dev/tools/archetypes-flags-tui/app.py
+++ b/dev/tools/archetypes-flags-tui/app.py
@@ -1,0 +1,379 @@
+"""Interactive Textual UI for toggling boolean flags in archetypes.json."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from rapidfuzz import fuzz
+from textual import on
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, VerticalScroll
+from textual.events import Key
+from textual.reactive import reactive
+from textual.widgets import DataTable, Footer, Header, Input, RichLog, Static
+
+from flatten import BooleanRow, load_archetypes
+
+
+WORKFLOW_FILE = "archetypes-boolean-apply.yml"
+
+
+def repo_root_from(start: Path) -> Path:
+    """Resolve git repo root; start should be a path inside the repo."""
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=start,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(
+            "Not inside a git repository (git rev-parse --show-toplevel failed)."
+        )
+    return Path(out.stdout.strip())
+
+
+def token_backspace(query: str) -> str:
+    """Remove the last whitespace-separated token."""
+    parts = query.split()
+    if not parts:
+        return ""
+    return " ".join(parts[:-1])
+
+
+class ArchetypesFlagApp(App[None]):
+    """Browse and toggle booleans, then dispatch the apply workflow."""
+
+    CSS = """
+    Screen { background: $surface; }
+    #summary_panel { height: auto; max-height: 70%; margin: 1 2; }
+    #summary_log { min-height: 8; max-height: 28; border: solid $primary; }
+    #confirm_hint { margin-top: 1; color: $text-muted; }
+    DataTable { height: 1fr; margin: 0 1; }
+    #search_line { margin: 0 1; color: $accent; }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("escape", "maybe_leave_summary", "Back"),
+    ]
+
+    query_text: reactive[str] = reactive("")
+    cursor_row: reactive[int] = reactive(0)
+    view_mode: reactive[str] = reactive("edit")  # "edit" | "summary"
+
+    def __init__(self, archetypes_path: Path) -> None:
+        super().__init__()
+        self._archetypes_path = archetypes_path
+        self._repo_root = repo_root_from(archetypes_path.parent)
+        _, self._rows = load_archetypes(archetypes_path)
+        self._filtered: list[int] = list(range(len(self._rows)))
+        self._overrides: dict[tuple, bool] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Container(id="edit_panel"):
+            yield Static("", id="search_line")
+            table = DataTable(zebra_stripes=True, cursor_type="row", id="flag_table")
+            table.can_focus = True
+            yield table
+        with VerticalScroll(id="summary_panel"):
+            yield RichLog(id="summary_log", wrap=True, markup=True)
+            yield Static(
+                "Type Y then Enter to open the GitHub Actions workflow, or n then Enter to return.",
+                id="confirm_hint",
+            )
+            yield Input(placeholder="Y / n", id="confirm_input")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#summary_panel").display = False
+        table = self.query_one("#flag_table", DataTable)
+        table.focus()
+        table.add_columns("On", "Setting")
+        self.refresh_table()
+
+    def effective(self, row: BooleanRow) -> bool:
+        key = row.path_tuple
+        if key in self._overrides:
+            return self._overrides[key]
+        return row.original
+
+    def compute_filtered(self) -> list[int]:
+        n = len(self._rows)
+        if n == 0:
+            return []
+        q = self.query_text.strip().lower()
+        if not q:
+            return list(range(n))
+        scored: list[tuple[int, int]] = []
+        for i in range(n):
+            row = self._rows[i]
+            score = fuzz.token_set_ratio(q, row.search_blob)
+            scored.append((score, i))
+        scored.sort(key=lambda x: (-x[0], x[1]))
+        return [i for _, i in scored]
+
+    def refresh_table(self) -> None:
+        table = self.query_one("#flag_table", DataTable)
+        self._filtered = self.compute_filtered()
+        table.clear(columns=False)
+        if table.column_count == 0:
+            table.add_columns("On", "Setting")
+        for _pos, row_i in enumerate(self._filtered):
+            r = self._rows[row_i]
+            on = self.effective(r)
+            sym = "[x]" if on else "[ ]"
+            table.add_row(sym, r.label)
+        self.query_one("#search_line", Static).update(
+            "Search: "
+            + repr(self.query_text)
+            + "  |  Backspace token  Ctrl+W clear  |  Up/Down  Space toggle  Enter summary  Esc back"
+        )
+        if not self._filtered:
+            return
+        self.cursor_row = max(
+            0, min(self.cursor_row, len(self._filtered) - 1)
+        )
+        table.move_cursor(row=self.cursor_row)
+
+    def watch_query_text(self, _value: str) -> None:
+        if self.view_mode == "edit":
+            self.cursor_row = 0
+            self.refresh_table()
+
+    def watch_view_mode(self, mode: str) -> None:
+        edit = self.query_one("#edit_panel")
+        summ = self.query_one("#summary_panel")
+        if mode == "summary":
+            edit.display = False
+            summ.display = True
+            self.call_later(lambda: self.query_one("#confirm_input", Input).focus())
+        else:
+            edit.display = True
+            summ.display = False
+            self.call_later(self._focus_table_and_refresh)
+
+    def _focus_table_and_refresh(self) -> None:
+        self.query_one("#flag_table", DataTable).focus()
+        self.refresh_table()
+
+    def _row_at_cursor(self) -> BooleanRow | None:
+        if not self._filtered or self.cursor_row >= len(self._filtered):
+            return None
+        return self._rows[self._filtered[self.cursor_row]]
+
+    def action_quit(self) -> None:
+        self.exit()
+
+    def action_maybe_leave_summary(self) -> None:
+        if self.view_mode == "summary":
+            self.view_mode = "edit"
+
+    async def on_key(self, event: Key) -> None:
+        if self.view_mode == "summary":
+            return
+        key = event.key
+        if key == "up":
+            event.prevent_default()
+            if self._filtered:
+                self.cursor_row = max(0, self.cursor_row - 1)
+                tbl = self.query_one("#flag_table", DataTable)
+                tbl.move_cursor(row=self.cursor_row)
+            return
+        if key == "down":
+            event.prevent_default()
+            if self._filtered:
+                self.cursor_row = min(
+                    len(self._filtered) - 1, self.cursor_row + 1
+                )
+                tbl = self.query_one("#flag_table", DataTable)
+                tbl.move_cursor(row=self.cursor_row)
+            return
+        if key == "enter":
+            event.prevent_default()
+            await self._open_summary()
+            return
+        if key == "space":
+            event.prevent_default()
+            row = self._row_at_cursor()
+            if row:
+                cur = self.effective(row)
+                newv = not cur
+                if newv == row.original:
+                    self._overrides.pop(row.path_tuple, None)
+                else:
+                    self._overrides[row.path_tuple] = newv
+                self.refresh_table()
+            return
+        if key in ("ctrl+w", "ctrl+backspace"):
+            event.prevent_default()
+            self.query_text = ""
+            return
+        if key == "backspace":
+            event.prevent_default()
+            self.query_text = token_backspace(self.query_text)
+            return
+        char = event.character
+        if char and len(char) == 1 and char.isprintable():
+            event.prevent_default()
+            self.query_text = f"{self.query_text}{char}"
+            return
+
+    async def _open_summary(self) -> None:
+        changes: list[tuple[BooleanRow, bool, bool]] = []
+        for row in self._rows:
+            newv = self.effective(row)
+            if newv != row.original:
+                changes.append((row, row.original, newv))
+        log = self.query_one("#summary_log", RichLog)
+        log.clear()
+        if not changes:
+            log.write(
+                "[yellow]No changes — nothing to dispatch.[/] "
+                "Press n then Enter to return."
+            )
+        else:
+            log.write("[bold]Pending changes:[/]\n")
+            for row, old, new in changes:
+                log.write(f"  • {row.label}\n")
+                log.write(f"    {old} → {new}\n")
+            log.write(
+                f"\n[bold]{len(changes)}[/] boolean(s) will be sent to "
+                f"[cyan]{WORKFLOW_FILE}[/]."
+            )
+        self.query_one("#confirm_input", Input).value = ""
+        self.view_mode = "summary"
+
+    @on(Input.Submitted, "#confirm_input")
+    async def confirm_submitted(self, event: Input.Submitted) -> None:
+        if self.view_mode != "summary":
+            return
+        val = event.value.strip().upper()
+        if val == "N" or val == "":
+            self.view_mode = "edit"
+            return
+        if val != "Y":
+            log = self.query_one("#summary_log", RichLog)
+            log.write(
+                "\n[red]Expected Y to dispatch or n to return.[/] Try again."
+            )
+            self.query_one("#confirm_input", Input).value = ""
+            return
+        patches = self._build_patch_list()
+        if not patches:
+            log = self.query_one("#summary_log", RichLog)
+            log.write("\n[yellow]No patches; nothing dispatched.[/]")
+            self.view_mode = "edit"
+            return
+        log = self.query_one("#summary_log", RichLog)
+        log.write("\n[bold]Dispatching workflow…[/]")
+
+        def run_dispatch() -> str | None:
+            try:
+                self._run_gh_dispatch(patches, "main")
+                return None
+            except Exception as e:  # noqa: BLE001
+                return str(e)
+
+        err = await asyncio.to_thread(run_dispatch)
+        self._dispatch_done(err)
+
+    def _build_patch_list(self) -> list[dict]:
+        out: list[dict] = []
+        for row in self._rows:
+            newv = self.effective(row)
+            if newv == row.original:
+                continue
+            out.append(row.patch_entry(newv))
+        return out
+
+    def _run_gh_dispatch(self, patches: list[dict], base_ref: str) -> None:
+        proc_chk = subprocess.run(
+            ["gh", "auth", "status"],
+            cwd=self._repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if proc_chk.returncode != 0:
+            raise RuntimeError(
+                "gh is not authenticated. Run `gh auth login` with repo + workflow scopes."
+            )
+        owner_repo = subprocess.check_output(
+            [
+                "gh",
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "-q",
+                ".nameWithOwner",
+            ],
+            cwd=self._repo_root,
+            text=True,
+        ).strip()
+        body = {
+            "ref": base_ref,
+            "inputs": {
+                "patch_json": json.dumps(patches, separators=(",", ":")),
+                "base_ref": base_ref,
+            },
+        }
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                f"repos/{owner_repo}/actions/workflows/{WORKFLOW_FILE}/dispatches",
+                "--input",
+                "-",
+            ],
+            input=json.dumps(body).encode(),
+            cwd=self._repo_root,
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            msg = proc.stderr.decode() or proc.stdout.decode() or "gh api failed"
+            raise RuntimeError(msg)
+
+    def _dispatch_done(self, err: str | None) -> None:
+        log = self.query_one("#summary_log", RichLog)
+        if err:
+            log.write(f"\n[red]Dispatch failed:[/]\n{err}\n")
+            log.write(
+                "\n[yellow]Fix the error above, then try again, or press n then Enter / Esc to return.[/]"
+            )
+            self.query_one("#confirm_input", Input).value = ""
+            return
+        log.write(
+            "\n[green]Workflow dispatch submitted.[/] "
+            "Check Actions on GitHub for a new run of "
+            f"'{WORKFLOW_FILE}'."
+        )
+        self.view_mode = "edit"
+
+
+def main() -> None:
+    here = Path(__file__).resolve()
+    try:
+        root = repo_root_from(here.parent)
+    except RuntimeError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
+    arch = root / "archetypes.json"
+    if not arch.is_file():
+        print(f"archetypes.json not found at {arch}", file=sys.stderr)
+        sys.exit(1)
+    app = ArchetypesFlagApp(arch)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/tools/archetypes-flags-tui/app.py
+++ b/dev/tools/archetypes-flags-tui/app.py
@@ -114,13 +114,24 @@ class ArchetypesFlagApp(App[None]):
         q = self.query_text.strip().lower()
         if not q:
             return list(range(n))
-        scored: list[tuple[int, int]] = []
+        # Tier: 0 = query is contiguous substring of visible label (strongest)
+        #       1 = substring of full search_blob but not label alone
+        #       2 = fuzzy only (substring match never applied)
+        ranked: list[tuple[int, int, int]] = []
         for i in range(n):
             row = self._rows[i]
-            score = fuzz.token_set_ratio(q, row.search_blob)
-            scored.append((score, i))
-        scored.sort(key=lambda x: (-x[0], x[1]))
-        return [i for _, i in scored]
+            lab = row.label.lower()
+            blob = row.search_blob
+            if q in lab:
+                tier = 0
+            elif q in blob:
+                tier = 1
+            else:
+                tier = 2
+            fuzz_sc = fuzz.token_set_ratio(q, blob)
+            ranked.append((tier, fuzz_sc, i))
+        ranked.sort(key=lambda t: (t[0], -t[1], t[2]))
+        return [i for _, _, i in ranked]
 
     def refresh_table(self) -> None:
         table = self.query_one("#flag_table", DataTable)

--- a/dev/tools/archetypes-flags-tui/app.py
+++ b/dev/tools/archetypes-flags-tui/app.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from rapidfuzz import fuzz
+from rich.text import Text
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -40,7 +41,7 @@ def repo_root_from(start: Path) -> Path:
 
 
 def token_backspace(query: str) -> str:
-    """Remove the last whitespace-separated token."""
+    """Remove the last whitespace-separated token (readline/word-style)."""
     parts = query.split()
     if not parts:
         return ""
@@ -127,12 +128,13 @@ class ArchetypesFlagApp(App[None]):
         for _pos, row_i in enumerate(self._filtered):
             r = self._rows[row_i]
             on = self.effective(r)
-            sym = "[x]" if on else "[ ]"
-            table.add_row(sym, r.label)
+            # Plain str is parsed as Rich markup; [x] would vanish. Use Text for literals.
+            flag = Text("[x]" if on else "[ ]")
+            table.add_row(flag, r.label)
         self.query_one("#search_line", Static).update(
             "Search: "
             + repr(self.query_text)
-            + "  |  Backspace token  Ctrl+W clear  |  Up/Down  Space toggle  Enter summary  Esc back"
+            + "  |  Backspace char  Ctrl+W word  Ctrl+U clear  |  Up/Down  Space  Enter  Esc"
         )
         if not self._filtered:
             return
@@ -210,13 +212,18 @@ class ArchetypesFlagApp(App[None]):
                     self._overrides[row.path_tuple] = newv
                 self.refresh_table()
             return
-        if key in ("ctrl+w", "ctrl+backspace"):
+        if key in ("ctrl+u", "ctrl+backspace"):
             event.prevent_default()
             self.query_text = ""
             return
-        if key == "backspace":
+        if key == "ctrl+w":
             event.prevent_default()
             self.query_text = token_backspace(self.query_text)
+            return
+        if key == "backspace":
+            event.prevent_default()
+            if self.query_text:
+                self.query_text = self.query_text[:-1]
             return
         char = event.character
         if char and len(char) == 1 and char.isprintable():

--- a/dev/tools/archetypes-flags-tui/flatten.py
+++ b/dev/tools/archetypes-flags-tui/flatten.py
@@ -1,0 +1,127 @@
+"""Discover boolean fields in archetypes.json and build stable jq paths."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List
+
+
+@dataclass
+class BooleanRow:
+    """One editable boolean in archetypes.json."""
+
+    path: List[str | int]
+    original: bool
+    search_blob: str
+    label: str
+
+    @property
+    def path_tuple(self) -> tuple:
+        return tuple(self.path)
+
+    def patch_entry(self, value: bool) -> dict:
+        return {"op": "set_boolean", "path": list(self.path), "value": value}
+
+
+def _flatten(data: dict[str, Any]) -> List[BooleanRow]:
+    rows: List[BooleanRow] = []
+
+    for key, val in data.items():
+        if isinstance(val, bool):
+            rows.append(
+                BooleanRow(
+                    path=[key],
+                    original=val,
+                    search_blob=" ".join(
+                        ["global", key, str(val).lower()]
+                    ).lower(),
+                    label=f"global  |  {key}",
+                )
+            )
+
+    logs = data.get("logs")
+    if isinstance(logs, dict):
+        for lk, lv in logs.items():
+            if isinstance(lv, bool):
+                rows.append(
+                    BooleanRow(
+                        path=["logs", lk],
+                        original=lv,
+                        search_blob=" ".join(
+                            ["logs", lk, str(lv).lower()]
+                        ).lower(),
+                        label=f"logs  |  {lk}",
+                    )
+                )
+
+    for bucket, key in (
+        ("corePlugins", "corePlugins"),
+        ("devPlugins", "devPlugins"),
+    ):
+        arr = data.get(key)
+        if not isinstance(arr, list):
+            continue
+        for i, plugin in enumerate(arr):
+            if not isinstance(plugin, dict):
+                continue
+            pname = str(plugin.get("name", ""))
+            pver = str(plugin.get("version", ""))
+            for pk, pv in plugin.items():
+                if isinstance(pv, bool):
+                    rows.append(
+                        BooleanRow(
+                            path=[key, i, pk],
+                            original=pv,
+                            search_blob=" ".join(
+                                [bucket, pname, pver, pk, str(pv).lower()]
+                            ).lower(),
+                            label=f"{bucket}[{i}]  |  {pname}@{pver}  |  {pk}",
+                        )
+                    )
+
+    archs = data.get("archetypes")
+    if isinstance(archs, list):
+        for ai, arch in enumerate(archs):
+            if not isinstance(arch, dict):
+                continue
+            aid = str(arch.get("id", ""))
+            aname = str(arch.get("name", ""))
+            plugins = arch.get("plugins")
+            if not isinstance(plugins, list):
+                continue
+            for pi, plugin in enumerate(plugins):
+                if not isinstance(plugin, dict):
+                    continue
+                pname = str(plugin.get("name", ""))
+                pver = str(plugin.get("version", ""))
+                for pk, pv in plugin.items():
+                    if isinstance(pv, bool):
+                        rows.append(
+                            BooleanRow(
+                                path=["archetypes", ai, "plugins", pi, pk],
+                                original=pv,
+                                search_blob=" ".join(
+                                    [
+                                        aid,
+                                        aname,
+                                        pname,
+                                        pver,
+                                        pk,
+                                        str(pv).lower(),
+                                    ]
+                                ).lower(),
+                                label=f"{aid}  |  {pname}@{pver}  |  {pk}",
+                            )
+                        )
+
+    return rows
+
+
+def load_archetypes(path: Path) -> tuple[dict[str, Any], List[BooleanRow]]:
+    text = path.read_text(encoding="utf-8")
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError("archetypes.json must be a JSON object")
+    return data, _flatten(data)

--- a/dev/tools/archetypes-flags-tui/requirements.txt
+++ b/dev/tools/archetypes-flags-tui/requirements.txt
@@ -1,0 +1,2 @@
+textual>=0.58.0
+rapidfuzz>=3.6.0

--- a/dev/utils/apply-archetypes-boolean-patch.sh
+++ b/dev/utils/apply-archetypes-boolean-patch.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# apply-archetypes-boolean-patch.sh — Merge validated boolean patches into archetypes.json
+#
+# Patch format (JSON array):
+#   [{ "op": "set_boolean", "path": ["logs","debug"], "value": true }, ...]
+#
+# Path rules (jq getpath/setpath segments):
+#   - Top-level boolean: ["coreOnlyMode"], ["extensionPingEveryLoad"], etc.
+#   - Logs: ["logs", "<key>"] where <key> is a direct child of logs
+#   - Core plugin: ["corePlugins", <index>, "<key>"]
+#   - Dev plugin: ["devPlugins", <index>, "<key>"]
+#   - Archetype plugin: ["archetypes", <a>, "plugins", <p>, "<key>"]
+#
+# Each path must exist in the current file and resolve to a JSON boolean.
+# Each value must be a JSON boolean.
+#
+# Output: full merged archetypes.json on stdout.
+# If any boolean value changed, archetypesVersion is bumped by 0.1 (same rule as
+# toggle-core-only-mode.sh). If patches are no-ops, the original file is echoed
+# unchanged (including archetypesVersion).
+#
+# Usage:
+#   ./apply-archetypes-boolean-patch.sh <archetypes.json> <patch.json>
+#
+# Exits non-zero if validation or jq fails.
+#
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <archetypes.json> <patch.json>" >&2
+  exit 1
+fi
+
+arch_path="$1"
+patch_path="$2"
+
+if ! command -v jq &>/dev/null; then
+  echo "[error] jq is required but not installed." >&2
+  exit 1
+fi
+
+if [[ ! -f "$arch_path" ]]; then
+  echo "[error] archetypes.json not found: $arch_path" >&2
+  exit 1
+fi
+
+if [[ ! -f "$patch_path" ]]; then
+  echo "[error] patch file not found: $patch_path" >&2
+  exit 1
+fi
+
+tmp_merged="$(mktemp)"
+trap 'rm -f "$tmp_merged"' EXIT
+
+jq --slurpfile root "$arch_path" --argjson plist "$(cat "$patch_path")" '
+  ($plist | if type != "array" then error("patch file must be a JSON array") else . end) as $patches
+  | reduce $patches[] as $p ($root[0];
+      if $p.op != "set_boolean" then error("invalid op: \($p.op)")
+      elif ($p.path | type) != "array" then error("path must be a JSON array")
+      elif ($p.path | length) < 1 then error("path must be non-empty")
+      elif ($p.value | type) != "boolean" then error("value must be boolean")
+      else
+        ($p.path | getpath(.)) as $cur
+        | if $cur == null then error("path not found: \($p.path)")
+          elif ($cur | type) != "boolean" then error("not a boolean at path: \($p.path)")
+          else setpath($p.path; $p.value)
+          end
+      end
+    )
+' >"$tmp_merged"
+
+# Compare canonical JSON (exclude ordering noise); if identical to input, no bump
+if jq -e -S . "$arch_path" >/dev/null 2>&1 && [[ "$(jq -cS . "$arch_path")" == "$(jq -cS . "$tmp_merged")" ]]; then
+  cat "$arch_path"
+  exit 0
+fi
+
+jq '
+  .archetypesVersion = (
+    .archetypesVersion
+    | split(".")
+    | (.[1] |= ((tonumber? // 0) + 1 | tostring))
+    | join(".")
+  )
+' "$tmp_merged"

--- a/dev/utils/checkout.sh
+++ b/dev/utils/checkout.sh
@@ -13,15 +13,17 @@
 #
 # Effects:
 #   1. Checks out main and creates a new branch with the given name.
-#   2. Updates fleet.user.js so it targets this branch:
+#   2. Updates fleet.user.js so it targets this branch (via sync-branch-config.sh):
 #      - @name: prefixed with "[<branch>] " (e.g. "[my-feature] Fleet").
 #      - @downloadURL / @updateURL: branch segment set to <branch> so Tampermonkey
 #        installs/updates from the branch-specific raw URL.
 #      - GITHUB_CONFIG.branch: set to <branch> for in-script behaviour.
 #      - VERSION: kept in sync with the header @version.
-#   3. Commits these changes with message "Sync branch config" and pushes the new
+#   3. Runs toggle-core-only-mode.sh -f so archetypes.json has coreOnlyMode false for
+#      feature work (bumps archetypesVersion only when that value changes).
+#   4. Commits these changes with message "Sync branch config" and pushes the new
 #      branch to origin.
-#   4. Prints the GitHub tree URL for the branch so you can install the branch-specific
+#   5. Prints the GitHub tree URL for the branch so you can install the branch-specific
 #      userscript for development and testing.
 #
 # Use this when starting work on a feature: install the script from the printed URL
@@ -51,14 +53,20 @@ if [[ -z "$BRANCH" ]]; then
 fi
 
 sync_script="$script_dir/sync-branch-config.sh"
+toggle_core_script="$script_dir/toggle-core-only-mode.sh"
 if [[ ! -f "$sync_script" ]]; then
   echo "[error] sync-branch-config.sh not found: $sync_script" >&2
+  exit 1
+fi
+if [[ ! -f "$toggle_core_script" ]]; then
+  echo "[error] toggle-core-only-mode.sh not found: $toggle_core_script" >&2
   exit 1
 fi
 
 if [[ "$dry_run" == true ]]; then
   echo "[info] Dry run - would create branch: $BRANCH (no git or file changes)"
   "$sync_script" --dry-run --branch "$BRANCH"
+  echo "[dry-run] Would run: \"$toggle_core_script\" -f"
   echo "[dry-run] Would run: git checkout main"
   echo "[dry-run] Would run: git checkout -b $BRANCH"
   echo "[dry-run] Would run: $sync_script"
@@ -73,6 +81,7 @@ git -C "$root" checkout -b "$BRANCH"
 echo "[info] Current branch: $(git -C "$root" rev-parse --abbrev-ref HEAD)"
 
 "$sync_script"
+"$toggle_core_script" -f
 
 git -C "$root" add .
 git -C "$root" commit -m "Sync branch config"

--- a/dev/utils/toggle-core-only-mode.sh
+++ b/dev/utils/toggle-core-only-mode.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# toggle-core-only-mode.sh — Set archetypes.json coreOnlyMode and bump archetypesVersion on change
+#
+# Usage:
+#   ./utils/toggle-core-only-mode.sh -t   # set coreOnlyMode to true
+#   ./utils/toggle-core-only-mode.sh -f   # set coreOnlyMode to false
+#
+# Arguments (required; the script does nothing without exactly one of these):
+#   -t   Enable core-only mode (archetype UX plugins off; core plugins remain).
+#   -f   Disable core-only mode.
+#
+# Effects:
+#   1. Updates archetypes.json field coreOnlyMode to true or false.
+#   2. If and only if that value changed, bumps archetypesVersion by 0.1 (minor;
+#      same rule as update-versions.sh: increment the segment after the dot, e.g. 6.94 -> 6.95).
+#
+# Prerequisites: jq (must be on PATH). Repo root is derived from git.
+#
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 -t|-f" >&2
+  exit 1
+fi
+
+want_json=""
+case "$1" in
+  -t) want_json='true' ;;
+  -f) want_json='false' ;;
+  *)
+    echo "Usage: $0 -t|-f" >&2
+    exit 1
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+archetypes_path="$root/archetypes.json"
+
+if ! command -v jq &>/dev/null; then
+  echo "[error] jq is required but not installed." >&2
+  exit 1
+fi
+
+if [[ ! -f "$archetypes_path" ]]; then
+  echo "[error] archetypes.json not found: $archetypes_path" >&2
+  exit 1
+fi
+
+if jq -e --argjson want "$want_json" '(.coreOnlyMode // false) == $want' "$archetypes_path" >/dev/null 2>&1; then
+  echo "[info] coreOnlyMode already $want_json; no changes to $archetypes_path"
+  exit 0
+fi
+
+tmp_out="$(mktemp)"
+trap 'rm -f "$tmp_out"' EXIT
+
+jq --argjson want "$want_json" '
+  .coreOnlyMode = $want
+  | .archetypesVersion = (
+      .archetypesVersion
+      | split(".")
+      | (.[1] |= ((tonumber? // 0) + 1 | tostring))
+      | join(".")
+    )
+' "$archetypes_path" > "$tmp_out"
+
+old_ver="$(jq -r '.archetypesVersion // ""' "$archetypes_path")"
+new_ver="$(jq -r '.archetypesVersion // ""' "$tmp_out")"
+cp "$tmp_out" "$archetypes_path"
+echo "[info] coreOnlyMode -> $want_json; archetypesVersion: \"$old_ver\" -> \"$new_ver\""

--- a/dev/utils/toggle-core-only-mode.sh
+++ b/dev/utils/toggle-core-only-mode.sh
@@ -3,41 +3,84 @@
 # toggle-core-only-mode.sh — Set archetypes.json coreOnlyMode and bump archetypesVersion on change
 #
 # Usage:
-#   ./utils/toggle-core-only-mode.sh -t   # set coreOnlyMode to true
-#   ./utils/toggle-core-only-mode.sh -f   # set coreOnlyMode to false
+#   ./utils/toggle-core-only-mode.sh -t|-f [-c]
+#   ./utils/toggle-core-only-mode.sh -tc|-ct|-fc|-cf
 #
-# Arguments (required; the script does nothing without exactly one of these):
+# Arguments (required; mode is not applied without exactly one of -t or -f):
 #   -t   Enable core-only mode (archetype UX plugins off; core plugins remain).
 #   -f   Disable core-only mode.
+#   -c   After a successful toggle, git commit archetypes.json with an appropriate message.
 #
 # Effects:
 #   1. Updates archetypes.json field coreOnlyMode to true or false.
 #   2. If and only if that value changed, bumps archetypesVersion by 0.1 (minor;
 #      same rule as update-versions.sh: increment the segment after the dot, e.g. 6.94 -> 6.95).
+#   3. With -c, commits only when step 1 changed the file; otherwise logs that there is nothing to commit.
 #
 # Prerequisites: jq (must be on PATH). Repo root is derived from git.
 #
 
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 -t|-f" >&2
+want_json=""
+commit_after=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t)
+      if [[ -n "$want_json" ]]; then
+        echo "[error] Specify only one of -t or -f" >&2
+        exit 1
+      fi
+      want_json='true'
+      shift
+      ;;
+    -f)
+      if [[ -n "$want_json" ]]; then
+        echo "[error] Specify only one of -t or -f" >&2
+        exit 1
+      fi
+      want_json='false'
+      shift
+      ;;
+    -c)
+      commit_after=true
+      shift
+      ;;
+    -tc|-ct)
+      if [[ -n "$want_json" ]]; then
+        echo "[error] Specify only one of -t or -f" >&2
+        exit 1
+      fi
+      want_json='true'
+      commit_after=true
+      shift
+      ;;
+    -fc|-cf)
+      if [[ -n "$want_json" ]]; then
+        echo "[error] Specify only one of -t or -f" >&2
+        exit 1
+      fi
+      want_json='false'
+      commit_after=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [-c] -t|-f   or   $0 -tc|-ct|-fc|-cf" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$want_json" ]]; then
+  echo "Usage: $0 [-c] -t|-f   or   $0 -tc|-ct|-fc|-cf" >&2
   exit 1
 fi
-
-want_json=""
-case "$1" in
-  -t) want_json='true' ;;
-  -f) want_json='false' ;;
-  *)
-    echo "Usage: $0 -t|-f" >&2
-    exit 1
-    ;;
-esac
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(git -C "$script_dir" rev-parse --show-toplevel)"
 archetypes_path="$root/archetypes.json"
+archetypes_rel="archetypes.json"
 
 if ! command -v jq &>/dev/null; then
   echo "[error] jq is required but not installed." >&2
@@ -51,6 +94,9 @@ fi
 
 if jq -e --argjson want "$want_json" '(.coreOnlyMode // false) == $want' "$archetypes_path" >/dev/null 2>&1; then
   echo "[info] coreOnlyMode already $want_json; no changes to $archetypes_path"
+  if [[ "$commit_after" == true ]]; then
+    echo "[info] No commit (-c): archetypes.json was already in the requested state"
+  fi
   exit 0
 fi
 
@@ -71,3 +117,15 @@ old_ver="$(jq -r '.archetypesVersion // ""' "$archetypes_path")"
 new_ver="$(jq -r '.archetypesVersion // ""' "$tmp_out")"
 cp "$tmp_out" "$archetypes_path"
 echo "[info] coreOnlyMode -> $want_json; archetypesVersion: \"$old_ver\" -> \"$new_ver\""
+
+if [[ "$want_json" == 'true' ]]; then
+  mode_phrase="Enable core-only mode"
+else
+  mode_phrase="Disable core-only mode"
+fi
+
+if [[ "$commit_after" == true ]]; then
+  git -C "$root" add -- "$archetypes_path"
+  git -C "$root" commit -m "$mode_phrase in archetypes.json" -m "Set coreOnlyMode to $want_json and bump archetypesVersion ($old_ver -> $new_ver)."
+  echo "[info] Committed $archetypes_rel"
+fi

--- a/dev/utils/vercel-tests/extension-ping-post.sh
+++ b/dev/utils/vercel-tests/extension-ping-post.sh
@@ -8,6 +8,7 @@
 # Examples:
 #   ./dev/utils/extension-ping-post.sh
 #   ./dev/utils/extension-ping-post.sh maxwellturner@gmail.com
+#   ./dev/utils/extension-ping-post.sh maxwellturner@gmail.com 1.4.2
 #
 
 set -euo pipefail
@@ -15,16 +16,19 @@ set -euo pipefail
 BASE_URL="https://operations-toolkit-admin.vercel.app"
 ENDPOINT="/api/extension-ping"
 EMAIL="${1:-test@example.com}"
+EXT_VERSION="${2:-1.4.2}"
 
 if [[ "$EMAIL" == "--help" || "$EMAIL" == "-h" ]]; then
   cat <<'EOF'
-Usage: extension-ping-post.sh [email]
+Usage: extension-ping-post.sh [email] [extensionVersion]
 
 Sends POST https://operations-toolkit-admin.vercel.app/api/extension-ping
 
 Arguments:
-  email   Optional. Email to send in JSON body.
-          Defaults to test@example.com
+  email             Optional. Email in JSON body. Defaults to test@example.com
+  extensionVersion  Optional. metadata.extensionVersion. Defaults to 1.4.2
+
+Sample metadata matches the userscript shape: extensionVersion + userAgent string.
 EOF
   exit 0
 fi
@@ -34,7 +38,7 @@ if [[ "$EMAIL" != *"@"* ]]; then
   exit 1
 fi
 
-payload=$(printf '{"email":"%s"}' "$EMAIL")
+payload=$(printf '{"email":"%s","metadata":{"extensionVersion":"%s","userAgent":"Mozilla/5.0 (test) Chrome/123.0.6312.86"}}' "$EMAIL" "$EXT_VERSION")
 
 echo "[info] POST ${BASE_URL}${ENDPOINT}"
 echo "[info] Payload: $payload"

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [fix-spa-url-check] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      6.4.0
+// @version      7.0.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '6.4.0';
+    const VERSION = '7.0.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -371,10 +371,18 @@
             }
             
             const previousUrl = this._lastUrl;
+            const previousPath = UrlMatcher.getPathFromUrl(previousUrl);
+            const nextPath = UrlMatcher.getPathFromUrl(newUrl);
+
             this._lastUrl = newUrl;
-            
+
+            if (previousPath === nextPath) {
+                Logger.debug('Query-only or hash-only URL change; skipping plugin navigation');
+                return;
+            }
+
             Logger.log(`Navigation detected [${method}]: ${previousUrl} → ${newUrl}`);
-            
+
             this._onNavigateCallbacks.forEach(callback => {
                 try {
                     callback(newUrl, previousUrl);
@@ -2215,21 +2223,6 @@
     }
     
     /**
-     * Extract a specific query parameter from a URL
-     * @param {string} url - The full URL
-     * @param {string} param - The parameter name to extract
-     * @returns {string|null} - The parameter value or null if not found
-     */
-    function getQueryParam(url, param) {
-        try {
-            const urlObj = new URL(url);
-            return urlObj.searchParams.get(param);
-        } catch (e) {
-            return null;
-        }
-    }
-
-    /**
      * Whether SPA navigation to this path should trigger a full reload (archetype plugins
      * are listed in archetypes.json for the main archetype and/or devArchetypes when dev is on).
      */
@@ -2265,16 +2258,6 @@
 
         if (newUrl === previousUrl) {
             Logger.log('URL is the same, skipping...');
-            return;
-        }
-
-        // Check if task_project_target_id matches - if so, don't reload
-        // This prevents reload when only instance_id changes (e.g., backend reset)
-        const previousProjectId = getQueryParam(previousUrl, 'task_project_target_id');
-        const newProjectId = getQueryParam(newUrl, 'task_project_target_id');
-
-        if (previousProjectId && newProjectId && previousProjectId === newProjectId) {
-            Logger.log(`Navigation has same task_project_target_id (${newProjectId}), skipping reload...`);
             return;
         }
 

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix-spa-url-check] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-spa-url-check/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-spa-url-check/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix-spa-url-check',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [fix-spa-url-check] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      7.0.0
+// @version      7.1.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '7.0.0';
+    const VERSION = '7.1.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -74,6 +74,10 @@
         getPageWindow: () => typeof unsafeWindow !== 'undefined' ? unsafeWindow : window,
         storageKeys: SHARED_STORAGE_KEYS,
         settingsModalDocs: {},
+        /** From archetypes.json `logs` + per-plugin `log`; defaults until fetch completes. */
+        remoteLogging: { debug: false, verbose: false, submodule: false },
+        /** Filenames (archetypes `name`) with `log: true` */
+        remoteModuleLogByFile: {},
     };
 
     // ============= DEV-ONLY REDIRECT (GODMODE) =============
@@ -635,21 +639,29 @@
         
         isDebugEnabled() {
             if (this._debugEnabled === null) {
-                this._debugEnabled = Storage.get('debug', true);
+                const storageOn = Storage.get('debug', true);
+                const rl = Context.remoteLogging;
+                const remoteOn = rl && rl.debug && rl.submodule;
+                this._debugEnabled = storageOn || !!remoteOn;
             }
             return this._debugEnabled;
         },
         
         isVerboseEnabled() {
             if (this._verboseEnabled === null) {
-                this._verboseEnabled = Storage.get('verbose', true);
+                const storageOn = Storage.get('verbose', true);
+                const rl = Context.remoteLogging;
+                const remoteOn = rl && rl.verbose && rl.submodule;
+                this._verboseEnabled = storageOn || !!remoteOn;
             }
             return this._verboseEnabled;
         },
 
         isSubmoduleLoggingEnabled() {
             if (this._submoduleEnabled === null) {
-                this._submoduleEnabled = Storage.getSubmoduleLoggingEnabled();
+                const storageOn = Storage.getSubmoduleLoggingEnabled();
+                const rl = Context.remoteLogging;
+                this._submoduleEnabled = storageOn || !!(rl && rl.submodule);
             }
             return this._submoduleEnabled;
         },
@@ -657,7 +669,14 @@
         isModuleLoggingEnabled(moduleId) {
             if (!moduleId) return false;
             if (typeof this._moduleLogEnabled[moduleId] === 'undefined') {
-                this._moduleLogEnabled[moduleId] = Storage.getModuleLoggingEnabled(moduleId);
+                const storageOn = Storage.getModuleLoggingEnabled(moduleId);
+                let remoteOn = false;
+                const reg = typeof PluginManager !== 'undefined' ? PluginManager.get(moduleId) : null;
+                const file = reg && reg._sourceFile;
+                if (file && Context.remoteModuleLogByFile && Context.remoteModuleLogByFile[file]) {
+                    remoteOn = true;
+                }
+                this._moduleLogEnabled[moduleId] = storageOn || remoteOn;
             }
             return this._moduleLogEnabled[moduleId];
         },
@@ -781,6 +800,38 @@
         }
     };
 
+    /**
+     * Read `logs` / per-plugin `log` from archetypes.json and merge into Context.
+     * Remote debug/verbose only apply when remote submodule is true. Per-file `log` follows
+     * the same submodule master gate as storage (via _shouldLogModule).
+     */
+    function applyArchetypeRemoteLoggingConfig(config) {
+        const logs = (config && config.logs) || {};
+        Context.remoteLogging = {
+            debug: logs.debug === true,
+            verbose: logs.verbose === true,
+            submodule: logs.submodule === true
+        };
+        const byFile = Object.create(null);
+        const ingestPluginList = (list) => {
+            if (!list || !Array.isArray(list)) return;
+            for (const def of list) {
+                if (def && typeof def === 'object' && def.name && def.log === true) {
+                    byFile[def.name] = true;
+                }
+            }
+        };
+        ingestPluginList(config.corePlugins);
+        ingestPluginList(config.devPlugins);
+        (config.archetypes || []).forEach((a) => ingestPluginList(a.plugins));
+        (config.devArchetypes || []).forEach((a) => ingestPluginList(a.plugins));
+        Context.remoteModuleLogByFile = byFile;
+        Logger._debugEnabled = null;
+        Logger._verboseEnabled = null;
+        Logger._submoduleEnabled = null;
+        Logger._moduleLogEnabled = {};
+    }
+
     // ============= DOM SELECTORS (SAFE) =============
     const DomUtils = {
         _invalidSelectorLog: new Set(),
@@ -889,6 +940,7 @@
                                 // Always log archetypes version (cannot be disabled)
                                 Context.archetypesVersion = config.archetypesVersion || null;
                                 Context.coreOnlyMode = config.coreOnlyMode === true;
+                                applyArchetypeRemoteLoggingConfig(config);
                                 console.log(`${LOG_PREFIX} archetypes v${config.archetypesVersion || 'unknown'}`);
                                 if (Context.coreOnlyMode) {
                                     Logger.log('coreOnlyMode is enabled: archetype UX plugins and SPA auto-reload are off; core plugins remain active.');

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -66,6 +66,8 @@
         latestVersion: null,
         /** When true (from archetypes.json coreOnlyMode), skip archetype plugins and SPA full reload; core plugins (e.g. settings UI) still run. */
         coreOnlyMode: false,
+        /** When true (from archetypes.json extensionPingEveryLoad), extension-ping POSTs on every load instead of once per userscript version. */
+        extensionPingEveryLoad: false,
         isDevBranch: DEV_SCRIPTS_ENABLED,
         githubBranch: GITHUB_CONFIG.branch,
         githubOwner: GITHUB_CONFIG.owner,
@@ -940,6 +942,7 @@
                                 // Always log archetypes version (cannot be disabled)
                                 Context.archetypesVersion = config.archetypesVersion || null;
                                 Context.coreOnlyMode = config.coreOnlyMode === true;
+                                Context.extensionPingEveryLoad = config.extensionPingEveryLoad === true;
                                 applyArchetypeRemoteLoggingConfig(config);
                                 console.log(`${LOG_PREFIX} archetypes v${config.archetypesVersion || 'unknown'}`);
                                 if (Context.coreOnlyMode) {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix-spa-url-check] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      6.4.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-spa-url-check/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-spa-url-check/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix-spa-url-check',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/extension-ping.js
+++ b/plugins/core/main/extension-ping.js
@@ -4,8 +4,9 @@
 const plugin = {
     id: 'extension-ping',
     name: 'Extension Ping',
-    description: 'Pings extension endpoint once per userscript version',
-    _version: '1.1',
+    description:
+        'Pings extension usage endpoint; once per userscript version by default, or every load when archetypes.json sets extensionPingEveryLoad',
+    _version: '1.4',
     phase: 'core',
     enabledByDefault: true,
 
@@ -18,10 +19,15 @@ const plugin = {
             }
 
             const storageKey = 'extension-ping-last-version';
-            const lastPingedVersion = Storage.get(storageKey, null);
-            if (lastPingedVersion === currentVersion) {
-                Logger.debug(`Extension ping skipped: already pinged for version ${currentVersion}`);
-                return;
+            const pingEveryLoad = context && context.extensionPingEveryLoad === true;
+            if (!pingEveryLoad) {
+                const lastPingedVersion = Storage.get(storageKey, null);
+                if (lastPingedVersion === currentVersion) {
+                    Logger.debug(`Extension ping skipped: already pinged for version ${currentVersion}`);
+                    return;
+                }
+            } else {
+                Logger.debug('Extension ping: extensionPingEveryLoad is set; skipping version dedup');
             }
 
             const email = this._extractEmailFromInlineScripts();
@@ -30,7 +36,7 @@ const plugin = {
                 return;
             }
 
-            this._sendPing(email, currentVersion, storageKey);
+            this._sendPing(email, currentVersion, storageKey, pingEveryLoad);
         } catch (error) {
             Logger.error('Extension ping init failed:', error);
         }
@@ -64,13 +70,42 @@ const plugin = {
         return null;
     },
 
-    _sendPing(email, currentVersion, storageKey) {
+    _buildPingMetadata(extensionVersion) {
+        const meta = { extensionVersion: String(extensionVersion) };
+        const nav = typeof navigator !== 'undefined' ? navigator : null;
+        if (nav && nav.userAgent) {
+            meta.userAgent = nav.userAgent;
+        }
+        if (nav && nav.userAgentData) {
+            const uad = nav.userAgentData;
+            const plain = {};
+            if (uad.brands && uad.brands.length > 0) {
+                plain.brands = uad.brands.map((b) => ({ brand: b.brand, version: b.version }));
+            }
+            if (typeof uad.mobile === 'boolean') {
+                plain.mobile = uad.mobile;
+            }
+            if (uad.platform) {
+                plain.platform = uad.platform;
+            }
+            if (Object.keys(plain).length > 0) {
+                meta.userAgentData = plain;
+            }
+        }
+        return meta;
+    },
+
+    _sendPing(email, currentVersion, storageKey, pingEveryLoad) {
         if (typeof GM_xmlhttpRequest !== 'function') {
             Logger.error('Extension ping unavailable: GM_xmlhttpRequest is not defined');
             return;
         }
 
-        const payload = JSON.stringify({ email });
+        const body = {
+            email,
+            metadata: this._buildPingMetadata(currentVersion)
+        };
+        const payload = JSON.stringify(body);
         const url = 'https://operations-toolkit-admin.vercel.app/api/extension-ping';
 
         GM_xmlhttpRequest({
@@ -83,8 +118,14 @@ const plugin = {
             onload: (response) => {
                 const status = response && typeof response.status === 'number' ? response.status : 0;
                 if (status >= 200 && status < 300) {
-                    Storage.set(storageKey, currentVersion);
-                    Logger.info(`Extension ping sent for version ${currentVersion}`);
+                    if (!pingEveryLoad) {
+                        Storage.set(storageKey, currentVersion);
+                    }
+                    Logger.info(
+                        pingEveryLoad
+                            ? `Extension ping sent for version ${currentVersion} (extensionPingEveryLoad)`
+                            : `Extension ping sent for version ${currentVersion}`
+                    );
                     return;
                 }
 

--- a/plugins/core/main/extension-ping.js
+++ b/plugins/core/main/extension-ping.js
@@ -6,7 +6,7 @@ const plugin = {
     name: 'Extension Ping',
     description:
         'Pings extension usage endpoint; once per userscript version by default, or every load when archetypes.json sets extensionPingEveryLoad',
-    _version: '1.4',
+    _version: '1.5',
     phase: 'core',
     enabledByDefault: true,
 
@@ -75,22 +75,6 @@ const plugin = {
         const nav = typeof navigator !== 'undefined' ? navigator : null;
         if (nav && nav.userAgent) {
             meta.userAgent = nav.userAgent;
-        }
-        if (nav && nav.userAgentData) {
-            const uad = nav.userAgentData;
-            const plain = {};
-            if (uad.brands && uad.brands.length > 0) {
-                plain.brands = uad.brands.map((b) => ({ brand: b.brand, version: b.version }));
-            }
-            if (typeof uad.mobile === 'boolean') {
-                plain.mobile = uad.mobile;
-            }
-            if (uad.platform) {
-                plain.platform = uad.platform;
-            }
-            if (Object.keys(plain).length > 0) {
-                meta.userAgentData = plain;
-            }
         }
         return meta;
     },


### PR DESCRIPTION
## Summary

This branch improves Fleet’s SPA navigation, extension telemetry, archetypes configuration, and local developer workflows. Navigation ignores query- and hash-only history changes so the userscript does not reinitialize unnecessarily. Archetypes and `fleet.user.js` gain remote logging controls and related wiring. Extension ping carries a richer metadata payload with configurable per-load behavior. Developer tooling adds an interactive Textual TUI for editing boolean archetype flags, plus CI and shell helpers to apply boolean patches, alongside checkout integration for core-only mode toggling.

## Changes

- **Navigation (`fleet.user.js`)** — Treat URL updates that only change query or hash as non-navigations for SPA reinit logic.
- **Archetypes & logging** — Expand `archetypes.json` and loader behavior for remote logging (global and per-plugin); document workflow notes in `dev/module-workflow.md`.
- **Extension ping** — Update `plugins/core/main/extension-ping.js` and `fleet.user.js` for metadata payload, `extensionPingEveryLoad`, and ping dispatch tuning (including test harness tweaks under `dev/utils/vercel-tests/`).
- **Dev tooling** — Add `dev/tools/archetypes-flags-tui/` (Textual app + flatten helper + requirements), `dev/utils/apply-archetypes-boolean-patch.sh`, and `.github/workflows/archetypes-boolean-apply.yml` for applying boolean edits from automation.
- **Checkout / core-only** — Extend `dev/utils/checkout.sh` and add `dev/utils/toggle-core-only-mode.sh` so branch checkout can align core-only mode and archetypes as needed.

## Commit history

- `caa0d1d` feat(archetypes-flags-tui): rank search with LCS coverage and normalized LCS
- `8838827` fix(archetypes-flags-tui): rank substring matches before fuzzy scores
- `47c86a5` feat(archetypes-flags-tui): quit immediately on Ctrl+C
- `d65b4f7` fix(archetypes-flags-tui): literal [x]/[ ] cells and saner search Backspace
- `d025e57` fix(archetypes-flags-tui): drop DataTable.column_count check for Textual compat
- `7527d8f` feat(dev): interactive archetypes boolean editor and workflow apply
- `e83dc1c` Sync fleet.user.js branch config to main
- `41a68c8` Disable ping on every load
- `fd7cfd7` chore(extension-ping): drop userAgentData from ping metadata
- `05227b7` Set ping to true for testing
- `e288ba2` feat(extension-ping): metadata payload + extensionPingEveryLoad
- `5e2bbbe` feat(archetypes): remote logging flags (logs + per-plugin log)
- `9ec7914` fix(nav): ignore query/hash-only URL changes for SPA reinit
- `e511913` Disable core-only mode in archetypes.json
- `63da974` Restore toggle-core-only-mode -c commit option
- `938eb87` Add toggle-core-only-mode.sh and run it from checkout

## Stats

12 files changed, 1237 insertions(+), 169 deletions(-)

```
 .github/workflows/archetypes-boolean-apply.yml  |  62 ++++
 archetypes.json                                 | 356 ++++++++++++-------
 dev/module-workflow.md                          |  11 +
 dev/tools/archetypes-flags-tui/app.py           | 452 ++++++++++++++++++++++++
 dev/tools/archetypes-flags-tui/flatten.py       | 127 +++++++
 dev/tools/archetypes-flags-tui/requirements.txt |   2 +
 dev/utils/apply-archetypes-boolean-patch.sh     |  87 +++++
 dev/utils/checkout.sh                           |  15 +-
 dev/utils/toggle-core-only-mode.sh              | 131 +++++++
 dev/utils/vercel-tests/extension-ping-post.sh   |  12 +-
 fleet.user.js                                   | 104 ++++--
 plugins/core/main/extension-ping.js             |  47 ++-
 12 files changed, 1237 insertions(+), 169 deletions(-)
```
