### PR TITLE
Document Brass, Medora, and StackLine environment codenames

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.114",
+  "archetypesVersion": "6.115",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -33,7 +33,7 @@
   "settingsModalDocs": [
     {
       "name": "information-tab.md",
-      "version": "1.9"
+      "version": "1.10"
     },
     {
       "name": "features-tab.md",

--- a/docs/settings-modal/information-tab.md
+++ b/docs/settings-modal/information-tab.md
@@ -1,4 +1,4 @@
-1.9
+1.10
 ## Information
 -> Pro-tip: Use `Ctrl`/`CMD` + `F` to search for names in this table. If you can't find one, please use the `Feedback` tab to notify me!
 #### Environment Codennames
@@ -8,6 +8,7 @@
 | Aisle                     | Walmart                |
 | Atlas                     | Google Maps            |
 | Bay                       | Amazon                 |
+| Brass                     | Bill                   |
 | Chorus                    | Teams                  |
 | Crate                     | Instacart              |
 | Docket                    | Dropbox                |
@@ -21,6 +22,7 @@
 | Ledger                    | Quickbooks             |
 | LedgerGov                 | DMV                    |
 | Lumen                     | Datadog                |
+| Medora                    | Zocdoc                 |
 | Nest                      | Zillow                 |
 | Orbit                     | PandaDoc               |
 | Portal                    | Ticketmaster           |
@@ -28,6 +30,7 @@
 | Seal                      | Docusign               |
 | Sentinel                  | Vanta                  |
 | Signal                    | Sentry                 |
+| StackLine                 | StackOverflow          |
 | Torch                     | PagerDuty              |
 | Vault                     | Confluence             |
 | Ward                      | Synk                   |

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [update-codenames] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-codenames/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-codenames/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'update-codenames',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [update-codenames] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-codenames/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/update-codenames/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'update-codenames',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',


### PR DESCRIPTION
## Summary

Extends the settings Information tab environment codename table with three mappings (Brass → Bill, Medora → Zocdoc, StackLine → StackOverflow) and bumps the bundled documentation version so the modal stays in sync with `archetypes.json`.

## Changes

- **`docs/settings-modal/information-tab.md`**: Add three rows in codename order; bump embedded doc version from 1.9 to 1.10.
- **`archetypes.json`**: Raise `settingsModalDocs` entry for `information-tab.md` to 1.10 and bump `archetypesVersion` accordingly.

## Commit history

- `1b9068e` docs(settings-modal): add Brass, Medora, Stack-line codenames

## Stats

```
 archetypes.json                        | 4 ++--
 docs/settings-modal/information-tab.md | 5 ++++-
 2 files changed, 6 insertions(+), 3 deletions(-)
```
