### PR TITLE
Consolidate dispute resolution actions into confirm dropdown

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.116",
+  "archetypesVersion": "6.117",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -524,8 +524,8 @@
         },
         {
           "name": "dispute-resolution-action-menu.js",
-          "version": "1.0",
-          "hash": "sha256-02b28f69bda9d5c4216a7f8fbca8653ef7b109241ae339f323f322dac3d3f2ff",
+          "version": "1.1",
+          "hash": "sha256-415e6112e054fbdc553ad7b099ec554bbf5413c3892ef287e52be49288097a49",
           "log": false
         },
         {
@@ -536,8 +536,8 @@
         },
         {
           "name": "dispute-resolution-widgets-toggle.js",
-          "version": "2.0",
-          "hash": "sha256-a6cab015e8efca7d041130598d2c551b55ee1a733e0a6eb1810cb01bd2fe96bb",
+          "version": "2.1",
+          "hash": "sha256-47a8d08b3a34573a466f320f10253512207e88f99b2f64506c17b941b4a6e357",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.118",
+  "archetypesVersion": "6.119",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -524,8 +524,8 @@
         },
         {
           "name": "dispute-resolution-action-menu.js",
-          "version": "1.1",
-          "hash": "sha256-415e6112e054fbdc553ad7b099ec554bbf5413c3892ef287e52be49288097a49",
+          "version": "1.2",
+          "hash": "sha256-acafb0c177c84f96585c5f1a51835b5686cf601a9b93fb16620a5be3791a7d8c",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.117",
+  "archetypesVersion": "6.118",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -536,8 +536,8 @@
         },
         {
           "name": "dispute-resolution-widgets-toggle.js",
-          "version": "2.1",
-          "hash": "sha256-47a8d08b3a34573a466f320f10253512207e88f99b2f64506c17b941b4a6e357",
+          "version": "2.2",
+          "hash": "sha256-0d927f8a6c4c211281f12a985fbafcaf719fe49a6cbb166f4f88f16e9c656cc6",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.3",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.115",
+  "archetypesVersion": "6.116",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -523,9 +523,9 @@
           "log": false
         },
         {
-          "name": "dispute-content-layout-fixes.js",
-          "version": "1.3",
-          "hash": "sha256-a0c38cbd2566727127c4797261296ffc300023315af4010a6480ebfeeee1f40d",
+          "name": "dispute-resolution-action-menu.js",
+          "version": "1.0",
+          "hash": "sha256-02b28f69bda9d5c4216a7f8fbca8653ef7b109241ae339f323f322dac3d3f2ff",
           "log": false
         },
         {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-consolidate-dispute-resolution-buttons] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-consolidate-dispute-resolution-buttons/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-consolidate-dispute-resolution-buttons/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-consolidate-dispute-resolution-buttons',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-consolidate-dispute-resolution-buttons] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-consolidate-dispute-resolution-buttons/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-consolidate-dispute-resolution-buttons/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-consolidate-dispute-resolution-buttons',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/deprecated/dispute-content-layout-fixes.js
+++ b/plugins/archetypes/dispute-detail/deprecated/dispute-content-layout-fixes.js
@@ -1,5 +1,7 @@
-// ============= dispute-content-layout-fixes.js =============
-// Targeted layout fixes for dispute detail text blocks and action buttons.
+// ============= dispute-content-layout-fixes.js (deprecated) =============
+// Deprecated: superseded by dispute-resolution-action-menu.js, which keeps the
+// non–action-bar layout rules in its stylesheet and replaces the action button
+// row with a dropdown + Confirm control.
 
 const STYLE_ID = 'fleet-dispute-detail-layout-fixes-style';
 

