### PR TITLE
Add Disputes Reviewed View Task column from history API

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.8",
+  "archetypesVersion": "7.9",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -56,8 +56,8 @@
         },
         {
           "name": "disputes-reviewed-view-task.js",
-          "version": "1.1",
-          "hash": "sha256-664ee6ee6bbe283c0d43c5f52d8f901244382f7688ba018207742b9dd5274f8c",
+          "version": "1.2",
+          "hash": "sha256-b0ec065890afcf0dbfc43a0147cfbdb47bdf34f09fec67242759ed6ae207b117",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.7",
+  "archetypesVersion": "7.8",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -56,8 +56,8 @@
         },
         {
           "name": "disputes-reviewed-view-task.js",
-          "version": "1.0",
-          "hash": "sha256-a26680c7f38ff6d9a46b4eec0edbd4a97413c16cbea0f226d63c03f3ccf1fcbc",
+          "version": "1.1",
+          "hash": "sha256-664ee6ee6bbe283c0d43c5f52d8f901244382f7688ba018207742b9dd5274f8c",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.6",
+  "archetypesVersion": "7.7",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -52,6 +52,12 @@
           "name": "disputes-reviewed-today.js",
           "version": "3.0",
           "hash": "sha256-eece62dc245e0482ca91851b53460142fd5f2bb0dc00d8953ed233c479aff158",
+          "log": false
+        },
+        {
+          "name": "disputes-reviewed-view-task.js",
+          "version": "1.0",
+          "hash": "sha256-a26680c7f38ff6d9a46b4eec0edbd4a97413c16cbea0f226d63c03f3ccf1fcbc",
           "log": false
         },
         {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-dispute-breakdown-details] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-breakdown-details/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-breakdown-details/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-dispute-breakdown-details',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-dispute-breakdown-details] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-breakdown-details/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-breakdown-details/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-dispute-breakdown-details',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dashboard/main/disputes-reviewed-view-task.js
+++ b/plugins/archetypes/dashboard/main/disputes-reviewed-view-task.js
@@ -1,18 +1,22 @@
 // ============= disputes-reviewed-view-task.js =============
-// Captures dispute-reviews/history API responses on the dashboard Disputes tab and adds a View Task link per row (task_key → eval_task_id).
+// Captures dispute-reviews/history API on dashboard Disputes tab; inserts a column between Task and Outcome with View Task links (task_key → eval_task_id).
 
 const plugin = {
     id: 'disputesReviewedViewTask',
     name: 'Disputes Reviewed View Task Links',
-    description: 'Add a View Task link next to each task key in the Disputes Reviewed table using eval_task_id from the history API',
-    _version: '1.1',
+    description: 'Insert a View Task column on the Disputes Reviewed table using eval_task_id from the history API',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
         interceptionInstalled: false,
         missingLogged: false,
-        loggedFirstHistoryCapture: false
+        loggedFirstHistoryCapture: false,
+        loggedColumnInject: false
     },
