### PR TITLE
Add and harden page refresh confirmation flow

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,8 +1,8 @@
 {
-  "version": "7.1.0",
+  "version": "7.1.1",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.104",
+  "archetypesVersion": "6.105",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,8 +1,8 @@
 {
-  "version": "7.1.2",
+  "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.107",
+  "archetypesVersion": "6.108",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.109",
+  "archetypesVersion": "6.110",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -11,8 +11,8 @@
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.5",
-      "hash": "sha256-7806ed8a2b64c4919e210b1a501dbc35e9c0443bd53c0631f7618047fa96ef13",
+      "version": "6.6",
+      "hash": "sha256-41d7f552bf27523d7e93214cd68fd617162640b39c0e1541ef854ca0fb0a672a",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,8 +1,8 @@
 {
-  "version": "7.1.1",
+  "version": "7.1.2",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.105",
+  "archetypesVersion": "6.106",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.0",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.103",
+  "archetypesVersion": "6.104",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -11,8 +11,8 @@
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.2",
-      "hash": "sha256-eac152cd0dbcf5c97bff3ddc17c3ccc65a2fadfbca2af55e0f89f62b4febf07c",
+      "version": "6.3",
+      "hash": "sha256-0ca25ecdf6bc263c0371dfdb611100a98ef822fea559d5a05550a272b6cdb4cf",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.108",
+  "archetypesVersion": "6.109",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -11,8 +11,8 @@
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.4",
-      "hash": "sha256-d80f37469a191f64c5cbc8894c545a182e2bbea1a6f3faa9ae715fdcc5f29d6c",
+      "version": "6.5",
+      "hash": "sha256-7806ed8a2b64c4919e210b1a501dbc35e9c0443bd53c0631f7618047fa96ef13",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.2",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.106",
+  "archetypesVersion": "6.107",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -11,8 +11,8 @@
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.3",
-      "hash": "sha256-0ca25ecdf6bc263c0371dfdb611100a98ef822fea559d5a05550a272b6cdb4cf",
+      "version": "6.4",
+      "hash": "sha256-d80f37469a191f64c5cbc8894c545a182e2bbea1a6f3faa9ae715fdcc5f29d6c",
       "log": false
     },
     {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -82,6 +82,107 @@
         remoteModuleLogByFile: {},
     };
 
+    const RefreshGuard = {
+        _pendingReloadSource: null,
+        _pendingReloadReason: null,
+        _pendingReloadAt: 0,
+        _beforeUnloadBound: false,
+        _reloadPatched: false,
+
+        isPageRefreshConfirmationEnabled() {
+            return Storage.get('page-refresh-confirmation-enabled', true);
+        },
+
+        isExtensionRefreshConfirmationEnabled() {
+            return Storage.get('extension-refresh-confirmation-enabled', false);
+        },
+
+        markPendingReload(source = 'page', reason = '') {
+            this._pendingReloadSource = source;
+            this._pendingReloadReason = reason || '';
+            this._pendingReloadAt = Date.now();
+            Logger.info(`Refresh pending (${source})${reason ? `: ${reason}` : ''}`);
+        },
+
+        _consumePendingReloadSource() {
+            const now = Date.now();
+            // Keep source marks only briefly so stale values don't leak into unrelated unloads.
+            if (!this._pendingReloadSource || (now - this._pendingReloadAt) > 3000) {
+                this._pendingReloadSource = null;
+                this._pendingReloadReason = null;
+                this._pendingReloadAt = 0;
+                return 'page';
+            }
+            const source = this._pendingReloadSource;
+            this._pendingReloadSource = null;
+            this._pendingReloadReason = null;
+            this._pendingReloadAt = 0;
+            return source;
+        },
+
+        _inferSourceFromStack(stack) {
+            if (!stack) return 'page';
+            if (/fleet\.user\.js|plugins\/core\/|plugins\/archetypes\//i.test(stack)) {
+                return 'extension';
+            }
+            return 'page';
+        },
+
+        _beforeUnloadHandler(event) {
+            const source = this._consumePendingReloadSource();
+            const pageEnabled = this.isPageRefreshConfirmationEnabled();
+            const extensionEnabled = this.isExtensionRefreshConfirmationEnabled();
+            const shouldPrompt = source === 'extension' ? extensionEnabled : pageEnabled;
+            if (!shouldPrompt) {
+                Logger.debug(`Refresh confirmation skipped (${source})`);
+                return undefined;
+            }
+            Logger.warn(`Showing refresh confirmation dialog (${source})`);
+            event.preventDefault();
+            event.returnValue = '';
+            return '';
+        },
+
+        _patchReloadMethod(locationObject, label) {
+            if (!locationObject || typeof locationObject.reload !== 'function') {
+                return false;
+            }
+            const original = locationObject.reload.bind(locationObject);
+            try {
+                locationObject.reload = (...args) => {
+                    const source = this._inferSourceFromStack(new Error().stack || '');
+                    this.markPendingReload(source, `${label}.reload()`);
+                    return original(...args);
+                };
+                Logger.log(`Patched ${label}.reload for refresh confirmation tracking`);
+                return true;
+            } catch (e) {
+                Logger.warn(`Could not patch ${label}.reload directly:`, e);
+                return false;
+            }
+        },
+
+        init() {
+            if (!this._beforeUnloadBound) {
+                window.addEventListener('beforeunload', (event) => this._beforeUnloadHandler(event));
+                this._beforeUnloadBound = true;
+                Logger.log('Refresh confirmation guard initialized');
+            }
+            if (this._reloadPatched) return;
+            const pageWindow = Context.getPageWindow();
+            const patchedCurrentWindow = this._patchReloadMethod(window.location, 'window.location');
+            const patchedPageWindow = pageWindow && pageWindow !== window
+                ? this._patchReloadMethod(pageWindow.location, 'unsafeWindow.location')
+                : false;
+            this._reloadPatched = patchedCurrentWindow || patchedPageWindow;
+        },
+
+        requestExtensionReload(reason = 'extension action') {
+            this.markPendingReload('extension', reason);
+            location.reload();
+        }
+    };
+
     // ============= DEV-ONLY REDIRECT (GODMODE) =============
     // If this build is not main and the user does not have the GODMODE userscript, show a modal and stop.
     const MAIN_SCRIPT_RAW_URL = 'https://raw.githubusercontent.com/' + GITHUB_CONFIG.owner + '/' + GITHUB_CONFIG.repo + '/main/fleet.user.js';
@@ -156,6 +257,8 @@
     }
 
     function runFleet() {
+    Context.requestExtensionReload = (reason) => RefreshGuard.requestExtensionReload(reason);
+    RefreshGuard.init();
 
     // ============= CLEANUP REGISTRY =============
     const CleanupRegistry = {
@@ -533,6 +636,8 @@
             const globalKeys = [
                 'global-plugins-enabled',
                 'global-plugins-previous',
+                'page-refresh-confirmation-enabled',
+                'extension-refresh-confirmation-enabled',
                 'debug',
                 'verbose',
                 'submodule-logging',
@@ -2355,7 +2460,7 @@
                 Logger.log('Navigation target has configured archetype plugins; refreshing page...');
                 Storage.delete('workflow-cache-latest');
                 Storage.delete('workflow-cache-latest-url');
-                location.reload();
+                Context.requestExtensionReload('SPA navigation with configured archetype plugins');
                 return;
             }
             if (warrantsFullReload && Context.coreOnlyMode) {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -110,7 +110,7 @@
 
         isPageRefreshConfirmationEnabled() {
             const storage = this._getStorage();
-            return storage ? storage.get('page-refresh-confirmation-enabled', true) : true;
+            return storage ? storage.get('page-refresh-confirmation-enabled', false) : false;
         },
 
         isExtensionRefreshConfirmationEnabled() {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-confirm-refresh-dialogue] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      7.1.2
+// @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '7.1.2';
+    const VERSION = '7.1.3';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -88,6 +88,7 @@
         _pendingReloadAt: 0,
         _beforeUnloadBound: false,
         _reloadPatched: false,
+        _skipNextBeforeUnloadPrompt: false,
 
         _getStorage() {
             return Context.storage || null;
@@ -150,6 +151,11 @@
 
         _beforeUnloadHandler(event) {
             const source = this._consumePendingReloadSource();
+            if (this._skipNextBeforeUnloadPrompt) {
+                this._skipNextBeforeUnloadPrompt = false;
+                this._log('debug', `Skipping beforeunload prompt once (${source})`);
+                return undefined;
+            }
             const pageEnabled = this.isPageRefreshConfirmationEnabled();
             const extensionEnabled = this.isExtensionRefreshConfirmationEnabled();
             const shouldPrompt = source === 'extension' ? extensionEnabled : pageEnabled;
@@ -157,10 +163,15 @@
                 this._log('debug', `Refresh confirmation skipped (${source})`);
                 return undefined;
             }
+            const bracketLabel = source === 'extension'
+                ? '[Extension Initiated Refresh]'
+                : '[Fleet Initiated Refresh]';
+            const message = `${bracketLabel} Are you sure you want to refresh this page?`;
             this._log('warn', `Showing refresh confirmation dialog (${source})`);
             event.preventDefault();
-            event.returnValue = '';
-            return '';
+            // Browsers may ignore custom beforeunload text, but setting it is still best-effort.
+            event.returnValue = message;
+            return message;
         },
 
         _patchReloadMethod(locationObject, label) {
@@ -202,6 +213,17 @@
         },
 
         requestExtensionReload(reason = 'extension action') {
+            if (this.isExtensionRefreshConfirmationEnabled()) {
+                const confirmed = window.confirm(
+                    '[Extension Initiated Refresh] Are you sure you want to refresh this page?'
+                );
+                if (!confirmed) {
+                    this._log('info', `Extension refresh cancelled by user${reason ? `: ${reason}` : ''}`);
+                    return;
+                }
+                // Prevent a second native beforeunload prompt for the same extension reload.
+                this._skipNextBeforeUnloadPrompt = true;
+            }
             this.markPendingReload('extension', reason);
             location.reload();
         }

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-confirm-refresh-dialogue] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      7.1.0
+// @version      7.1.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '7.1.0';
+    const VERSION = '7.1.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -257,9 +257,6 @@
     }
 
     function runFleet() {
-    Context.requestExtensionReload = (reason) => RefreshGuard.requestExtensionReload(reason);
-    RefreshGuard.init();
-
     // ============= CLEANUP REGISTRY =============
     const CleanupRegistry = {
         _items: {
@@ -906,6 +903,9 @@
             this._emit('error', payload);
         }
     };
+
+    Context.requestExtensionReload = (reason) => RefreshGuard.requestExtensionReload(reason);
+    RefreshGuard.init();
 
     /**
      * Read `logs` / per-plugin `log` from archetypes.json and merge into Context.

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-confirm-refresh-dialogue] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-confirm-refresh-dialogue/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-confirm-refresh-dialogue/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-confirm-refresh-dialogue',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat-confirm-refresh-dialogue] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      7.1.1
+// @version      7.1.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -29,7 +29,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '7.1.1';
+    const VERSION = '7.1.2';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -89,19 +89,39 @@
         _beforeUnloadBound: false,
         _reloadPatched: false,
 
+        _getStorage() {
+            return Context.storage || null;
+        },
+
+        _getLogger() {
+            return Context.logger || null;
+        },
+
+        _log(level, message, ...args) {
+            const logger = this._getLogger();
+            if (logger && typeof logger[level] === 'function') {
+                logger[level](message, ...args);
+                return;
+            }
+            const fn = typeof console[level] === 'function' ? console[level] : console.log;
+            fn(`${LOG_PREFIX} ${message}`, ...args);
+        },
+
         isPageRefreshConfirmationEnabled() {
-            return Storage.get('page-refresh-confirmation-enabled', true);
+            const storage = this._getStorage();
+            return storage ? storage.get('page-refresh-confirmation-enabled', true) : true;
         },
 
         isExtensionRefreshConfirmationEnabled() {
-            return Storage.get('extension-refresh-confirmation-enabled', false);
+            const storage = this._getStorage();
+            return storage ? storage.get('extension-refresh-confirmation-enabled', false) : false;
         },
 
         markPendingReload(source = 'page', reason = '') {
             this._pendingReloadSource = source;
             this._pendingReloadReason = reason || '';
             this._pendingReloadAt = Date.now();
-            Logger.info(`Refresh pending (${source})${reason ? `: ${reason}` : ''}`);
+            this._log('info', `Refresh pending (${source})${reason ? `: ${reason}` : ''}`);
         },
 
         _consumePendingReloadSource() {
@@ -134,10 +154,10 @@
             const extensionEnabled = this.isExtensionRefreshConfirmationEnabled();
             const shouldPrompt = source === 'extension' ? extensionEnabled : pageEnabled;
             if (!shouldPrompt) {
-                Logger.debug(`Refresh confirmation skipped (${source})`);
+                this._log('debug', `Refresh confirmation skipped (${source})`);
                 return undefined;
             }
-            Logger.warn(`Showing refresh confirmation dialog (${source})`);
+            this._log('warn', `Showing refresh confirmation dialog (${source})`);
             event.preventDefault();
             event.returnValue = '';
             return '';
@@ -154,10 +174,10 @@
                     this.markPendingReload(source, `${label}.reload()`);
                     return original(...args);
                 };
-                Logger.log(`Patched ${label}.reload for refresh confirmation tracking`);
+                this._log('log', `Patched ${label}.reload for refresh confirmation tracking`);
                 return true;
             } catch (e) {
-                Logger.warn(`Could not patch ${label}.reload directly:`, e);
+                this._log('warn', `Could not patch ${label}.reload directly:`, e);
                 return false;
             }
         },
@@ -166,15 +186,19 @@
             if (!this._beforeUnloadBound) {
                 window.addEventListener('beforeunload', (event) => this._beforeUnloadHandler(event));
                 this._beforeUnloadBound = true;
-                Logger.log('Refresh confirmation guard initialized');
+                this._log('log', 'Refresh confirmation guard initialized');
             }
             if (this._reloadPatched) return;
-            const pageWindow = Context.getPageWindow();
-            const patchedCurrentWindow = this._patchReloadMethod(window.location, 'window.location');
-            const patchedPageWindow = pageWindow && pageWindow !== window
-                ? this._patchReloadMethod(pageWindow.location, 'unsafeWindow.location')
-                : false;
-            this._reloadPatched = patchedCurrentWindow || patchedPageWindow;
+            try {
+                const pageWindow = Context.getPageWindow();
+                const patchedCurrentWindow = this._patchReloadMethod(window.location, 'window.location');
+                const patchedPageWindow = pageWindow && pageWindow !== window
+                    ? this._patchReloadMethod(pageWindow.location, 'unsafeWindow.location')
+                    : false;
+                this._reloadPatched = patchedCurrentWindow || patchedPageWindow;
+            } catch (e) {
+                this._log('warn', 'Refresh guard init continued without reload patching', e);
+            }
         },
 
         requestExtensionReload(reason = 'extension action') {
@@ -733,6 +757,8 @@
         }
     };
 
+    Context.storage = Storage;
+
     // ============= LOGGING =============
     const Logger = {
         _debugEnabled: null,
@@ -903,6 +929,8 @@
             this._emit('error', payload);
         }
     };
+
+    Context.logger = Logger;
 
     Context.requestExtensionReload = (reason) => RefreshGuard.requestExtensionReload(reason);
     RefreshGuard.init();

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-confirm-refresh-dialogue] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-confirm-refresh-dialogue/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-confirm-refresh-dialogue/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-confirm-refresh-dialogue',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '6.5',
+    _version: '6.6',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
     
@@ -1643,7 +1643,7 @@ const plugin = {
     },
 
     _getPageRefreshConfirmationEnabled() {
-        return Storage.get('page-refresh-confirmation-enabled', true);
+        return Storage.get('page-refresh-confirmation-enabled', false);
     },
 
     _setPageRefreshConfirmationEnabled(enabled) {

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '6.3',
+    _version: '6.4',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
     
@@ -472,18 +472,30 @@ const plugin = {
                     Refresh Confirmation
                 </h3>
                 <div style="display: flex; flex-direction: column; gap: 10px;">
-                    ${this._createToggleHTML(
-                        'wf-page-refresh-confirmation-enabled',
-                        'Page refresh confirmation dialog',
-                        pageRefreshConfirmEnabled,
-                        'main'
-                    )}
-                    ${this._createToggleHTML(
-                        'wf-extension-refresh-confirmation-enabled',
-                        'Confirm before refreshes initiated by this extension?',
-                        extensionRefreshConfirmEnabled,
-                        'sub'
-                    )}
+                    <div style="padding: 10px 12px; border: 1px solid var(--border, #e5e5e5); border-radius: 6px; background: var(--card, #fafafa);">
+                        <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px;">
+                            <label style="font-size: 13px; color: var(--foreground, #333);" for="wf-page-refresh-confirmation-enabled">Page refresh confirmation dialog</label>
+                            ${this._createSwitchHTML('wf-page-refresh-confirmation-enabled', pageRefreshConfirmEnabled, null, false, { variant: 'main' })}
+                        </div>
+                        <div style="font-size: 12px; color: var(--muted-foreground, #666); margin-top: 8px; line-height: 1.45;">
+                            This will show a confirmation dialog before any refresh that is initiated by the Fleet website. If you are experiencing nuisance refreshes, this should allow you to prevent them from affecting you.
+                        </div>
+                        <div style="font-size: 12px; color: #b45309; margin-top: 8px; line-height: 1.45;">
+                            Please note that if you refuse a Fleet refresh (for example, one that occurs from a site update), you may end up continuing to work on an outdated website, and successful page interactions are not guaranteed after this point.
+                        </div>
+                    </div>
+                    <div style="padding: 10px 12px; border: 1px solid var(--border, #e5e5e5); border-radius: 6px; background: var(--card, #fafafa);">
+                        <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px;">
+                            <label style="font-size: 13px; color: var(--foreground, #333);" for="wf-extension-refresh-confirmation-enabled">Confirm before refreshes initiated by this extension?</label>
+                            ${this._createSwitchHTML('wf-extension-refresh-confirmation-enabled', extensionRefreshConfirmEnabled, null, false, { variant: 'sub' })}
+                        </div>
+                        <div style="font-size: 12px; color: var(--muted-foreground, #666); margin-top: 8px; line-height: 1.45;">
+                            This will show a confirmation dialog before any page refresh, including refreshes initiated by this extension.
+                        </div>
+                        <div style="font-size: 12px; color: #b45309; margin-top: 8px; line-height: 1.45;">
+                            Please note that this extension works by refreshing every time you navigate to a page that has plugins associated with it. This toggle should only be used as a last resort for debugging purposes. If you find that you need this toggle enabled to prevent nuisance refreshes, please use the &quot;Feedback&quot; tab to create an issue immediately!
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '6.4',
+    _version: '6.5',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
     
@@ -479,6 +479,9 @@ const plugin = {
                         </div>
                         <div style="font-size: 12px; color: var(--muted-foreground, #666); margin-top: 8px; line-height: 1.45;">
                             This will show a confirmation dialog before any refresh that is initiated by the Fleet website. If you are experiencing nuisance refreshes, this should allow you to prevent them from affecting you.
+                        </div>
+                        <div style="font-size: 12px; color: var(--muted-foreground, #666); margin-top: 8px; line-height: 1.45;">
+                            Please also note that when this toggle is on, you will get a confirmation dialog even when you manually refresh the page (such as by using the browser refresh button, or using <code>CMD/Ctrl + R</code>, etc)
                         </div>
                         <div style="font-size: 12px; color: #b45309; margin-top: 8px; line-height: 1.45;">
                             Please note that if you refuse a Fleet refresh (for example, one that occurs from a site update), you may end up continuing to work on an outdated website, and successful page interactions are not guaranteed after this point.

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '6.2',
+    _version: '6.3',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
     
@@ -266,6 +266,8 @@ const plugin = {
         // Build plugin toggles HTML
         const submoduleLoggingEnabled = Logger.isSubmoduleLoggingEnabled();
         const globalEnabled = this._getGlobalEnabled();
+        const pageRefreshConfirmEnabled = this._getPageRefreshConfirmationEnabled();
+        const extensionRefreshConfirmEnabled = this._getExtensionRefreshConfirmationEnabled();
         const noPluginsMsg = Context.isOutdated
             ? 'No plugins will load until you update the userscript.'
             : 'No plugins loaded for this page.';
@@ -461,6 +463,27 @@ const plugin = {
                         cursor: pointer;
                         transition: all 0.2s;
                     ">All Off</button>
+                </div>
+            </div>
+
+            <!-- Refresh Confirmation -->
+            <div style="margin-bottom: 20px;">
+                <h3 style="font-size: 14px; font-weight: 600; margin: 0 0 12px 0; color: var(--foreground, #333);">
+                    Refresh Confirmation
+                </h3>
+                <div style="display: flex; flex-direction: column; gap: 10px;">
+                    ${this._createToggleHTML(
+                        'wf-page-refresh-confirmation-enabled',
+                        'Page refresh confirmation dialog',
+                        pageRefreshConfirmEnabled,
+                        'main'
+                    )}
+                    ${this._createToggleHTML(
+                        'wf-extension-refresh-confirmation-enabled',
+                        'Confirm before refreshes initiated by this extension?',
+                        extensionRefreshConfirmEnabled,
+                        'sub'
+                    )}
                 </div>
             </div>
 
@@ -723,7 +746,11 @@ const plugin = {
         }
         if (refreshBtn) {
             refreshBtn.addEventListener('click', () => {
-                window.location.reload();
+                if (typeof Context.requestExtensionReload === 'function') {
+                    Context.requestExtensionReload('settings-ui update banner refresh');
+                } else {
+                    window.location.reload();
+                }
             });
         }
 
@@ -1040,7 +1067,35 @@ const plugin = {
         if (reloadLink) {
             reloadLink.addEventListener('click', (e) => {
                 e.preventDefault();
-                window.location.reload();
+                if (typeof Context.requestExtensionReload === 'function') {
+                    Context.requestExtensionReload('settings-ui reload plugins link');
+                } else {
+                    window.location.reload();
+                }
+            });
+        }
+
+        const pageRefreshConfirmationToggle = Context.dom.query('#wf-page-refresh-confirmation-enabled', {
+            root: modal,
+            context: `${this.id}.pageRefreshConfirmationToggle`
+        });
+        if (pageRefreshConfirmationToggle) {
+            pageRefreshConfirmationToggle.addEventListener('change', (e) => {
+                this._handleToggleChange(e);
+                this._setPageRefreshConfirmationEnabled(e.target.checked);
+                this._updateSettingsMessage(modal, plugins);
+            });
+        }
+
+        const extensionRefreshConfirmationToggle = Context.dom.query('#wf-extension-refresh-confirmation-enabled', {
+            root: modal,
+            context: `${this.id}.extensionRefreshConfirmationToggle`
+        });
+        if (extensionRefreshConfirmationToggle) {
+            extensionRefreshConfirmationToggle.addEventListener('change', (e) => {
+                this._handleToggleChange(e);
+                this._setExtensionRefreshConfirmationEnabled(e.target.checked);
+                this._updateSettingsMessage(modal, plugins);
             });
         }
         
@@ -1057,7 +1112,11 @@ const plugin = {
                     const clearedCount = Storage.clearAll(allPlugins);
                     Logger.log(`✓ Cache cleared: ${clearedCount} keys removed`);
                     alert(`Cache cleared successfully. ${clearedCount} storage keys were removed. The page will now reload.`);
-                    window.location.reload();
+                    if (typeof Context.requestExtensionReload === 'function') {
+                        Context.requestExtensionReload('settings-ui clear cache');
+                    } else {
+                        window.location.reload();
+                    }
                 }
             });
             clearCacheBtn.addEventListener('mouseenter', () => {
@@ -1516,6 +1575,8 @@ const plugin = {
             .sort((a, b) => (a.id || '').localeCompare(b.id || ''));
         const snapshot = {
             globalEnabled: this._getGlobalEnabled(),
+            pageRefreshConfirmationEnabled: this._getPageRefreshConfirmationEnabled(),
+            extensionRefreshConfirmationEnabled: this._getExtensionRefreshConfirmationEnabled(),
             debug: Logger.isDebugEnabled(),
             verbose: Logger.isVerboseEnabled(),
             submoduleLogging: Logger.isSubmoduleLoggingEnabled(),
@@ -1564,6 +1625,22 @@ const plugin = {
 
     _setGlobalEnabled(enabled) {
         Storage.set('global-plugins-enabled', enabled);
+    },
+
+    _getPageRefreshConfirmationEnabled() {
+        return Storage.get('page-refresh-confirmation-enabled', true);
+    },
+
+    _setPageRefreshConfirmationEnabled(enabled) {
+        Storage.set('page-refresh-confirmation-enabled', enabled);
+    },
+
+    _getExtensionRefreshConfirmationEnabled() {
+        return Storage.get('extension-refresh-confirmation-enabled', false);
+    },
+
+    _setExtensionRefreshConfirmationEnabled(enabled) {
+        Storage.set('extension-refresh-confirmation-enabled', enabled);
     },
     
     _getPulseOverrideEnabled() {
@@ -1676,7 +1753,11 @@ const plugin = {
             if (refreshLink) {
                 refreshLink.addEventListener('click', (e) => {
                     e.preventDefault();
-                    window.location.reload();
+                    if (typeof Context.requestExtensionReload === 'function') {
+                        Context.requestExtensionReload('settings-ui settings changed refresh');
+                    } else {
+                        window.location.reload();
+                    }
                 });
             }
         }


### PR DESCRIPTION
## Summary
Add and harden core page-refresh confirmation controls, then align branch config output with main so refresh safety behavior is explicit and stable.

## Changes
- Added refresh confirmation controls in core settings and wired a reload guard path to protect manual refresh workflows.
- Fixed startup-order and bootstrap-scope crashes in the refresh guard so logging/storage access resolve safely during initialization.
- Improved confirmation UX copy by clarifying behavior text and adding bracketed source labels in dialogs.
- Synced generated branch-config output into `fleet.user.js` to keep branch behavior aligned with `main` expectations.

## Commit history
- 07cce0b Sync fleet.user.js branch config to main
- 46dde84 Clarify main refresh confirmation behavior for manual page reloads.
- a903785 Add bracketed source labels to refresh confirmation dialogs.
- 3931c15 Improve refresh confirmation setting descriptions for user guidance and safety.
- 8c84fa0 Fix RefreshGuard bootstrap scope crash with safe context-backed logging/storage access.
- 00ff7a0 Fix refresh guard startup order crash in runFleet.
- 94c18b8 Add core page refresh confirmation controls and extension reload guard.

## Stats
- 3 files changed, 264 insertions(+), 13 deletions(-)
- `archetypes.json`: 8 changes
- `fleet.user.js`: 163 changes
- `plugins/core/main/settings-ui.js`: 106 changes
