### PR TITLE
Disable remote extension plugins

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,8 +1,8 @@
 {
   "version": "7.1.3",
-  "coreOnlyMode": false,
+  "coreOnlyMode": true,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.110",
+  "archetypesVersion": "6.111",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [update-remote-disable] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-remote-disable/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-remote-disable/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'update-remote-disable',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [update-remote-disable] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-remote-disable/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-remote-disable/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'update-remote-disable',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',


### PR DESCRIPTION
## Summary
Disable remote extension plugins by enabling core-only mode in archetype configuration and align branch config state for `main`.

## Changes
- Enabled `coreOnlyMode` in `archetypes.json` so extension plugins are disabled by default for this branch state.
- Bumped `archetypesVersion` from `6.110` to `6.111` to reflect the archetype config update.
- Included branch-config synchronization commit to keep `fleet.user.js` branch settings aligned with main-target behavior.

## Commit history
- a148af3 Remote disable extension plugins
- 0676f8a Sync fleet.user.js branch config to main

## Stats
- 1 file changed, 2 insertions(+), 2 deletions(-)
- `archetypes.json`: toggled `coreOnlyMode` and incremented `archetypesVersion`
