### PR TITLE
Fix Disputes Reviewed today breakdown when View Task column is present

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.9",
+  "archetypesVersion": "7.10",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -50,8 +50,8 @@
       "plugins": [
         {
           "name": "disputes-reviewed-today.js",
-          "version": "3.0",
-          "hash": "sha256-eece62dc245e0482ca91851b53460142fd5f2bb0dc00d8953ed233c479aff158",
+          "version": "3.1",
+          "hash": "sha256-9a5c90e98b1aad29cb3b4b36db317274570820abad1e684390c2c85985aa46f2",
           "log": false
         },
         {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix-copy-breakdown-dispute] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-copy-breakdown-dispute/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-copy-breakdown-dispute/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix-copy-breakdown-dispute',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix-copy-breakdown-dispute] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-copy-breakdown-dispute/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-copy-breakdown-dispute/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix-copy-breakdown-dispute',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dashboard/main/disputes-reviewed-today.js
+++ b/plugins/archetypes/dashboard/main/disputes-reviewed-today.js
@@ -3,7 +3,7 @@ const plugin = {
     id: 'disputesReviewedToday',
     name: 'Disputes Reviewed Today Breakdown',
     description: 'Show today\'s disputes reviewed count and approved/rejected breakdown with copy and scroll warning',
-    _version: '3.0',
+    _version: '3.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, lastUncertain: false },
@@ -99,6 +99,31 @@ const plugin = {
     },
 
     /**
+     * Resolve Date and Outcome column indices from thead so counts work with or without
+     * injected columns (e.g. View Task between Task and Outcome).
+     * @returns {{ dateIdx: number, outcomeIdx: number }}
+     */
+    resolveReviewedTableColumnIndices(table) {
+        const theadRow = table.tHead && table.tHead.rows[0];
+        const fallback = { dateIdx: 0, outcomeIdx: 2 };
+        if (!theadRow || theadRow.cells.length === 0) return fallback;
+
+        let dateIdx = -1;
+        let outcomeIdx = -1;
+        for (let i = 0; i < theadRow.cells.length; i++) {
+            const raw = (theadRow.cells[i].textContent || '').trim().replace(/\s+/g, ' ');
+            if (/^date$/i.test(raw)) dateIdx = i;
+            if (/outcome/i.test(raw)) outcomeIdx = i;
+        }
+        if (dateIdx < 0) dateIdx = 0;
+        if (outcomeIdx < 0) {
+            const n = theadRow.cells.length;
+            outcomeIdx = n > 3 ? n - 1 : 2;
+        }
+        return { dateIdx, outcomeIdx };
+    },
+
+    /**
      * Find the Disputes Reviewed tab panel: table with Date, Task, Outcome (no Environment).
      * @returns {HTMLTableElement | null}
      */
@@ -118,13 +143,13 @@ const plugin = {
         return null;
     },
 
-    getStatsForDate(rows, targetMonth, targetDay) {
+    getStatsForDate(rows, targetMonth, targetDay, dateIdx, outcomeIdx) {
         let count = 0;
         let approved = 0;
         let rejected = 0;
         for (const tr of rows) {
-            const dateCell = tr.cells[0];
-            const outcomeCell = tr.cells[2];
+            const dateCell = tr.cells[dateIdx];
+            const outcomeCell = tr.cells[outcomeIdx];
             const dateText = dateCell ? dateCell.textContent.trim() : '';
             const parsed = this.parseDateText(dateText);
             if (this.sameDate(parsed, { month: targetMonth, day: targetDay })) {
@@ -149,16 +174,18 @@ const plugin = {
         return lines.join('\n');
     },
 
-    isPastDayUncertain(rows, targetMonth, targetDay, stats) {
+    isPastDayUncertain(rows, targetMonth, targetDay, stats, dateIdx) {
         if (!rows || rows.length === 0) return true;
         if (!stats) return true;
         if (stats.count === 0) return true;
         if (stats.count !== 10) return false;
 
+        const dIdx = typeof dateIdx === 'number' ? dateIdx : 0;
+
         let lastIndex = -1;
         for (let i = 0; i < rows.length; i++) {
             const tr = rows[i];
-            const dateCell = tr.cells[0];
+            const dateCell = tr.cells[dIdx];
             const dateText = dateCell ? dateCell.textContent.trim() : '';
             const parsed = this.parseDateText(dateText);
             if (this.sameDate(parsed, { month: targetMonth, day: targetDay })) {
@@ -170,7 +197,7 @@ const plugin = {
         }
         for (let i = lastIndex + 1; i < rows.length; i++) {
             const tr = rows[i];
-            const dateCell = tr.cells[0];
+            const dateCell = tr.cells[dIdx];
             const dateText = dateCell ? dateCell.textContent.trim() : '';
             const parsed = this.parseDateText(dateText);
             if (parsed && !this.sameDate(parsed, { month: targetMonth, day: targetDay })) {
@@ -210,6 +237,7 @@ const plugin = {
         }
         state.missingLogged = false;
 
+        const { dateIdx, outcomeIdx } = this.resolveReviewedTableColumnIndices(table);
         const rows = Array.from(table.querySelectorAll('tbody tr'));
         let todayCount = 0;
         let todayApproved = 0;
@@ -218,8 +246,8 @@ const plugin = {
 
         for (let i = 0; i < rows.length; i++) {
             const tr = rows[i];
-            const dateCell = tr.cells[0];
-            const outcomeCell = tr.cells[2];
+            const dateCell = tr.cells[dateIdx];
+            const outcomeCell = tr.cells[outcomeIdx];
             const dateText = dateCell ? dateCell.textContent.trim() : '';
             const parsed = this.parseDateText(dateText);
             const rowIsToday = this.isToday(parsed);
@@ -349,8 +377,9 @@ const plugin = {
                     const panelEl = block.closest('[role="tabpanel"]');
                     const tableEl = panelEl ? panelEl.querySelector('table') : null;
                     const liveRows = tableEl ? Array.from(tableEl.querySelectorAll('tbody tr')) : [];
-                    const stats = self.getStatsForDate(liveRows, ref.month, ref.day);
-                    isUncertain = self.isPastDayUncertain(liveRows, ref.month, ref.day, stats);
+                    const col = tableEl ? self.resolveReviewedTableColumnIndices(tableEl) : { dateIdx: 0, outcomeIdx: 2 };
+                    const stats = self.getStatsForDate(liveRows, ref.month, ref.day, col.dateIdx, col.outcomeIdx);
+                    isUncertain = self.isPastDayUncertain(liveRows, ref.month, ref.day, stats, col.dateIdx);
                     copyText = self.buildCopyTextForDate(stats, isUncertain);
                     const dayArPast = stats.count > 0 ? Math.round((stats.approved / stats.count) * 100) : null;
                     displayCount = `${stats.count}${isUncertain ? '?' : ''}` + (dayArPast != null ? ` (${dayArPast}% AR)` : '');


### PR DESCRIPTION
## Summary

Repairs the **Disputes Reviewed Today** breakdown so approved/rejected counts stay accurate when the **View Task** column is injected (extra column before Outcome). Column indices are derived from the table header instead of assuming a fixed layout.

## Changes

- **`disputes-reviewed-today.js`**: Added `resolveReviewedTableColumnIndices()` to locate **Date** and **Outcome** from `<thead>`, with fallbacks for legacy three-column tables. The today loop, **`getStatsForDate`**, and **`isPastDayUncertain`** now use those indices so they match the DOM whether the view-task plugin is on or off.
- **`archetypes.json`**: Bumped **disputes-reviewed-today.js** to `3.1`, **`archetypesVersion`** to `7.10`, and refreshed plugin hashes.

## Commit history

- `60f2eb4` fix(dashboard): resolve Disputes Reviewed columns by header for today breakdown
- `f9cc7cc` Sync fleet.user.js branch config to main

## Stats

```
 archetypes.json                                    |  6 +--
 .../dashboard/main/disputes-reviewed-today.js      | 51 +++++++++++++++++-----
 2 files changed, 43 insertions(+), 14 deletions(-)
```