+
+    ACTION_COL_ATTR: 'data-fleet-drvt-action-col',
+    ACTION_CELL_ATTR: 'data-fleet-drvt-action-cell',
 
     mergeHistoryPayload(context, disputes) {
         if (!context.disputeReviewHistoryTaskKeyToEvalId) {
@@ -45,6 +49,22 @@ const plugin = {
             return String(urlStr).includes('dispute-reviews/history');
         };
 
+        const scheduleSyncFromHistory = () => {
+            const pw = context.getPageWindow();
+            pw.requestAnimationFrame(() => {
+                try {
+                    const main = Context.dom.query('main', { context: `${self.id}.history-sync` });
+                    if (!main) return;
+                    const table = self.findDisputesReviewedTable(main);
+                    if (!table) return;
+                    const map = context.disputeReviewHistoryTaskKeyToEvalId || {};
+                    self.syncViewTaskLinks(table, map, state);
+                } catch (e) {
+                    Logger.error('disputes-reviewed-view-task: sync after history response failed', e);
+                }
+            });
+        };
+
         const onDisputesPayload = (data) => {
             if (!data || !Array.isArray(data.disputes)) return;
             const n = self.mergeHistoryPayload(context, data.disputes);
@@ -56,20 +76,7 @@ const plugin = {
                 } else {
                     Logger.debug(`disputes-reviewed-view-task: history page merged (+${n} rows, ${totalKeys} keys total)`);
                 }
-                const pageWindow = context.getPageWindow();
-                pageWindow.requestAnimationFrame(() => {
-                    try {
-                        const main = Context.dom.query('main', { context: `${self.id}.history-sync` });
-                        if (!main) return;
-                        const table = self.findDisputesReviewedTable(main);
-                        const map = context.disputeReviewHistoryTaskKeyToEvalId;
-                        if (table && map) {
-                            self.syncViewTaskLinks(table, map);
-                        }
-                    } catch (e) {
-                        Logger.error('disputes-reviewed-view-task: sync after history response failed', e);
-                    }
-                });
+                scheduleSyncFromHistory();
             }
         };
 
@@ -147,43 +154,108 @@ const plugin = {
     },
 
     /**
-     * Task key from the prompt UI only — never use taskCell.textContent: after we inject
-     * "View Task", the full cell text is not a valid map key and caused add/remove thrash.
+     * Task column only (no View Task in this cell — link lives in the injected column).
      */
     getTaskKeyFromCell(taskCell) {
         if (!taskCell) return '';
         const inner = taskCell.querySelector('.fleet-progress-prompt-inner div');
         if (inner) {
             const key = (inner.textContent || '').trim();
-            if (key) {
-                taskCell.dataset.fleetDisputeReviewedTaskKey = key;
-                return key;
-            }
+            if (key) return key;
         }
         const wrap = taskCell.querySelector('.fleet-progress-prompt-inner');
         if (wrap) {
             const key = (wrap.textContent || '').trim();
-            if (key) {
-                taskCell.dataset.fleetDisputeReviewedTaskKey = key;
-                return key;
-            }
+            if (key) return key;
         }
-        const cached = (taskCell.dataset.fleetDisputeReviewedTaskKey || '').trim();
-        return cached;
+        return (taskCell.textContent || '').trim();
     },
 
     VIEW_LINK_ATTR: 'data-fleet-disputes-reviewed-view-task',
 
-    syncViewTaskLinks(table, map) {
-        if (!table || !map) return;
+    ensureActionColumn(table, state) {
+        const theadRow = table.tHead && table.tHead.rows[0];
+        const tbody = table.tBodies[0];
+        if (!theadRow || !tbody) return;
+
+        const hasOurHeader = theadRow.querySelector(`th[${this.ACTION_COL_ATTR}]`);
+
+        if (hasOurHeader) {
+            for (const tr of tbody.rows) {
+                if (tr.cells.length >= 4 && tr.cells[2] && tr.cells[2].hasAttribute(this.ACTION_CELL_ATTR)) {
+                    continue;
+                }
+                if (tr.cells.length === 3) {
+                    const td = this.createActionBodyCell(tr.cells[1]);
+                    tr.insertBefore(td, tr.cells[2]);
+                }
+            }
+            return;
+        }
+
+        if (theadRow.cells.length !== 3) {
+            Logger.debug('disputes-reviewed-view-task: skip column insert — thead column count is not 3', {
+                count: theadRow.cells.length
+            });
+            return;
+        }
+
+        const th = document.createElement('th');
+        th.setAttribute(this.ACTION_COL_ATTR, 'true');
+        th.setAttribute('scope', 'col');
+        th.className = theadRow.cells[1].className;
+        th.textContent = '';
+        theadRow.insertBefore(th, theadRow.cells[2]);
+
+        for (const tr of tbody.rows) {
+            if (tr.cells.length !== 3) continue;
+            const td = this.createActionBodyCell(tr.cells[1]);
+            tr.insertBefore(td, tr.cells[2]);
+        }
+
+        if (!state.loggedColumnInject) {
+            state.loggedColumnInject = true;
+            Logger.log('disputes-reviewed-view-task: inserted View Task column between Task and Outcome');
+        }
+    },
+
+    createActionBodyCell(taskTdRef) {
+        const td = document.createElement('td');
+        td.setAttribute(this.ACTION_CELL_ATTR, 'true');
+        const refClass = (taskTdRef && taskTdRef.className) || '';
+        td.className = refClass
+            .replace(/\bmax-w-\[[^\]]+\]\b/g, '')
+            .replace(/\btruncate\b/g, '')
+            .trim();
+        if (!td.className) {
+            td.className = 'p-2 align-middle text-xs whitespace-nowrap';
+        } else {
+            td.classList.add('whitespace-nowrap');
+        }
+        return td;
+    },
+
+    syncViewTaskLinks(table, map, state) {
+        if (!table) return;
+        const lookup = map || {};
+        this.ensureActionColumn(table, state);
+
+        if (Object.keys(lookup).length === 0) {
+            return;
+        }
+
         const rows = table.querySelectorAll('tbody tr');
         let injected = 0;
         for (const tr of rows) {
+            if (tr.cells.length < 4) continue;
             const taskCell = tr.cells[1];
-            if (!taskCell) continue;
+            const actionCell = tr.cells[2];
+            if (!taskCell || !actionCell || !actionCell.hasAttribute(this.ACTION_CELL_ATTR)) continue;
+
             const taskKey = this.getTaskKeyFromCell(taskCell);
-            const evalId = taskKey ? map[taskKey] : '';
-            let link = taskCell.querySelector(`[${this.VIEW_LINK_ATTR}]`);
+            const evalId = taskKey ? lookup[taskKey] : '';
+            let link = actionCell.querySelector(`[${this.VIEW_LINK_ATTR}]`);
+
             if (evalId) {
                 const href = `https://www.fleetai.com/work/problems/view-task/${evalId}`;
                 if (!link) {
@@ -195,17 +267,15 @@ const plugin = {
                     link.target = '_blank';
                     link.rel = 'noopener noreferrer';
                     link.href = href;
-                    if (!taskCell.classList.contains('flex')) {
-                        taskCell.classList.add('flex', 'flex-wrap', 'items-center', 'gap-2');
-                    }
-                    taskCell.appendChild(link);
+                    actionCell.appendChild(link);
                     injected++;
                 } else {
                     link.href = href;
                 }
-            } else if (taskKey && !evalId && link) {
+            } else if (taskKey && link) {
                 link.remove();
-                delete taskCell.dataset.fleetDisputeReviewedTaskKey;
+            } else if (!taskKey && link) {
+                link.remove();
             }
         }
         if (injected > 0) {
@@ -235,9 +305,7 @@ const plugin = {
         }
 
         state.missingLogged = false;
-        const map = context.disputeReviewHistoryTaskKeyToEvalId;
-        if (map && Object.keys(map).length > 0) {
-            this.syncViewTaskLinks(table, map);
-        }
+        const map = context.disputeReviewHistoryTaskKeyToEvalId || {};
+        this.syncViewTaskLinks(table, map, state);
     }
 };

--- a/plugins/archetypes/dashboard/main/disputes-reviewed-view-task.js
+++ b/plugins/archetypes/dashboard/main/disputes-reviewed-view-task.js
@@ -1,0 +1,225 @@
+// ============= disputes-reviewed-view-task.js =============
+// Captures dispute-reviews/history API responses on the dashboard Disputes tab and adds a View Task link per row (task_key → eval_task_id).
+
+const plugin = {
+    id: 'disputesReviewedViewTask',
+    name: 'Disputes Reviewed View Task Links',
+    description: 'Add a View Task link next to each task key in the Disputes Reviewed table using eval_task_id from the history API',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        interceptionInstalled: false,
+        missingLogged: false,
+        loggedFirstHistoryCapture: false
+    },
+
+    mergeHistoryPayload(context, disputes) {
+        if (!context.disputeReviewHistoryTaskKeyToEvalId) {
+            context.disputeReviewHistoryTaskKeyToEvalId = Object.create(null);
+        }
+        const map = context.disputeReviewHistoryTaskKeyToEvalId;
+        let added = 0;
+        for (const d of disputes) {
+            if (d && d.task_key && d.eval_task_id) {
+                map[d.task_key] = d.eval_task_id;
+                added++;
+            }
+        }
+        return added;
+    },
+
+    installDisputeHistoryInterception(context, state) {
+        const pageWindow = context.getPageWindow();
+        if (pageWindow.__fleetDisputeReviewHistoryInterceptionInstalled) {
+            state.interceptionInstalled = true;
+            return;
+        }
+        pageWindow.__fleetDisputeReviewHistoryInterceptionInstalled = true;
+
+        const self = this;
+
+        const matchesHistoryRequest = (urlStr, method) => {
+            const m = (method || 'GET').toUpperCase();
+            if (m !== 'GET') return false;
+            return String(urlStr).includes('dispute-reviews/history');
+        };
+
+        const onDisputesPayload = (data) => {
+            if (!data || !Array.isArray(data.disputes)) return;
+            const n = self.mergeHistoryPayload(context, data.disputes);
+            if (n > 0) {
+                const totalKeys = Object.keys(context.disputeReviewHistoryTaskKeyToEvalId).length;
+                if (!state.loggedFirstHistoryCapture) {
+                    state.loggedFirstHistoryCapture = true;
+                    Logger.log(`disputes-reviewed-view-task: captured dispute history (${n} in this response, ${totalKeys} task keys mapped)`);
+                } else {
+                    Logger.debug(`disputes-reviewed-view-task: history page merged (+${n} rows, ${totalKeys} keys total)`);
+                }
+                const pageWindow = context.getPageWindow();
+                pageWindow.requestAnimationFrame(() => {
+                    try {
+                        const main = Context.dom.query('main', { context: `${self.id}.history-sync` });
+                        if (!main) return;
+                        const table = self.findDisputesReviewedTable(main);
+                        const map = context.disputeReviewHistoryTaskKeyToEvalId;
+                        if (table && map) {
+                            self.syncViewTaskLinks(table, map);
+                        }
+                    } catch (e) {
+                        Logger.error('disputes-reviewed-view-task: sync after history response failed', e);
+                    }
+                });
+            }
+        };
+
+        const originalFetch = pageWindow.fetch;
+        if (typeof originalFetch === 'function') {
+            pageWindow.fetch = function (...args) {
+                const [resource, config] = args;
+                let url;
+                try {
+                    url = new URL(resource, pageWindow.location.href);
+                } catch (e) {
+                    url = { href: String(resource), pathname: '' };
+                }
+                const method = config && config.method ? String(config.method) : 'GET';
+                if (matchesHistoryRequest(url.href, method)) {
+                    return originalFetch.apply(this, args).then(async (response) => {
+                        if (!response.ok) return response;
+                        try {
+                            const clone = response.clone();
+                            const data = await clone.json();
+                            onDisputesPayload(data);
+                        } catch (e) {
+                            Logger.debug('disputes-reviewed-view-task: failed to parse history JSON (fetch)', e);
+                        }
+                        return response;
+                    });
+                }
+                return originalFetch.apply(this, args);
+            };
+        }
+
+        const originalXHROpen = pageWindow.XMLHttpRequest.prototype.open;
+        const originalXHRSend = pageWindow.XMLHttpRequest.prototype.send;
+        pageWindow.XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+            this._fleetDisputeHistoryURL = url;
+            this._fleetDisputeHistoryMethod = method;
+            return originalXHROpen.apply(this, [method, url, ...rest]);
+        };
+        pageWindow.XMLHttpRequest.prototype.send = function (body) {
+            const url = this._fleetDisputeHistoryURL;
+            const method = this._fleetDisputeHistoryMethod || 'GET';
+            if (matchesHistoryRequest(url, method)) {
+                this.addEventListener('load', function () {
+                    try {
+                        const text = this.responseText;
+                        if (!text) return;
+                        const data = JSON.parse(text);
+                        onDisputesPayload(data);
+                    } catch (e) {
+                        Logger.debug('disputes-reviewed-view-task: failed to parse history XHR', e);
+                    }
+                });
+            }
+            return originalXHRSend.apply(this, [body]);
+        };
+
+        state.interceptionInstalled = true;
+        Logger.log('disputes-reviewed-view-task: dispute history network interception installed');
+    },
+
+    findDisputesReviewedTable(main) {
+        const panels = main.querySelectorAll('[role="tabpanel"]');
+        for (const panel of panels) {
+            const table = panel.querySelector('table');
+            if (!table || !table.tHead) continue;
+            const thText = table.tHead.textContent || '';
+            if (thText.includes('Date') && thText.includes('Task') && thText.includes('Outcome') && !thText.includes('Environment')) {
+                const totalReviewedHeading = panel.querySelector('h3.tracking-tight');
+                if (totalReviewedHeading && totalReviewedHeading.textContent.trim() === 'Total Reviewed') {
+                    return table;
+                }
+            }
+        }
+        return null;
+    },
+
+    getTaskKeyFromCell(taskCell) {
+        if (!taskCell) return '';
+        const inner = taskCell.querySelector('.fleet-progress-prompt-inner div');
+        if (inner) return (inner.textContent || '').trim();
+        const wrap = taskCell.querySelector('.fleet-progress-prompt-inner');
+        if (wrap) return (wrap.textContent || '').trim();
+        return (taskCell.textContent || '').trim();
+    },
+
+    VIEW_LINK_ATTR: 'data-fleet-disputes-reviewed-view-task',
+
+    syncViewTaskLinks(table, map) {
+        if (!table || !map) return;
+        const rows = table.querySelectorAll('tbody tr');
+        let injected = 0;
+        for (const tr of rows) {
+            const taskCell = tr.cells[1];
+            if (!taskCell) continue;
+            const taskKey = this.getTaskKeyFromCell(taskCell);
+            const evalId = taskKey ? map[taskKey] : '';
+            let link = taskCell.querySelector(`[${this.VIEW_LINK_ATTR}]`);
+            if (evalId) {
+                const href = `https://www.fleetai.com/work/problems/view-task/${evalId}`;
+                if (!link) {
+                    link = document.createElement('a');
+                    link.setAttribute(this.VIEW_LINK_ATTR, 'true');
+                    link.className =
+                        'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-7 rounded-sm px-2 text-xs shrink-0';
+                    link.textContent = 'View Task';
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    link.href = href;
+                    if (!taskCell.classList.contains('flex')) {
+                        taskCell.classList.add('flex', 'flex-wrap', 'items-center', 'gap-2');
+                    }
+                    taskCell.appendChild(link);
+                    injected++;
+                } else {
+                    link.href = href;
+                }
+            } else if (link) {
+                link.remove();
+            }
+        }
+        if (injected > 0) {
+            Logger.log(`disputes-reviewed-view-task: added View Task link(s) to ${injected} row(s)`);
+        }
+    },
+
+    onMutation(state, context) {
+        this.installDisputeHistoryInterception(context, state);
+
+        const main = Context.dom.query('main', { context: `${this.id}.main` });
+        if (!main) {
+            if (!state.missingLogged) {
+                Logger.debug('disputes-reviewed-view-task: main not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        const table = this.findDisputesReviewedTable(main);
+        if (!table) {
+            if (!state.missingLogged) {
+                Logger.debug('disputes-reviewed-view-task: Disputes Reviewed table not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+
+        state.missingLogged = false;
+        const map = context.disputeReviewHistoryTaskKeyToEvalId;
+        if (map && Object.keys(map).length > 0) {
+            this.syncViewTaskLinks(table, map);
+        }
+    }
+};

--- a/plugins/archetypes/dashboard/main/disputes-reviewed-view-task.js
+++ b/plugins/archetypes/dashboard/main/disputes-reviewed-view-task.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'disputesReviewedViewTask',
     name: 'Disputes Reviewed View Task Links',
     description: 'Add a View Task link next to each task key in the Disputes Reviewed table using eval_task_id from the history API',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -146,13 +146,30 @@ const plugin = {
         return null;
     },
 
+    /**
+     * Task key from the prompt UI only — never use taskCell.textContent: after we inject
+     * "View Task", the full cell text is not a valid map key and caused add/remove thrash.
+     */
     getTaskKeyFromCell(taskCell) {
         if (!taskCell) return '';
         const inner = taskCell.querySelector('.fleet-progress-prompt-inner div');
-        if (inner) return (inner.textContent || '').trim();
+        if (inner) {
+            const key = (inner.textContent || '').trim();
+            if (key) {
+                taskCell.dataset.fleetDisputeReviewedTaskKey = key;
+                return key;
+            }
+        }
         const wrap = taskCell.querySelector('.fleet-progress-prompt-inner');
-        if (wrap) return (wrap.textContent || '').trim();
-        return (taskCell.textContent || '').trim();
+        if (wrap) {
+            const key = (wrap.textContent || '').trim();
+            if (key) {
+                taskCell.dataset.fleetDisputeReviewedTaskKey = key;
+                return key;
+            }
+        }
+        const cached = (taskCell.dataset.fleetDisputeReviewedTaskKey || '').trim();
+        return cached;
     },
 
     VIEW_LINK_ATTR: 'data-fleet-disputes-reviewed-view-task',
@@ -186,8 +203,9 @@ const plugin = {
                 } else {
                     link.href = href;
                 }
-            } else if (link) {
+            } else if (taskKey && !evalId && link) {
                 link.remove();
+                delete taskCell.dataset.fleetDisputeReviewedTaskKey;
             }
         }
         if (injected > 0) {


### PR DESCRIPTION
## Summary

Adds a **Disputes Reviewed → View Task** workflow on the dashboard: a new column between Task and Outcome links each row to the correct eval task by capturing **`task_key` → `eval_task_id`** from the existing `dispute-reviews/history` GET responses (fetch interception + `requestAnimationFrame` sync). Follow-up commits stabilize links when the table re-renders and align the column with plain task cell text.

## Changes

- **New plugin** `disputes-reviewed-view-task.js` (dashboard archetype, mutation phase): installs one-time fetch/XHR interception for dispute review history, merges dispute rows into a page-context map, injects the **View Task** column and cells with `data-fleet-drvt-*` markers, and re-syncs on observed DOM changes without polling loops.
- **`archetypes.json`**: registers the plugin (version **1.2**), updates hashes, and bumps `archetypesVersion` to **7.9**.
- **Branch sync**: `fleet.user.js` updated to match main’s branch config (`Sync fleet.user.js branch config to main`).

## New plugins

| Archetype | File | Version |
|-----------|------|--------|
| `dashboard` | `disputes-reviewed-view-task.js` | 1.2 |

## Commit history

- `0df6c1d` — feat(dashboard): Disputes Reviewed "View Task" links from history API
- `67dddb7` — fix(dashboard): stop Disputes Reviewed View Task link thrash
- `32b294a` — fix(dashboard): Disputes Reviewed View Task column + plain task cells
- `5bc27bd` — Sync fleet.user.js branch config to main

*(Omitted: `47e0b7f` — Sync branch config)*

## Stats

```
 archetypes.json                                    |   8 +-
 .../dashboard/main/disputes-reviewed-view-task.js  | 311 +++++++++++++++++++++
 2 files changed, 318 insertions(+), 1 deletion(-)
```