--- a/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
@@ -1,0 +1,235 @@
+// ============= dispute-resolution-action-menu.js =============
+// Collapses native dispute resolution buttons into a select + Confirm control,
+// and triggers the real button on confirm. Native buttons stay in the DOM
+// (visually hidden) so page handlers keep working.
+
+const STYLE_ID = 'fleet-dispute-resolution-action-menu-style';
+const MENU_ROOT_ATTR = 'data-fleet-dispute-action-menu';
+const MENU_CONTROL_ATTR = 'data-fleet-dispute-menu-control';
+const ROW_CLASS = 'fleet-dispute-action-row--menu';
+
+const plugin = {
+    id: 'disputeResolutionActionMenu',
+    name: 'Dispute Resolution Action Menu',
+    description:
+        'Replaces the row of dispute resolution buttons with a dropdown and Confirm Action control; triggers the underlying native button',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleReady: false,
+        missingPanelLogged: false,
+        missingRowLogged: false,
+        injectedLogged: false
+    },
+
+    onMutation(state) {
+        this.ensureStyles(state);
+        const panel = this.findResolutionPanel();
+        if (!panel) {
+            if (!state.missingPanelLogged) {
+                Logger.debug('Dispute Resolution Action Menu: resolution panel not found');
+                state.missingPanelLogged = true;
+            }
+            return;
+        }
+        state.missingPanelLogged = false;
+
+        const row = this.findActionButtonRow(panel);
+        if (!row) {
+            if (!state.missingRowLogged) {
+                Logger.debug('Dispute Resolution Action Menu: action button row not found');
+                state.missingRowLogged = true;
+            }
+            return;
+        }
+        state.missingRowLogged = false;
+
+        const natives = this.getNativeActionButtons(row);
+        if (!natives.length) {
+            return;
+        }
+
+        row.classList.add(ROW_CLASS);
+        const sig = this.signatureForButtons(natives);
+        let wrapper = row.querySelector(`[${MENU_ROOT_ATTR}]`);
+        if (!wrapper) {
+            wrapper = this.buildMenuWrapper(row, natives, sig);
+            row.appendChild(wrapper);
+            if (!state.injectedLogged) {
+                Logger.log('Dispute Resolution Action Menu: dropdown and confirm control added');
+                state.injectedLogged = true;
+            }
+        } else if (wrapper.dataset.fleetActionSig !== sig) {
+            const select = wrapper.querySelector('select');
+            const confirmBtn = wrapper.querySelector(`button[${MENU_CONTROL_ATTR}]`);
+            this.populateSelect(select, natives);
+            if (select) select.value = '';
+            if (confirmBtn) confirmBtn.disabled = true;
+            wrapper.dataset.fleetActionSig = sig;
+            Logger.log('Dispute Resolution Action Menu: action list refreshed');
+        }
+    },
+
+    signatureForButtons(buttons) {
+        return buttons
+            .map(b => (b.textContent || '').trim().replace(/\s+/g, ' '))
+            .join('\0');
+    },
+
+    getNativeActionButtons(row) {
+        return Array.from(row.querySelectorAll(':scope > button')).filter(
+            b => !b.hasAttribute(MENU_CONTROL_ATTR)
+        );
+    },
+
+    findResolutionPanel() {
+        const candidates = document.querySelectorAll('.border-t.pt-4');
+        for (const el of candidates) {
+            if (this.findActionButtonRow(el)) return el;
+        }
+        return null;
+    },
+
+    findActionButtonRow(panel) {
+        const rows = panel.querySelectorAll(':scope > .flex.items-center.justify-end.gap-2.mt-4');
+        for (const row of rows) {
+            const text = (row.textContent || '').trim();
+            if (
+                text.includes('Approve') ||
+                text.includes('Reject Dispute') ||
+                text.includes('Flag as Bug')
+            ) {
+                return row;
+            }
+        }
+        return null;
+    },
+
+    ensureStyles(state) {
+        if (state.styleReady && document.getElementById(STYLE_ID)) return;
+        let style = document.getElementById(STYLE_ID);
+        if (!style) {
+            style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.setAttribute('data-fleet-plugin', this.id);
+            document.head.appendChild(style);
+        }
+        style.textContent = `
+/* Merged from deprecated dispute-content-layout-fixes (minus action-bar flex rules) */
+.p-4 > .flex.items-center.justify-between.mb-2 {
+    flex-wrap: wrap !important;
+    gap: 0.5rem !important;
+    min-width: 0 !important;
+}
+.p-4 > .flex.items-center.justify-between.mb-2 > .flex.items-center.gap-2 {
+    flex-wrap: wrap !important;
+    min-width: 0 !important;
+}
+[data-state="open"] .rounded-lg.border.bg-muted\\/50 .space-y-2.text-sm > p,
+[data-state="open"] .rounded-lg.border.bg-muted\\/50 .space-y-2.text-sm > div {
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere !important;
+    word-break: break-word !important;
+}
+.border-t.pt-4 {
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+    background: var(--background, inherit);
+}
+/* Visually hide native actions; programmatic .click() still works */
+.${ROW_CLASS} > button:not([${MENU_CONTROL_ATTR}]) {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+.${ROW_CLASS} {
+    position: relative !important;
+    flex-wrap: wrap !important;
+    gap: 0.5rem !important;
+    min-width: 0 !important;
+}
+`;
+        state.styleReady = true;
+        Logger.debug('Dispute Resolution Action Menu: layout and hide styles applied');
+    },
+
+    populateSelect(select, nativeButtons) {
+        if (!select) return;
+        select.replaceChildren();
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Choose an action…';
+        placeholder.disabled = true;
+        placeholder.selected = true;
+        select.appendChild(placeholder);
+        nativeButtons.forEach((btn, i) => {
+            const opt = document.createElement('option');
+            opt.value = String(i);
+            opt.textContent = (btn.textContent || '').trim().replace(/\s+/g, ' ');
+            select.appendChild(opt);
+        });
+    },
+
+    buildMenuWrapper(row, natives, sig) {
+        const wrap = document.createElement('div');
+        wrap.setAttribute(MENU_ROOT_ATTR, '1');
+        wrap.setAttribute('data-fleet-plugin', this.id);
+        wrap.className = 'flex flex-wrap gap-2 items-center';
+        wrap.dataset.fleetActionSig = sig;
+
+        const select = document.createElement('select');
+        select.setAttribute('aria-label', 'Dispute resolution action');
+        select.className =
+            'h-9 min-w-[12rem] rounded-sm border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+
+        this.populateSelect(select, natives);
+
+        const confirmClass =
+            'inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-9 px-4';
+
+        const confirmBtn = document.createElement('button');
+        confirmBtn.type = 'button';
+        confirmBtn.setAttribute(MENU_CONTROL_ATTR, '1');
+        confirmBtn.setAttribute('data-fleet-plugin', this.id);
+        confirmBtn.className = confirmClass;
+        confirmBtn.textContent = 'Confirm Action';
+        confirmBtn.disabled = true;
+
+        select.addEventListener('change', () => {
+            confirmBtn.disabled = select.value === '';
+        });
+        confirmBtn.addEventListener('click', () => this.handleConfirm(row, select, confirmBtn));
+
+        wrap.appendChild(select);
+        wrap.appendChild(confirmBtn);
+        return wrap;
+    },
+
+    handleConfirm(row, select, confirmBtn) {
+        const idx = parseInt(select.value, 10);
+        const natives = this.getNativeActionButtons(row);
+        if (
+            select.value === '' ||
+            Number.isNaN(idx) ||
+            idx < 0 ||
+            idx >= natives.length
+        ) {
+            Logger.warn('Dispute Resolution Action Menu: confirm ignored (no valid selection)');
+            return;
+        }
+        const label = (natives[idx].textContent || '').trim().replace(/\s+/g, ' ');
+        Logger.log(`Dispute Resolution Action Menu: triggering native action "${label}"`);
+        natives[idx].click();
+        select.value = '';
+        confirmBtn.disabled = true;
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
@@ -7,13 +7,22 @@ const STYLE_ID = 'fleet-dispute-resolution-action-menu-style';
 const MENU_ROOT_ATTR = 'data-fleet-dispute-action-menu';
 const MENU_CONTROL_ATTR = 'data-fleet-dispute-menu-control';
 const ROW_CLASS = 'fleet-dispute-action-row--menu';
+const SELECT_CLASS_HOOK = 'fleet-dispute-action-select';
+
+/** Baseline when no action is chosen (not merged with button classes). */
+const SELECT_NEUTRAL_CLASSES = [
+    'h-9 min-w-[12rem] rounded-sm border border-input bg-background px-3 py-1',
+    'text-sm text-foreground ring-offset-background',
+    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+    SELECT_CLASS_HOOK
+].join(' ');
 
 const plugin = {
     id: 'disputeResolutionActionMenu',
     name: 'Dispute Resolution Action Menu',
     description:
         'Replaces the row of dispute resolution buttons with a dropdown and Confirm Action control; triggers the underlying native button',
-    _version: '1.1',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -66,6 +75,7 @@ const plugin = {
             this.populateSelect(select, natives);
             if (select) select.value = '';
             if (confirmBtn) confirmBtn.disabled = true;
+            this.syncSelectVisualFromNative(select, null);
             wrapper.dataset.fleetActionSig = sig;
             Logger.log('Dispute Resolution Action Menu: action list refreshed');
         }
@@ -158,6 +168,18 @@ const plugin = {
     gap: 0.5rem !important;
     min-width: 0 !important;
 }
+select.${SELECT_CLASS_HOOK} {
+    appearance: none !important;
+    cursor: pointer !important;
+    padding-right: 2rem !important;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat !important;
+    background-position: right 0.4rem center !important;
+    background-size: 1rem !important;
+}
+.dark select.${SELECT_CLASS_HOOK} {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") !important;
+}
 `;
         state.styleReady = true;
         Logger.debug('Dispute Resolution Action Menu: layout and hide styles applied');
@@ -180,6 +202,39 @@ const plugin = {
         });
     },
 
+    /**
+     * Button classes that do not apply sensibly to a &lt;select&gt; (layout with icons, etc.).
+     */
+    mirroredClassTokensFromButton(button) {
+        const raw = (button && button.getAttribute('class')) || '';
+        const drop = new Set([
+            'inline-flex',
+            'items-center',
+            'justify-center',
+            'whitespace-nowrap',
+            'mr-auto',
+            'ml-auto',
+            'flex',
+            'shrink-0',
+            'grow'
+        ]);
+        return raw.split(/\s+/).filter(t => {
+            if (!t || drop.has(t)) return false;
+            if (t.startsWith('disabled:')) return false;
+            return true;
+        });
+    },
+
+    syncSelectVisualFromNative(select, nativeButton) {
+        if (!select) return;
+        if (!nativeButton) {
+            select.className = SELECT_NEUTRAL_CLASSES;
+            return;
+        }
+        const tokens = this.mirroredClassTokensFromButton(nativeButton);
+        select.className = [...tokens, SELECT_CLASS_HOOK].join(' ');
+    },
+
     buildMenuWrapper(row, natives, sig) {
         const wrap = document.createElement('div');
         wrap.setAttribute(MENU_ROOT_ATTR, '1');
@@ -189,8 +244,7 @@ const plugin = {
 
         const select = document.createElement('select');
         select.setAttribute('aria-label', 'Dispute resolution action');
-        select.className =
-            'h-9 min-w-[12rem] rounded-sm border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+        this.syncSelectVisualFromNative(select, null);
 
         this.populateSelect(select, natives);
 
@@ -207,6 +261,11 @@ const plugin = {
 
         select.addEventListener('change', () => {
             confirmBtn.disabled = select.value === '';
+            const nativesNow = this.getNativeActionButtons(row);
+            const idx = select.value === '' ? -1 : parseInt(select.value, 10);
+            const native =
+                idx >= 0 && idx < nativesNow.length ? nativesNow[idx] : null;
+            this.syncSelectVisualFromNative(select, native);
         });
         confirmBtn.addEventListener('click', () => this.handleConfirm(row, select, confirmBtn));
 
@@ -232,5 +291,6 @@ const plugin = {
         natives[idx].click();
         select.value = '';
         confirmBtn.disabled = true;
+        this.syncSelectVisualFromNative(select, null);
     }
 };

--- a/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
@@ -13,7 +13,7 @@ const plugin = {
     name: 'Dispute Resolution Action Menu',
     description:
         'Replaces the row of dispute resolution buttons with a dropdown and Confirm Action control; triggers the underlying native button',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -92,7 +92,8 @@ const plugin = {
     },
 
     findActionButtonRow(panel) {
-        const rows = panel.querySelectorAll(':scope > .flex.items-center.justify-end.gap-2.mt-4');
+        // Row may be nested under collapsible content (not a direct child of .border-t.pt-4)
+        const rows = panel.querySelectorAll(':scope .flex.items-center.justify-end.gap-2.mt-4');
         for (const row of rows) {
             const text = (row.textContent || '').trim();
             if (

--- a/plugins/archetypes/dispute-detail/main/dispute-resolution-widgets-toggle.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-resolution-widgets-toggle.js
@@ -1,8 +1,8 @@
 // ============= dispute-resolution-widgets-toggle.js =============
 // Same behavior as guideline-buttons.js corner-widget hiding: CSS-only
 // (visibility + pointer-events) for Pylon chat + Report-a-bug FAB.
-// Default hidden. Toggle button is placed in the dispute resolution panel
-// before the action buttons row.
+// Default hidden. Toggle lives in the main top bar (right cluster next to nav tabs),
+// not in the dispute resolution sidebar.
 
 const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
 const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
@@ -12,7 +12,7 @@ const CORNER_WIDGETS_SUBOPTION = {
     id: CORNER_WIDGETS_SUBOPTION_ID,
     name: 'Show/Hide Widgets button',
     description:
-        'When enabled, adds a button in the resolution section that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
+        'When enabled, adds a button in the top bar that toggles visibility (CSS only) of the Pylon support chat bubble and the Report a bug floating action button in the bottom-right. Hidden by default to reduce clutter.',
     enabledByDefault: true
 };
 
@@ -20,8 +20,8 @@ const plugin = {
     id: 'disputeResolutionWidgetsToggle',
     name: 'Dispute Resolution Widgets Toggle',
     description:
-        'Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; hidden by default',
-    _version: '2.1',
+        'Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar',
+    _version: '2.2',
     enabledByDefault: true,
     phase: 'mutation',
     subOptions: [CORNER_WIDGETS_SUBOPTION],
@@ -36,46 +36,28 @@ const plugin = {
         this.ensureCornerWidgetsStyle(state);
         this.applyCornerWidgetsClassFromStorage();
 
-        const panel = this.findResolutionPanel();
-        if (!panel) {
+        const slot = this.findTopBarActionsContainer();
+        if (!slot) {
             if (!state.missingLogged) {
-                Logger.debug('Dispute Resolution Widgets Toggle: resolution panel not found');
+                Logger.debug('Dispute Resolution Widgets Toggle: top bar actions container not found');
                 state.missingLogged = true;
             }
             return;
         }
         state.missingLogged = false;
 
-        const buttonRow = this.findActionButtonRow(panel);
-        if (!buttonRow) {
-            if (!state.missingLogged) {
-                Logger.debug('Dispute Resolution Widgets Toggle: action button row not found');
-                state.missingLogged = true;
-            }
-            return;
-        }
-
-        this.ensureToggleWrapper(panel, buttonRow, state);
+        this.ensureToggleWrapper(slot, state);
     },
 
-    findResolutionPanel() {
-        const candidates = document.querySelectorAll('.border-t.pt-4');
-        for (const el of candidates) {
-            if (this.findActionButtonRow(el)) return el;
-        }
-        return null;
-    },
-
-    findActionButtonRow(panel) {
-        const rows = panel.querySelectorAll(':scope .flex.items-center.justify-end.gap-2.mt-4');
+    /** Right-side cluster in the main header (next to notifications / profile). */
+    findTopBarActionsContainer() {
+        const main = document.querySelector('main');
+        if (!main) return null;
+        const rows = main.querySelectorAll('.flex.items-center.justify-between');
         for (const row of rows) {
-            const text = (row.textContent || '').trim();
-            if (
-                text.includes('Approve') ||
-                text.includes('Reject Dispute') ||
-                text.includes('Flag as Bug')
-            ) {
-                return row;
+            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
+                const right = row.querySelector(':scope > .flex.items-center.gap-1.shrink-0');
+                if (right) return right;
             }
         }
         return null;
@@ -149,39 +131,35 @@ body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4.rounded-full {
         return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
     },
 
-    ensureToggleWrapper(panel, buttonRow, state) {
+    ensureToggleWrapper(slot, state) {
         const buttonClass =
             'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
 
-        const toggleBtnExisting = panel.querySelector(
-            `button[data-fleet-corner-widgets-toggle="${this.id}"]`
-        );
-
         if (!Storage.getSubOptionEnabled(this.id, CORNER_WIDGETS_SUBOPTION_ID, true)) {
-            const wrapper = panel.querySelector(`div[data-fleet-plugin="${this.id}"]`);
+            const wrapper = document.querySelector(`div[data-fleet-plugin="${this.id}"]`);
             if (wrapper) {
                 wrapper.remove();
                 Logger.log(
                     'Dispute Resolution Widgets Toggle: toggle wrapper removed (subOption disabled)'
                 );
             }
-            if (toggleBtnExisting && toggleBtnExisting.closest(`div[data-fleet-plugin="${this.id}"]`) === null) {
-                toggleBtnExisting.remove();
-            }
             this.setCornerWidgetsHidden(false, false);
             return;
         }
 
-        let wrapper = panel.querySelector(`div[data-fleet-plugin="${this.id}"]`);
+        let wrapper = document.querySelector(`div[data-fleet-plugin="${this.id}"]`);
+        if (wrapper && wrapper.parentElement !== slot) {
+            wrapper.remove();
+            wrapper = null;
+        }
+
         if (!wrapper) {
             wrapper = document.createElement('div');
             wrapper.setAttribute('data-fleet-plugin', this.id);
-            wrapper.className = 'flex flex-wrap gap-1 items-center justify-end mt-3 mb-1';
-            panel.insertBefore(wrapper, buttonRow);
+            wrapper.className = 'flex flex-wrap gap-1 items-center shrink-0 mr-1';
+            slot.insertBefore(wrapper, slot.firstChild);
             if (!state.toggleLogged) {
-                Logger.log(
-                    'Dispute Resolution Widgets Toggle: toggle wrapper added before action buttons'
-                );
+                Logger.log('Dispute Resolution Widgets Toggle: toggle added to top bar');
                 state.toggleLogged = true;
             }
         }

--- a/plugins/archetypes/dispute-detail/main/dispute-resolution-widgets-toggle.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-resolution-widgets-toggle.js
@@ -21,7 +21,7 @@ const plugin = {
     name: 'Dispute Resolution Widgets Toggle',
     description:
         'Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; hidden by default',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
     subOptions: [CORNER_WIDGETS_SUBOPTION],
@@ -67,7 +67,7 @@ const plugin = {
     },
 
     findActionButtonRow(panel) {
-        const rows = panel.querySelectorAll(':scope > .flex.items-center.justify-end.gap-2.mt-4');
+        const rows = panel.querySelectorAll(':scope .flex.items-center.justify-end.gap-2.mt-4');
         for (const row of rows) {
             const text = (row.textContent || '').trim();
             if (


### PR DESCRIPTION
## Summary

Dispute detail resolution actions are consolidated into a **dropdown plus Confirm** flow so reviewers pick an action explicitly before firing the real control. Native buttons stay in the DOM (visually hidden) so existing handlers keep working. Layout and sticky-panel behavior from the old layout-fixes plugin are preserved inside the new module. The corner-widgets toggle was moved to the **top bar** after the DOM stopped placing the action row as a direct child of the resolution block, and the action `<select>` **mirrors each native button’s Tailwind classes** when an option is chosen.

## Changes

- Added **`dispute-resolution-action-menu`**: finds the nested action row, injects select + Confirm, resets selection after confirm, applies filtered `className` from the matching native button to the closed select (with neutral styling for “Choose an action…”), and injects a small chevron style for `appearance-none` selects.
- **Deprecated** `dispute-content-layout-fixes` from the archetype load list (copy kept under `deprecated/`) and merged the non–action-bar CSS into the action-menu stylesheet.
- **Fixed** resolution row discovery using a descendant selector so the panel is found when actions live under collapsible “Your Resolution” content.
- **Relocated** the Pylon / report-a-bug visibility toggle from the sidebar to the main header’s right actions cluster to avoid invalid `insertBefore` when the button row is no longer a direct child of `.border-t.pt-4`.
- **`archetypes.json`**: new plugin entry, removed old one, version/hash and `archetypesVersion` updates through the normal scripts.

## New / updated plugins (dispute-detail)

| Plugin | Version | Notes |
|--------|---------|--------|
| `dispute-resolution-action-menu.js` | 1.2 | New: dropdown + confirm, mirrored button styling, merged layout CSS |
| `dispute-resolution-widgets-toggle.js` | 2.2 | Toggle UI moved to top bar |
| `dispute-content-layout-fixes.js` | — | Removed from archetype; archived under `deprecated/` |

## Commit history

- `a981a8d` feat(dispute-detail): mirror native button styles on resolution action select
- `3f2a79c` fix(dispute-detail): mount corner-widgets toggle in top bar, not resolution panel
- `832695b` fix(dispute-detail): find nested dispute action row under resolution panel
- `da03c72` feat(dispute-detail): replace action button row with confirm dropdown

## Stats

```
 archetypes.json                                    |  12 +-
 .../dispute-content-layout-fixes.js                |   6 +-
 .../main/dispute-resolution-action-menu.js         | 296 +++++++++++++++++++++
 .../main/dispute-resolution-widgets-toggle.js      |  78 ++----
 4 files changed, 334 insertions(+), 58 deletions(-)
```
