### PR TITLE
Add Session Trace Review archetype and QA-session UX plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
 - **Verifier Diff Highlight (Improved)**: Custom side-by-side diff viewer for Expected vs Your Answer in verifier output
 
+### Session Trace Review Page
+- **Session Trace Show/Hide Widgets**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar before Skip
+- **Remember Layout Proportions**: Save and restore panel split percentages (main columns, prompt vs comments in the left stack, transcript vs screenshot in the trace area)
+- **Auto-expand Verifier Output**: Expands the Verifier Output section on load by activating the score/timing header once (same as a user click)
+- **Toggle Left Panel**: Top-bar control to hide or show the left column (prompt and comments) via a body class so the trace column can use full width
+
 ### Task View
 *No production plugins are configured for this archetype.*
 

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.0",
+  "archetypesVersion": "7.1",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -401,6 +401,12 @@
           "name": "show-hide-widgets.js",
           "version": "1.0",
           "hash": "sha256-926c8bc44e3b55932f6326b3d148b18febaae9eb75ba3b72789d7b9fbb72d54c",
+          "log": false
+        },
+        {
+          "name": "remember-layout-proportions.js",
+          "version": "1.0",
+          "hash": "sha256-5a69e4876f4d3eb3118d98e72390f60539cdab45182bfbcacd757d397d00e677",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "6.125",
+  "archetypesVersion": "7.0",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -386,6 +386,21 @@
           "name": "useful-links-buttons.js",
           "version": "2.1",
           "hash": "sha256-92914ecd1790fa86c7054308c509d23e81defabfd98719f0c7b9720112339ff8",
+          "log": false
+        }
+      ]
+    },
+    {
+      "id": "qa-session",
+      "name": "Session Trace Review",
+      "description": "Page for reviewing session traces",
+      "urlPattern": "work/problems/qa-session/*",
+      "disambiguationSelectors": [],
+      "plugins": [
+        {
+          "name": "show-hide-widgets.js",
+          "version": "1.0",
+          "hash": "sha256-926c8bc44e3b55932f6326b3d148b18febaae9eb75ba3b72789d7b9fbb72d54c",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.2",
+  "archetypesVersion": "7.3",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -413,6 +413,12 @@
           "name": "auto-expand-verifier-section.js",
           "version": "1.0",
           "hash": "sha256-e4d307748eec0aef8a58f016c519550962ff5a8f950c22b4dc608c8d526ade7d",
+          "log": false
+        },
+        {
+          "name": "toggle-left-panel.js",
+          "version": "1.0",
+          "hash": "sha256-87a69e54ef701e571901f33f4d4c46bbc892a4040171760dd48e84c220d57736",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.1",
+  "archetypesVersion": "7.2",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -407,6 +407,12 @@
           "name": "remember-layout-proportions.js",
           "version": "1.0",
           "hash": "sha256-5a69e4876f4d3eb3118d98e72390f60539cdab45182bfbcacd757d397d00e677",
+          "log": false
+        },
+        {
+          "name": "auto-expand-verifier-section.js",
+          "version": "1.0",
+          "hash": "sha256-e4d307748eec0aef8a58f016c519550962ff5a8f950c22b4dc608c8d526ade7d",
           "log": false
         }
       ]

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-session-trace] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-session-trace/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-session-trace/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-session-trace',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-session-trace] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-session-trace/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-session-trace/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-session-trace',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/qa-session/main/auto-expand-verifier-section.js
+++ b/plugins/archetypes/qa-session/main/auto-expand-verifier-section.js
@@ -1,0 +1,69 @@
+// ============= auto-expand-verifier-section.js =============
+// Session Trace Review: one programmatic click on the verifier "Score" header row
+// so the collapsed details expand on load (same as a user click on that bar).
+
+const plugin = {
+    id: 'sessionTraceAutoExpandVerifier',
+    name: 'Auto-expand verifier output section',
+    description:
+        'Clicks the Verifier Output score/timing header once per page so expanded content is shown',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        lastPath: null,
+        didExpand: false,
+        missingLogged: false
+    },
+
+    onMutation(state) {
+        const path = typeof location !== 'undefined' ? location.pathname : '';
+        if (state.lastPath !== path) {
+            state.lastPath = path;
+            state.didExpand = false;
+            state.missingLogged = false;
+        }
+
+        if (state.didExpand) return;
+
+        const row = this.findVerifierScoreHeaderRow();
+        if (!row) {
+            if (!state.missingLogged) {
+                Logger.debug('Session Trace Auto-expand Verifier: score header row not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        row.click();
+        state.didExpand = true;
+        Logger.log('Session Trace Auto-expand Verifier: clicked score header to expand details');
+    },
+
+    /** Row under Verifier Output with "Score:" — matches Session Trace DOM. */
+    findVerifierScoreHeaderRow() {
+        const headers = document.querySelectorAll(
+            'div.text-sm.text-muted-foreground.font-medium'
+        );
+        let voSection = null;
+        for (const h of headers) {
+            if (h.textContent.trim() === 'Verifier Output') {
+                voSection = h.closest('.px-3') || h.parentElement;
+                break;
+            }
+        }
+        if (!voSection) return null;
+
+        const candidates = voSection.querySelectorAll(
+            'div.flex.items-center.justify-between.text-sm.cursor-pointer.select-none'
+        );
+        for (const el of candidates) {
+            if (el.querySelector('span.text-muted-foreground')?.textContent?.trim() === 'Score:') {
+                return el;
+            }
+        }
+        return null;
+    }
+};

--- a/plugins/archetypes/qa-session/main/remember-layout-proportions.js
+++ b/plugins/archetypes/qa-session/main/remember-layout-proportions.js
@@ -1,0 +1,305 @@
+// ============= remember-layout-proportions.js =============
+// Persists react-resizable panel splits on Session Trace Review (qa-session).
+// Three groups when Split + trace inner chrome is present:
+// - Main row: task stack (left) vs session trace (right)
+// - Left column: prompt/verifier vs comments
+// - Trace area: transcript vs screenshot column
+//
+// Uses MutationObserver on [data-panel-size] only; debounced saves (no polling loops).
+
+const SUM_TOLERANCE = 5;
+const SAVE_DEBOUNCE_MS = 500;
+
+const plugin = {
+    id: 'sessionTraceLayoutProportions',
+    name: 'Remember Layout Proportions',
+    description:
+        'Save and restore panel split percentages for Session Trace Review (main, left stack, trace transcript vs screenshot)',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        watchSignature: null,
+        panelObservers: [],
+        saveTimeoutId: null,
+        restoredMain: false,
+        restoredInner: false,
+        restoredTrace: false,
+        missingLogged: false
+    },
+
+    storageKey() {
+        return `plugin-${this.id}-layout-snapshot`;
+    },
+
+    getSnapshot() {
+        const raw = Storage.get(this.storageKey(), null);
+        if (raw == null) return null;
+        if (typeof raw === 'string') {
+            try {
+                return JSON.parse(raw);
+            } catch (e) {
+                Logger.error('Session Trace Layout: failed to parse snapshot', e);
+                return null;
+            }
+        }
+        return typeof raw === 'object' ? raw : null;
+    },
+
+    setSnapshot(obj) {
+        Storage.set(this.storageKey(), JSON.stringify(obj));
+    },
+
+    onMutation(state) {
+        const outer = this.findOuterHorizontalGroup();
+        if (!outer) {
+            if (!state.missingLogged) {
+                Logger.debug('Session Trace Layout: outer panel group not found');
+                state.missingLogged = true;
+            }
+            this.teardownWatchers(state);
+            return;
+        }
+        state.missingLogged = false;
+
+        const layout = this.resolveLayout(outer);
+        if (!layout) {
+            Logger.debug('Session Trace Layout: layout panels not ready');
+            return;
+        }
+
+        this.ensureWatchers(layout, state);
+        this.tryRestore(layout, state);
+    },
+
+    findOuterHorizontalGroup() {
+        const close = document.querySelector('a[href="/work/problems/qa-sessions"]');
+        if (!close) return null;
+        const header = close.closest('.flex-shrink-0.h-12');
+        if (!header || !header.parentElement) return null;
+        for (const child of header.parentElement.children) {
+            if (
+                child.matches?.('[data-panel-group][data-panel-group-direction="horizontal"]')
+            ) {
+                return child;
+            }
+        }
+        return null;
+    },
+
+    getPanelChildren(groupEl) {
+        return Array.from(groupEl.children).filter(el =>
+            el.matches?.('[data-panel][data-panel-id]')
+        );
+    },
+
+    findTraceSplitGroup(outerRight) {
+        const groups = outerRight.querySelectorAll(
+            '[data-panel-group-direction="horizontal"][data-panel-group]'
+        );
+        for (const g of groups) {
+            if (g.querySelector('[data-messages-list="true"]')) return g;
+        }
+        return null;
+    },
+
+    resolveLayout(outer) {
+        const outerPanels = this.getPanelChildren(outer);
+        if (outerPanels.length !== 2) return null;
+        const [outerLeft, outerRight] = outerPanels;
+
+        const innerGroup = outerLeft.querySelector(
+            ':scope [data-panel-group-direction="vertical"][data-panel-group]'
+        );
+        if (!innerGroup) return null;
+        const innerPanels = this.getPanelChildren(innerGroup);
+        if (innerPanels.length !== 2) return null;
+
+        const traceGroup = this.findTraceSplitGroup(outerRight);
+        let traceLeft = null;
+        let traceRight = null;
+        if (traceGroup) {
+            const tp = this.getPanelChildren(traceGroup);
+            if (tp.length === 2) {
+                traceLeft = tp[0];
+                traceRight = tp[1];
+            }
+        }
+
+        return {
+            outerLeft,
+            outerRight,
+            innerTop: innerPanels[0],
+            innerBottom: innerPanels[1],
+            traceLeft,
+            traceRight
+        };
+    },
+
+    tryRestore(layout, state) {
+        const snap = this.getSnapshot();
+        if (!snap) return;
+
+        if (!state.restoredMain) {
+            const a = snap.outerLeft;
+            const b = snap.outerRight;
+            if (
+                this.isPairValid(a, b) &&
+                this.readSize(layout.outerLeft) != null &&
+                this.readSize(layout.outerRight) != null
+            ) {
+                this.applyPair(layout.outerLeft, layout.outerRight, a, b);
+                state.restoredMain = true;
+                Logger.log(`Session Trace Layout: restored main split ${a} / ${b}`);
+            }
+        }
+
+        if (!state.restoredInner) {
+            const a = snap.innerTop;
+            const b = snap.innerBottom;
+            if (
+                this.isPairValid(a, b) &&
+                this.readSize(layout.innerTop) != null &&
+                this.readSize(layout.innerBottom) != null
+            ) {
+                this.applyPair(layout.innerTop, layout.innerBottom, a, b);
+                state.restoredInner = true;
+                Logger.log(`Session Trace Layout: restored left stack split ${a} / ${b}`);
+            }
+        }
+
+        if (layout.traceLeft && layout.traceRight && !state.restoredTrace) {
+            const a = snap.traceLeft;
+            const b = snap.traceRight;
+            if (
+                this.isPairValid(a, b) &&
+                this.readSize(layout.traceLeft) != null &&
+                this.readSize(layout.traceRight) != null
+            ) {
+                this.applyPair(layout.traceLeft, layout.traceRight, a, b);
+                state.restoredTrace = true;
+                Logger.log(`Session Trace Layout: restored trace split ${a} / ${b}`);
+            }
+        }
+    },
+
+    isPairValid(a, b) {
+        if (a == null || b == null) return false;
+        if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
+        return Math.abs(a + b - 100) <= SUM_TOLERANCE;
+    },
+
+    applyPair(elA, elB, sizeA, sizeB) {
+        elA.style.flex = `${sizeA} 1 0px`;
+        elA.setAttribute('data-panel-size', String(sizeA));
+        elB.style.flex = `${sizeB} 1 0px`;
+        elB.setAttribute('data-panel-size', String(sizeB));
+    },
+
+    readSize(panelEl) {
+        if (!panelEl) return null;
+        const attr = panelEl.getAttribute('data-panel-size');
+        if (attr == null || attr === '') return null;
+        const parsed = parseFloat(attr);
+        return Number.isFinite(parsed) ? parsed : null;
+    },
+
+    ensureWatchers(layout, state) {
+        const panels = [
+            layout.outerLeft,
+            layout.outerRight,
+            layout.innerTop,
+            layout.innerBottom
+        ];
+        if (layout.traceLeft && layout.traceRight) {
+            panels.push(layout.traceLeft, layout.traceRight);
+        }
+
+        const sig = panels.map(p => p.getAttribute('data-panel-id')).join(',');
+        if (state.watchSignature === sig) return;
+
+        this.teardownWatchers(state);
+        state.watchSignature = sig;
+        state.restoredMain = false;
+        state.restoredInner = false;
+        state.restoredTrace = false;
+
+        for (const p of panels) {
+            const obs = new MutationObserver(() => this.scheduleSave(state));
+            CleanupRegistry.registerObserver(obs);
+            obs.observe(p, {
+                attributes: true,
+                attributeFilter: ['data-panel-size']
+            });
+            state.panelObservers.push(obs);
+        }
+        Logger.log('Session Trace Layout: observing panel size changes');
+    },
+
+    teardownWatchers(state) {
+        for (const o of state.panelObservers) {
+            o.disconnect();
+        }
+        state.panelObservers = [];
+        state.watchSignature = null;
+        if (state.saveTimeoutId != null) {
+            clearTimeout(state.saveTimeoutId);
+            state.saveTimeoutId = null;
+        }
+        state.restoredMain = false;
+        state.restoredInner = false;
+        state.restoredTrace = false;
+    },
+
+    scheduleSave(state) {
+        if (state.saveTimeoutId != null) {
+            clearTimeout(state.saveTimeoutId);
+            state.saveTimeoutId = null;
+        }
+        state.saveTimeoutId = CleanupRegistry.registerTimeout(
+            setTimeout(() => {
+                state.saveTimeoutId = null;
+                const outer = this.findOuterHorizontalGroup();
+                if (!outer) return;
+                const layout = this.resolveLayout(outer);
+                if (!layout) return;
+                this.persistLayout(layout);
+            }, SAVE_DEBOUNCE_MS)
+        );
+    },
+
+    persistLayout(layout) {
+        const snap = {
+            outerLeft: this.readSize(layout.outerLeft),
+            outerRight: this.readSize(layout.outerRight),
+            innerTop: this.readSize(layout.innerTop),
+            innerBottom: this.readSize(layout.innerBottom)
+        };
+        if (
+            !this.isPairValid(snap.outerLeft, snap.outerRight) ||
+            !this.isPairValid(snap.innerTop, snap.innerBottom)
+        ) {
+            Logger.debug('Session Trace Layout: skip save (invalid main or inner pair)');
+            return;
+        }
+
+        if (layout.traceLeft && layout.traceRight) {
+            const tL = this.readSize(layout.traceLeft);
+            const tR = this.readSize(layout.traceRight);
+            if (this.isPairValid(tL, tR)) {
+                snap.traceLeft = tL;
+                snap.traceRight = tR;
+            }
+        }
+
+        this.setSnapshot(snap);
+        const tail =
+            snap.traceLeft != null && snap.traceRight != null
+                ? ` trace ${snap.traceLeft}/${snap.traceRight}`
+                : '';
+        Logger.log(
+            `Session Trace Layout: saved outer ${snap.outerLeft}/${snap.outerRight} inner ${snap.innerTop}/${snap.innerBottom}${tail}`
+        );
+    }
+};

--- a/plugins/archetypes/qa-session/main/show-hide-widgets.js
+++ b/plugins/archetypes/qa-session/main/show-hide-widgets.js
@@ -1,0 +1,144 @@
+// ============= show-hide-widgets.js =============
+// CSS-only toggle for Pylon chat + Report-a-bug FAB (visibility + pointer-events).
+// Default hidden. Button sits in the top menu bar, preceding the Skip button.
+
+const CORNER_WIDGETS_BODY_CLASS = 'fleet-hide-corner-widgets';
+const CORNER_WIDGETS_STORAGE_KEY = 'corner-widgets-hidden';
+
+const plugin = {
+    id: 'sessionTraceShowHideWidgets',
+    name: 'Session Trace Show/Hide Widgets',
+    description:
+        'Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; button in the top bar before Skip',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        styleInjected: false,
+        missingLogged: false,
+        buttonAdded: false
+    },
+
+    onMutation(state) {
+        this.ensureStyle(state);
+        this.applyClassFromStorage();
+
+        const skipBtn = this.findSkipButton();
+        if (!skipBtn) {
+            if (!state.missingLogged) {
+                Logger.debug('Session Trace Show/Hide Widgets: Skip button not found in top bar');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        this.ensureToggleButton(skipBtn, state);
+    },
+
+    findSkipButton() {
+        const buttons = document.querySelectorAll('button');
+        for (const btn of buttons) {
+            const span = btn.querySelector('span');
+            if (span && span.textContent.trim() === 'Skip') {
+                return btn;
+            }
+        }
+        return null;
+    },
+
+    ensureStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-corner-widgets-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-corner-widgets-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+body.${CORNER_WIDGETS_BODY_CLASS} #pylon-chat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat,
+body.${CORNER_WIDGETS_BODY_CLASS} .PylonChat-app {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4,
+body.${CORNER_WIDGETS_BODY_CLASS} button.right-4.bottom-20.fixed,
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.right-4.bottom-20.size-10,
+body.${CORNER_WIDGETS_BODY_CLASS} button.fixed.bottom-20.right-4.rounded-full {
+    visibility: hidden !important;
+    pointer-events: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Session Trace Show/Hide Widgets: corner widgets hide style injected');
+    },
+
+    storageKey() {
+        return `plugin-${this.id}-${CORNER_WIDGETS_STORAGE_KEY}`;
+    },
+
+    applyClassFromStorage() {
+        const hidden = Storage.get(this.storageKey(), true);
+        this.setHidden(!!hidden, false);
+    },
+
+    /** @param {boolean} hidden @param {boolean} persist */
+    setHidden(hidden, persist) {
+        document.body.classList.toggle(CORNER_WIDGETS_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKey(), hidden);
+            Logger.log(
+                `Session Trace Show/Hide Widgets: corner widgets ${hidden ? 'hidden' : 'shown'} (CSS only)`
+            );
+        }
+        const btn = document.querySelector(
+            `button[data-fleet-corner-widgets-toggle="${this.id}"]`
+        );
+        if (btn) {
+            btn.textContent = hidden ? 'Show Widgets' : 'Hide Widgets';
+            btn.title = hidden
+                ? 'Show Pylon support chat and Report a bug button (bottom-right)'
+                : 'Hide Pylon support chat and Report a bug button (bottom-right)';
+        }
+    },
+
+    isHidden() {
+        return document.body.classList.contains(CORNER_WIDGETS_BODY_CLASS);
+    },
+
+    ensureToggleButton(skipBtn, state) {
+        const container = skipBtn.parentElement;
+        if (!container) return;
+
+        let toggleBtn = container.querySelector(
+            `button[data-fleet-corner-widgets-toggle="${this.id}"]`
+        );
+        if (toggleBtn && toggleBtn.parentElement !== container) {
+            toggleBtn.remove();
+            toggleBtn = null;
+        }
+
+        if (!toggleBtn) {
+            toggleBtn = document.createElement('button');
+            toggleBtn.setAttribute('data-fleet-plugin', this.id);
+            toggleBtn.setAttribute('data-fleet-corner-widgets-toggle', this.id);
+            toggleBtn.type = 'button';
+            toggleBtn.className =
+                'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground bg-muted dark:!bg-secondary transition-colors hover:bg-secondary/80 hover:text-secondary-foreground h-8 rounded-sm pl-3 pr-3 text-xs';
+            toggleBtn.addEventListener('click', () => {
+                const nextHidden = !this.isHidden();
+                this.setHidden(nextHidden, true);
+            });
+            container.insertBefore(toggleBtn, skipBtn);
+            if (!state.buttonAdded) {
+                Logger.log('Session Trace Show/Hide Widgets: toggle button added before Skip');
+                state.buttonAdded = true;
+            }
+        }
+        this.setHidden(this.isHidden(), false);
+    }
+};

--- a/plugins/archetypes/qa-session/main/toggle-left-panel.js
+++ b/plugins/archetypes/qa-session/main/toggle-left-panel.js
@@ -1,0 +1,141 @@
+// ============= toggle-left-panel.js =============
+// Session Trace Review: top-bar toggle to hide/show the left column (prompt + comments)
+// via body class + CSS only (no React tree edits). Also collapses the main horizontal
+// resize handle so the trace column can use full width.
+
+const HIDDEN_BODY_CLASS = 'fleet-hide-session-left-panel';
+const STORAGE_SUFFIX = 'left-panel-hidden';
+
+const plugin = {
+    id: 'sessionTraceToggleLeftPanel',
+    name: 'Toggle left panel (prompt / comments)',
+    description:
+        'Yellow-outlined top-left control: CSS-hide the main left resizable panel (task stack) without touching React nodes',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        styleInjected: false,
+        missingLogged: false,
+        buttonEnsured: false
+    },
+
+    onMutation(state) {
+        this.ensureStyle(state);
+        this.applyClassFromStorage();
+
+        const cluster = this.findLeftToolbarCluster();
+        if (!cluster) {
+            if (!state.missingLogged) {
+                Logger.debug('Session Trace Left Panel: left toolbar cluster not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+        this.ensureToggleButton(cluster, state);
+    },
+
+    findLeftToolbarCluster() {
+        const close = document.querySelector('a[href="/work/problems/qa-sessions"]');
+        if (!close) return null;
+        return close.closest('.flex.items-center.gap-3');
+    },
+
+    ensureStyle(state) {
+        if (state.styleInjected) return;
+        if (document.getElementById('fleet-session-left-panel-toggle-style')) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = 'fleet-session-left-panel-toggle-style';
+        style.setAttribute('data-fleet-plugin', this.id);
+        // Main horizontal split: first panel (prompt/verifier/comments stack) + its drag handle.
+        style.textContent = `
+body.${HIDDEN_BODY_CLASS} .flex-shrink-0.h-12 + [data-panel-group][data-panel-group-direction="horizontal"] > [data-panel]:first-child {
+    flex: 0 0 0px !important;
+    min-width: 0 !important;
+    max-width: 0 !important;
+    width: 0 !important;
+    overflow: hidden !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+    opacity: 0 !important;
+    border: none !important;
+}
+body.${HIDDEN_BODY_CLASS} .flex-shrink-0.h-12 + [data-panel-group][data-panel-group-direction="horizontal"] > [data-resize-handle][data-panel-group-direction="horizontal"] {
+    flex: 0 0 0px !important;
+    min-width: 0 !important;
+    width: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+    visibility: hidden !important;
+    pointer-events: none !important;
+    opacity: 0 !important;
+    border: none !important;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+        Logger.log('Session Trace Left Panel: hide styles injected');
+    },
+
+    storageKey() {
+        return `plugin-${this.id}-${STORAGE_SUFFIX}`;
+    },
+
+    applyClassFromStorage() {
+        const hidden = Storage.get(this.storageKey(), false);
+        this.setPanelHidden(!!hidden, false);
+    },
+
+    /** @param {boolean} hidden @param {boolean} persist */
+    setPanelHidden(hidden, persist) {
+        document.body.classList.toggle(HIDDEN_BODY_CLASS, hidden);
+        if (persist) {
+            Storage.set(this.storageKey(), hidden);
+            Logger.log(
+                `Session Trace Left Panel: ${hidden ? 'hidden (CSS)' : 'shown (CSS)'} — prompt/comments column`
+            );
+        }
+        const btn = document.querySelector(`button[data-fleet-session-left-panel="${this.id}"]`);
+        if (btn) {
+            btn.textContent = hidden ? 'Show Left Panel' : 'Hide Left Panel';
+            btn.title = hidden
+                ? 'Show the left column (task prompt, verifier, comments)'
+                : 'Hide the left column with CSS only — full width for session trace';
+        }
+    },
+
+    isPanelHidden() {
+        return document.body.classList.contains(HIDDEN_BODY_CLASS);
+    },
+
+    ensureToggleButton(cluster, state) {
+        let btn = cluster.querySelector(`button[data-fleet-session-left-panel="${this.id}"]`);
+        if (btn && btn.parentElement !== cluster) {
+            btn.remove();
+            btn = null;
+        }
+        if (!btn) {
+            btn = document.createElement('button');
+            btn.type = 'button';
+            btn.setAttribute('data-fleet-plugin', this.id);
+            btn.setAttribute('data-fleet-session-left-panel', this.id);
+            btn.className =
+                'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 disabled:pointer-events-none disabled:opacity-50 h-8 rounded-sm pl-3 pr-3 text-xs border-2 border-yellow-500 dark:border-yellow-400 bg-background text-foreground shadow-sm hover:bg-muted/80 transition-colors';
+            btn.addEventListener('click', () => {
+                this.setPanelHidden(!this.isPanelHidden(), true);
+            });
+            cluster.appendChild(btn);
+            if (!state.buttonEnsured) {
+                Logger.log('Session Trace Left Panel: toggle button appended to left toolbar');
+                state.buttonEnsured = true;
+            }
+        }
+        this.setPanelHidden(this.isPanelHidden(), false);
+    }
+};


### PR DESCRIPTION
## Summary

Introduces the **Session Trace Review** archetype (`qa-session`) with focused UX plugins: corner-widget visibility, persistent panel splits, automatic verifier expansion, and a CSS-only left-panel toggle. README documents the new page features. Branch config was synced for `fleet.user.js`.

## Changes

- Registered `qa-session` in `archetypes.json` with four `main` plugins wired for `work/problems/qa-session/*`.
- **Show/hide widgets**: CSS-only toggling of Pylon chat and Report-a-bug FAB (default hidden), controlled from the top bar near Skip.
- **Remember layout proportions**: Observes panel size attributes, debounces saves, and restores main, inner, and trace column splits without polling.
- **Auto-expand verifier**: One programmatic activation of the verifier score header per navigation so expanded verifier content is visible on load.
- **Toggle left panel**: Body-class + CSS hides the prompt/comments stack and collapses the main horizontal splitter affordance so the trace view can span wide.
- **Documentation**: Added a Session Trace Review section to `README.md` listing the above behaviors.

## New plugins

| Plugin | Archetype | Role |
|--------|-----------|------|
| `show-hide-widgets.js` | Session Trace Review | Corner widgets visibility toggle |
| `remember-layout-proportions.js` | Session Trace Review | Persist panel splits |
| `auto-expand-verifier-section.js` | Session Trace Review | Expand verifier on load |
| `toggle-left-panel.js` | Session Trace Review | Hide/show left column |

## Commit history

- `e4a5143` docs: list Session Trace Review features in README
- `dde2a03` Sync fleet.user.js branch config to main
- `6fa2cae` feat(qa-session): toggle left panel with CSS-only body class
- `a034aca` feat(qa-session): auto-expand verifier Score row on load
- `f5d36d4` feat(qa-session): remember panel splits for Session Trace Review
- `466ad29` feat: add Session Trace Review archetype with show/hide widgets plugin

## Stats

```
 README.md                                          |   6 +
 archetypes.json                                    |  35 ++-
 .../main/auto-expand-verifier-section.js           |  69 +++++
 .../qa-session/main/remember-layout-proportions.js | 305 +++++++++++++++++++++
 .../qa-session/main/show-hide-widgets.js           | 144 ++++++++++
 .../qa-session/main/toggle-left-panel.js           | 141 ++++++++++
 6 files changed, 699 insertions(+), 1 deletion(-)
```
