### PR TITLE
Dispute detail: split Flag as Bug, upload/scenario/scratchpad plugins, settings fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
+- **Dispute Screenshot Upload Improvement**: Full-width screenshot control with click, drag-and-drop, and paste; forwards images to the native file input (original control visually hidden)
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages
 - **Execute to Current Tool**: Adds button to execute all tools from the beginning up to and including the current tool
 - **Tool Favorites**: Add favorite stars to tools list

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Clear Tool Search**: Adds a clear `X` button to the tool search box when it has text
 - **Copy Verifier Output**: Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text
 - **Create Instance Autoclick**: Automatically clicks the "Create Instance" button once when it becomes visible.
-- **Dispute Resolution Action Menu**: Replaces the row of dispute resolution buttons with a dropdown and Confirm Action control; triggers the underlying native button
+- **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
-- **Dispute Screenshot Upload Improvement**: Full-width screenshot control with click, drag-and-drop, and paste; forwards images to the native file input (original control visually hidden)
+- **Dispute Screenshot Upload Improvement**: Drag & Drop/Upload plus Paste Image (clipboard API) in one row; document paste; forwards images to the hidden native file input without duplicate controls after thumbnails appear
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages
 - **Execute to Current Tool**: Adds button to execute all tools from the beginning up to and including the current tool
 - **Tool Favorites**: Add favorite stars to tools list

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.15",
+  "archetypesVersion": "7.16",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -11,8 +11,8 @@
   "corePlugins": [
     {
       "name": "settings-ui.js",
-      "version": "6.7",
-      "hash": "sha256-636e3fa04960c455a7ee4ccfba7b5f64ecae3f1329ade4ac381c8bc759e6ea6d",
+      "version": "6.8",
+      "hash": "sha256-bceedbb627a1a46583d09aa418d77ce99de9285e3aa11a5822bce5c27eb658a1",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.12",
+  "archetypesVersion": "7.14",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -37,7 +37,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.11"
+      "version": "1.13"
     }
   ],
   "archetypes": [
@@ -547,6 +547,12 @@
           "name": "dispute-resolution-widgets-toggle.js",
           "version": "2.2",
           "hash": "sha256-0d927f8a6c4c211281f12a985fbafcaf719fe49a6cbb166f4f88f16e9c656cc6",
+          "log": false
+        },
+        {
+          "name": "dispute-screenshot-upload-improvement.js",
+          "version": "1.1",
+          "hash": "sha256-f356907fd5acb9d0ac596c160235ed0ac1c1d6aca5d6530a9a64590e039d3214",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.14",
+  "archetypesVersion": "7.15",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -37,7 +37,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.13"
+      "version": "1.14"
     }
   ],
   "archetypes": [
@@ -551,8 +551,8 @@
         },
         {
           "name": "dispute-screenshot-upload-improvement.js",
-          "version": "1.1",
-          "hash": "sha256-f356907fd5acb9d0ac596c160235ed0ac1c1d6aca5d6530a9a64590e039d3214",
+          "version": "1.2",
+          "hash": "sha256-a1bc305b24991917ce9e630cc23b1eb0d89cf4382fec4c9cab00f526c5ac25a3",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.10",
+  "archetypesVersion": "7.12",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -37,7 +37,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.10"
+      "version": "1.11"
     }
   ],
   "archetypes": [
@@ -533,8 +533,8 @@
         },
         {
           "name": "dispute-resolution-action-menu.js",
-          "version": "1.2",
-          "hash": "sha256-acafb0c177c84f96585c5f1a51835b5686cf601a9b93fb16620a5be3791a7d8c",
+          "version": "1.3",
+          "hash": "sha256-d08ed2518a117f8fb9be74b2e1716ee0f13d04f8516fd3ba8f6f48ee5ab93e9f",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.18",
+  "archetypesVersion": "7.19",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -545,8 +545,8 @@
         },
         {
           "name": "dispute-prompt-scratchpad.js",
-          "version": "1.0",
-          "hash": "sha256-a204497b7c3175ddb478047063ebb611ad1b344fdb0433fec684a4c9d89f3585",
+          "version": "1.1",
+          "hash": "sha256-0008ea0f12a40103417f3f741db224c89b909fb64c1c641e970e5fe62f138e37",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.16",
+  "archetypesVersion": "7.18",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -37,7 +37,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.14"
+      "version": "1.15"
     }
   ],
   "archetypes": [
@@ -544,9 +544,21 @@
           "log": false
         },
         {
+          "name": "dispute-prompt-scratchpad.js",
+          "version": "1.0",
+          "hash": "sha256-a204497b7c3175ddb478047063ebb611ad1b344fdb0433fec684a4c9d89f3585",
+          "log": false
+        },
+        {
           "name": "dispute-resolution-widgets-toggle.js",
           "version": "2.2",
           "hash": "sha256-0d927f8a6c4c211281f12a985fbafcaf719fe49a6cbb166f4f88f16e9c656cc6",
+          "log": false
+        },
+        {
+          "name": "dispute-scenario-near-prompt.js",
+          "version": "1.1",
+          "hash": "sha256-f233fa419797bc3cc723dff9f75635fa794153003f81bb26f34a93143559fbe7",
           "log": false
         },
         {

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.11
+1.13
 
 ## Features
 
@@ -87,6 +87,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
+- **Dispute Screenshot Upload Improvement**: Full-width screenshot control with click, drag-and-drop, and paste; forwards images to the native file input (original control visually hidden)
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages
 - **Execute to Current Tool**: Adds button to execute all tools from the beginning up to and including the current tool
 - **Tool Favorites**: Add favorite stars to tools list

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.13
+1.14
 
 ## Features
 
@@ -87,7 +87,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
-- **Dispute Screenshot Upload Improvement**: Full-width screenshot control with click, drag-and-drop, and paste; forwards images to the native file input (original control visually hidden)
+- **Dispute Screenshot Upload Improvement**: Drag & Drop/Upload plus Paste Image (clipboard API) in one row; document paste; forwards images to the hidden native file input without duplicate controls after thumbnails appear
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages
 - **Execute to Current Tool**: Adds button to execute all tools from the beginning up to and including the current tool
 - **Tool Favorites**: Add favorite stars to tools list

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.14
+1.15
 
 ## Features
 
@@ -86,7 +86,9 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Create Instance Autoclick**: Automatically clicks the "Create Instance" button once when it becomes visible.
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
+- **Dispute Prompt Scratchpad**: Collapsible notes between the task prompt and writer dispute (default collapsed; not saved across reloads)
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
+- **Dispute Scenario Near Prompt**: Expands Scenario / User Story, duplicates it above the task prompt in an always-open form, and hides the original block with CSS
 - **Dispute Screenshot Upload Improvement**: Drag & Drop/Upload plus Paste Image (clipboard API) in one row; document paste; forwards images to the hidden native file input without duplicate controls after thumbnails appear
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages
 - **Execute to Current Tool**: Adds button to execute all tools from the beginning up to and including the current tool

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.10
+1.11
 
 ## Features
 
@@ -84,7 +84,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Clear Tool Search**: Adds a clear `X` button to the tool search box when it has text
 - **Copy Verifier Output**: Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text
 - **Create Instance Autoclick**: Automatically clicks the "Create Instance" button once when it becomes visible.
-- **Dispute Resolution Action Menu**: Replaces the row of dispute resolution buttons with a dropdown and Confirm Action control; triggers the underlying native button
+- **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
 - **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix-dispute-action-buttons] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-dispute-action-buttons/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-dispute-action-buttons/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix-dispute-action-buttons',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix-dispute-action-buttons] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-dispute-action-buttons/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix-dispute-action-buttons/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix-dispute-action-buttons',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/dispute-prompt-scratchpad.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-prompt-scratchpad.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'disputePromptScratchpad',
     name: 'Dispute Prompt Scratchpad',
     description: 'Collapsible scratchpad after the task prompt on dispute detail (not persisted)',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -45,7 +45,7 @@ const plugin = {
 
     buildScratchpad() {
         const wrap = document.createElement('div');
-        wrap.className = 'mb-4';
+        wrap.className = 'mt-4 mb-4';
         wrap.dataset.fleetDisputePromptScratchpad = 'true';
 
         const inner = document.createElement('div');
@@ -72,8 +72,7 @@ const plugin = {
         const textarea = document.createElement('textarea');
         textarea.className =
             'flex min-h-[120px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y';
-        textarea.placeholder =
-            'Notes for this dispute only (not saved; cleared on reload).';
+        textarea.placeholder = 'QA Scratchpad';
 
         panel.appendChild(textarea);
 

--- a/plugins/archetypes/dispute-detail/main/dispute-prompt-scratchpad.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-prompt-scratchpad.js
@@ -1,0 +1,114 @@
+// ============= dispute-prompt-scratchpad.js =============
+// Collapsible notes area between the task prompt card and the writer dispute section.
+// Default collapsed; contents are never persisted (fresh every load).
+
+const plugin = {
+    id: 'disputePromptScratchpad',
+    name: 'Dispute Prompt Scratchpad',
+    description: 'Collapsible scratchpad after the task prompt on dispute detail (not persisted)',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        missingPromptLogged: false
+    },
+
+    onMutation(state) {
+        if (document.querySelector('[data-fleet-dispute-prompt-scratchpad]')) {
+            return;
+        }
+
+        const promptCard = this.findPromptCard();
+        if (!promptCard || !promptCard.parentElement) {
+            if (!state.missingPromptLogged) {
+                Logger.debug('Dispute Prompt Scratchpad: task prompt card not found');
+                state.missingPromptLogged = true;
+            }
+            return;
+        }
+        state.missingPromptLogged = false;
+
+        const wrap = this.buildScratchpad();
+        promptCard.insertAdjacentElement('afterend', wrap);
+        Logger.log('Dispute Prompt Scratchpad: inserted collapsible scratchpad after task prompt');
+    },
+
+    findPromptCard() {
+        const disputesBack = document.querySelector('a[href="/work/problems/disputes"]');
+        const host = disputesBack?.closest('div.p-4');
+        const card = host?.querySelector(':scope > div.rounded-xl.text-card-foreground.border.bg-card');
+        if (card?.querySelector('pre.text-sm.whitespace-pre-wrap')) return card;
+        const pre = document.querySelector('pre.text-sm.whitespace-pre-wrap.font-mono.text-foreground');
+        return pre?.closest('div.rounded-xl.text-card-foreground.border.bg-card') || null;
+    },
+
+    buildScratchpad() {
+        const wrap = document.createElement('div');
+        wrap.className = 'mb-4';
+        wrap.dataset.fleetDisputePromptScratchpad = 'true';
+
+        const inner = document.createElement('div');
+        inner.setAttribute('data-state', 'closed');
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className =
+            'inline-flex items-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm text-xs w-full justify-between p-2';
+        btn.setAttribute('aria-expanded', 'false');
+
+        const label = document.createElement('span');
+        label.className = 'text-sm font-medium';
+        label.textContent = 'Scratchpad';
+
+        let chevron = this.createChevronSvg(false);
+        btn.appendChild(label);
+        btn.appendChild(chevron);
+
+        const panel = document.createElement('div');
+        panel.className = 'mt-2';
+        panel.hidden = true;
+
+        const textarea = document.createElement('textarea');
+        textarea.className =
+            'flex min-h-[120px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y';
+        textarea.placeholder =
+            'Notes for this dispute only (not saved; cleared on reload).';
+
+        panel.appendChild(textarea);
+
+        btn.addEventListener('click', () => {
+            const open = panel.hidden;
+            panel.hidden = !open;
+            inner.setAttribute('data-state', open ? 'open' : 'closed');
+            btn.setAttribute('aria-expanded', String(open));
+            const next = this.createChevronSvg(open);
+            chevron.replaceWith(next);
+            chevron = next;
+        });
+
+        inner.appendChild(btn);
+        inner.appendChild(panel);
+        wrap.appendChild(inner);
+
+        return wrap;
+    },
+
+    createChevronSvg(expanded) {
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        svg.setAttribute('width', '24');
+        svg.setAttribute('height', '24');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('stroke-width', '2');
+        svg.setAttribute('stroke-linecap', 'round');
+        svg.setAttribute('stroke-linejoin', 'round');
+        svg.setAttribute('class', 'h-4 w-4');
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', expanded ? 'm6 9 6 6 6-6' : 'm9 18 6-6-6-6');
+        svg.appendChild(path);
+        return svg;
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-resolution-action-menu.js
@@ -1,28 +1,31 @@
 // ============= dispute-resolution-action-menu.js =============
-// Collapses native dispute resolution buttons into a select + Confirm control,
-// and triggers the real button on confirm. Native buttons stay in the DOM
-// (visually hidden) so page handlers keep working.
+// Shows Flag as Bug as a full-width native button; other actions use a select +
+// Confirm control that triggers visually hidden native buttons.
 
 const STYLE_ID = 'fleet-dispute-resolution-action-menu-style';
 const MENU_ROOT_ATTR = 'data-fleet-dispute-action-menu';
 const MENU_CONTROL_ATTR = 'data-fleet-dispute-menu-control';
+const FLAG_WRAP_ATTR = 'data-fleet-dispute-flag-actions';
 const ROW_CLASS = 'fleet-dispute-action-row--menu';
 const SELECT_CLASS_HOOK = 'fleet-dispute-action-select';
 
-/** Baseline when no action is chosen (not merged with button classes). */
+/** Baseline when no action is chosen (not merged with button classes). Width comes from flex row. */
 const SELECT_NEUTRAL_CLASSES = [
-    'h-9 min-w-[12rem] rounded-sm border border-input bg-background px-3 py-1',
+    'h-9 rounded-sm border border-input bg-background px-3 py-1',
     'text-sm text-foreground ring-offset-background',
     'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
     SELECT_CLASS_HOOK
 ].join(' ');
 
+/** Appended on every select sync so the dropdown grows with the menu row. */
+const SELECT_LAYOUT_CLASSES = 'flex-1 min-w-0 w-full max-w-full';
+
 const plugin = {
     id: 'disputeResolutionActionMenu',
     name: 'Dispute Resolution Action Menu',
     description:
-        'Replaces the row of dispute resolution buttons with a dropdown and Confirm Action control; triggers the underlying native button',
-    _version: '1.2',
+        'Keeps Flag as Bug as a full-width native button above a full-width row with an action dropdown (flex width) and fixed Confirm; other actions trigger the hidden native button',
+    _version: '1.3',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -54,25 +57,41 @@ const plugin = {
         }
         state.missingRowLogged = false;
 
-        const natives = this.getNativeActionButtons(row);
-        if (!natives.length) {
+        let wrapper = row.querySelector(`[${MENU_ROOT_ATTR}]`);
+        if (!wrapper) {
+            const directButtons = this.getDirectNativeButtons(row);
+            const { flags, menu: menuNatives } = this.partitionActionButtons(directButtons);
+            if (!menuNatives.length) {
+                return;
+            }
+
+            row.classList.add(ROW_CLASS);
+            const flagWrap = this.ensureFlagWrap(row, flags);
+            if (flagWrap) {
+                row.insertBefore(flagWrap, row.firstChild);
+            }
+            const sig = this.signatureForButtons(menuNatives);
+            wrapper = this.buildMenuWrapper(row, menuNatives, sig);
+            row.insertBefore(wrapper, flagWrap ? flagWrap.nextSibling : row.firstChild);
+            if (!state.injectedLogged) {
+                Logger.log(
+                    'Dispute Resolution Action Menu: flag row (if any), dropdown and confirm control added'
+                );
+                state.injectedLogged = true;
+            }
+        }
+
+        const menuNatives = this.getMenuNativeButtons(row);
+        if (!menuNatives.length) {
             return;
         }
 
         row.classList.add(ROW_CLASS);
-        const sig = this.signatureForButtons(natives);
-        let wrapper = row.querySelector(`[${MENU_ROOT_ATTR}]`);
-        if (!wrapper) {
-            wrapper = this.buildMenuWrapper(row, natives, sig);
-            row.appendChild(wrapper);
-            if (!state.injectedLogged) {
-                Logger.log('Dispute Resolution Action Menu: dropdown and confirm control added');
-                state.injectedLogged = true;
-            }
-        } else if (wrapper.dataset.fleetActionSig !== sig) {
+        const sig = this.signatureForButtons(menuNatives);
+        if (wrapper.dataset.fleetActionSig !== sig) {
             const select = wrapper.querySelector('select');
             const confirmBtn = wrapper.querySelector(`button[${MENU_CONTROL_ATTR}]`);
-            this.populateSelect(select, natives);
+            this.populateSelect(select, menuNatives);
             if (select) select.value = '';
             if (confirmBtn) confirmBtn.disabled = true;
             this.syncSelectVisualFromNative(select, null);
@@ -87,10 +106,39 @@ const plugin = {
             .join('\0');
     },
 
-    getNativeActionButtons(row) {
+    /** Native action buttons that are still direct children of the row (menu actions once Flag is moved out). */
+    getMenuNativeButtons(row) {
         return Array.from(row.querySelectorAll(':scope > button')).filter(
             b => !b.hasAttribute(MENU_CONTROL_ATTR)
         );
+    },
+
+    /** All native action buttons that are direct children of the row (pre- and post-inject). */
+    getDirectNativeButtons(row) {
+        return this.getMenuNativeButtons(row);
+    },
+
+    partitionActionButtons(buttons) {
+        const flags = [];
+        const menu = [];
+        for (const b of buttons) {
+            const t = (b.textContent || '').trim();
+            if (t.includes('Flag as Bug')) flags.push(b);
+            else menu.push(b);
+        }
+        return { flags, menu };
+    },
+
+    ensureFlagWrap(row, flags) {
+        if (!flags.length) return null;
+        const wrap = document.createElement('div');
+        wrap.setAttribute(FLAG_WRAP_ATTR, '1');
+        wrap.setAttribute('data-fleet-plugin', this.id);
+        wrap.className = 'w-full min-w-0 flex flex-col gap-2';
+        for (const b of flags) {
+            wrap.appendChild(b);
+        }
+        return wrap;
     },
 
     findResolutionPanel() {
@@ -164,8 +212,25 @@ const plugin = {
 }
 .${ROW_CLASS} {
     position: relative !important;
-    flex-wrap: wrap !important;
+    flex-direction: column !important;
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    flex-wrap: nowrap !important;
     gap: 0.5rem !important;
+    min-width: 0 !important;
+}
+.${ROW_CLASS} [${FLAG_WRAP_ATTR}] {
+    width: 100% !important;
+}
+.${ROW_CLASS} [${FLAG_WRAP_ATTR}] > button {
+    width: 100% !important;
+    box-sizing: border-box !important;
+}
+.${ROW_CLASS} [${MENU_ROOT_ATTR}] {
+    display: flex !important;
+    flex-flow: row nowrap !important;
+    align-items: center !important;
+    width: 100% !important;
     min-width: 0 !important;
 }
 select.${SELECT_CLASS_HOOK} {
@@ -228,18 +293,18 @@ select.${SELECT_CLASS_HOOK} {
     syncSelectVisualFromNative(select, nativeButton) {
         if (!select) return;
         if (!nativeButton) {
-            select.className = SELECT_NEUTRAL_CLASSES;
+            select.className = [SELECT_NEUTRAL_CLASSES, SELECT_LAYOUT_CLASSES].join(' ');
             return;
         }
         const tokens = this.mirroredClassTokensFromButton(nativeButton);
-        select.className = [...tokens, SELECT_CLASS_HOOK].join(' ');
+        select.className = [...tokens, SELECT_CLASS_HOOK, SELECT_LAYOUT_CLASSES].join(' ');
     },
 
     buildMenuWrapper(row, natives, sig) {
         const wrap = document.createElement('div');
         wrap.setAttribute(MENU_ROOT_ATTR, '1');
         wrap.setAttribute('data-fleet-plugin', this.id);
-        wrap.className = 'flex flex-wrap gap-2 items-center';
+        wrap.className = 'flex flex-row flex-nowrap gap-2 items-center w-full min-w-0';
         wrap.dataset.fleetActionSig = sig;
 
         const select = document.createElement('select');
@@ -249,7 +314,7 @@ select.${SELECT_CLASS_HOOK} {
         this.populateSelect(select, natives);
 
         const confirmClass =
-            'inline-flex items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-9 px-4';
+            'inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-sm text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-9 px-4';
 
         const confirmBtn = document.createElement('button');
         confirmBtn.type = 'button';
@@ -261,7 +326,7 @@ select.${SELECT_CLASS_HOOK} {
 
         select.addEventListener('change', () => {
             confirmBtn.disabled = select.value === '';
-            const nativesNow = this.getNativeActionButtons(row);
+            const nativesNow = this.getMenuNativeButtons(row);
             const idx = select.value === '' ? -1 : parseInt(select.value, 10);
             const native =
                 idx >= 0 && idx < nativesNow.length ? nativesNow[idx] : null;
@@ -276,7 +341,7 @@ select.${SELECT_CLASS_HOOK} {
 
     handleConfirm(row, select, confirmBtn) {
         const idx = parseInt(select.value, 10);
-        const natives = this.getNativeActionButtons(row);
+        const natives = this.getMenuNativeButtons(row);
         if (
             select.value === '' ||
             Number.isNaN(idx) ||

--- a/plugins/archetypes/dispute-detail/main/dispute-scenario-near-prompt.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-scenario-near-prompt.js
@@ -1,0 +1,195 @@
+// ============= dispute-scenario-near-prompt.js =============
+// Expands the native "Scenario / User Story" collapsible, clones it in an always-open
+// form above the task prompt card, and hides the original block with CSS only.
+
+const STYLE_ID = 'fleet-dispute-scenario-near-prompt-style';
+const SCENARIO_LABEL = 'Scenario / User Story';
+
+const plugin = {
+    id: 'disputeScenarioNearPrompt',
+    name: 'Dispute Scenario Near Prompt',
+    description:
+        'Moves Scenario / User Story above the task prompt (expanded clone; original hidden with CSS)',
+    _version: '1.1',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        completed: false,
+        inProgress: false,
+        observer: null,
+        timeoutId: null,
+        missingLogged: false
+    },
+
+    onMutation(state) {
+        if (state.completed || document.querySelector('[data-fleet-dispute-scenario-near-prompt]')) {
+            state.completed = true;
+            return;
+        }
+        if (state.inProgress) return;
+
+        const btn = this.findScenarioButton();
+        if (!btn) {
+            if (!state.missingLogged) {
+                Logger.debug('Dispute Scenario Near Prompt: Scenario / User Story control not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        const sourceRoot = btn.closest('div[data-state]');
+        if (!sourceRoot || !sourceRoot.parentElement) {
+            Logger.warn('Dispute Scenario Near Prompt: collapsible root not found');
+            return;
+        }
+
+        const promptCard = this.findPromptCard();
+        if (!promptCard || !promptCard.parentElement) {
+            Logger.debug('Dispute Scenario Near Prompt: task prompt card not found yet');
+            return;
+        }
+
+        state.inProgress = true;
+        this.beginExpandAndRelocate(state, btn, sourceRoot, promptCard);
+    },
+
+    findScenarioButton() {
+        const spans = document.querySelectorAll('span.text-sm.font-medium');
+        for (const s of spans) {
+            if ((s.textContent || '').trim() !== SCENARIO_LABEL) continue;
+            const b = s.closest('button[type="button"]');
+            if (b) return b;
+        }
+        return null;
+    },
+
+    findPromptCard() {
+        const disputesBack = document.querySelector('a[href="/work/problems/disputes"]');
+        const host = disputesBack?.closest('div.p-4');
+        const card = host?.querySelector(':scope > div.rounded-xl.text-card-foreground.border.bg-card');
+        if (card?.querySelector('pre.text-sm.whitespace-pre-wrap')) return card;
+        const pre = document.querySelector('pre.text-sm.whitespace-pre-wrap.font-mono.text-foreground');
+        return pre?.closest('div.rounded-xl.text-card-foreground.border.bg-card') || null;
+    },
+
+    beginExpandAndRelocate(state, btn, sourceRoot, promptCard) {
+        const panel = btn.nextElementSibling;
+        if (!panel || !(panel instanceof HTMLElement)) {
+            Logger.warn('Dispute Scenario Near Prompt: collapsible panel sibling missing');
+            state.inProgress = false;
+            return;
+        }
+
+        const finalize = () => {
+            if (state.completed) return;
+            if (state.timeoutId) {
+                clearTimeout(state.timeoutId);
+                state.timeoutId = null;
+            }
+            if (state.observer) {
+                state.observer.disconnect();
+                state.observer = null;
+            }
+            try {
+                this.installScenarioClone(sourceRoot, promptCard);
+                sourceRoot.setAttribute('data-fleet-dispute-scenario-original', 'true');
+                this.ensureHideOriginalStyle();
+                state.completed = true;
+                Logger.log(
+                    'Dispute Scenario Near Prompt: expanded, cloned Scenario / User Story above task prompt (original hidden)'
+                );
+            } catch (e) {
+                Logger.error('Dispute Scenario Near Prompt: relocation failed', e);
+            } finally {
+                state.inProgress = false;
+            }
+        };
+
+        const tryFinalize = () => {
+            if (state.completed) return;
+            const expanded = btn.getAttribute('aria-expanded') === 'true';
+            const notHidden = !panel.hasAttribute('hidden');
+            const hasContent =
+                panel.querySelector(':scope > *') != null || (panel.textContent || '').trim().length > 0;
+            if (expanded && notHidden && hasContent) {
+                finalize();
+            }
+        };
+
+        if (btn.getAttribute('aria-expanded') === 'false') {
+            btn.click();
+        }
+
+        tryFinalize();
+        if (state.completed) return;
+
+        state.observer = new MutationObserver(() => tryFinalize());
+        state.observer.observe(sourceRoot, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['hidden', 'data-state', 'aria-expanded', 'style']
+        });
+
+        state.timeoutId = setTimeout(() => {
+            state.timeoutId = null;
+            if (state.completed) return;
+            if (state.observer) {
+                state.observer.disconnect();
+                state.observer = null;
+            }
+            state.inProgress = false;
+            Logger.warn('Dispute Scenario Near Prompt: timed out waiting for scenario content to expand');
+        }, 12000);
+    },
+
+    installScenarioClone(sourceRoot, promptCard) {
+        const clone = sourceRoot.cloneNode(true);
+        clone.removeAttribute('data-fleet-dispute-scenario-original');
+        clone.querySelectorAll('[id]').forEach((el) => el.removeAttribute('id'));
+        clone.querySelectorAll('[aria-controls]').forEach((el) => el.removeAttribute('aria-controls'));
+        this.forceCloneExpanded(clone);
+
+        const wrap = document.createElement('div');
+        wrap.className = 'mb-4';
+        wrap.dataset.fleetDisputeScenarioNearPrompt = 'true';
+        wrap.appendChild(clone);
+
+        promptCard.insertAdjacentElement('beforebegin', wrap);
+    },
+
+    forceCloneExpanded(root) {
+        const chevronExpanded = 'm6 9 6 6 6-6';
+        root.querySelectorAll('[data-state]').forEach((el) => el.setAttribute('data-state', 'open'));
+        root.querySelectorAll('[hidden]').forEach((el) => el.removeAttribute('hidden'));
+        const headerBtn = root.querySelector(':scope > button[type="button"]');
+        if (headerBtn) {
+            headerBtn.setAttribute('aria-expanded', 'true');
+            headerBtn.style.pointerEvents = 'none';
+            const path = headerBtn.querySelector(':scope > svg path');
+            if (path) path.setAttribute('d', chevronExpanded);
+        }
+        root.querySelectorAll('[style]').forEach((el) => {
+            const st = (el.getAttribute('style') || '').toLowerCase();
+            if (st.includes('display:none') || st.includes('display: none')) {
+                el.style.display = '';
+            }
+        });
+    },
+
+    ensureHideOriginalStyle() {
+        if (document.getElementById(STYLE_ID)) return;
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+[data-fleet-dispute-scenario-original] {
+    display: none !important;
+}
+`;
+        (document.head || document.documentElement).appendChild(style);
+        Logger.log('Dispute Scenario Near Prompt: injected CSS to hide original scenario block');
+    }
+};

--- a/plugins/archetypes/dispute-detail/main/dispute-screenshot-upload-improvement.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-screenshot-upload-improvement.js
@@ -3,7 +3,9 @@
 // dispute resolution screenshot <input type="file"> (original label visually hidden).
 
 const STYLE_ID = 'fleet-dispute-screenshot-upload-improvement-style';
+const CONTROLS_WRAP_ATTR = 'data-fleet-screenshot-improvement-controls';
 const UPLOAD_CONTROL_ATTR = 'data-fleet-screenshot-upload-improvement';
+const PASTE_BUTTON_ATTR = 'data-fleet-screenshot-paste-image';
 const NATIVE_LABEL_ATTR = 'data-fleet-screenshot-native-label';
 const FILE_INPUT_ATTR = 'data-fleet-screenshot-forward-input';
 const ZONE_WRAP_ATTR = 'data-fleet-screenshot-zone';
@@ -12,8 +14,11 @@ const MAX_FILES = 5;
 const MAX_BYTES = 5 * 1024 * 1024;
 
 const UPLOAD_CONTROL_CLASS =
-    'flex w-full items-center gap-2 px-3 py-2 rounded-md border border-dashed border-border ' +
+    'flex flex-1 min-w-0 items-center justify-center gap-2 px-3 py-2 rounded-md border border-dashed border-border ' +
     'hover:border-brand/50 hover:bg-muted/50 cursor-pointer transition-colors';
+const PASTE_BUTTON_CLASS =
+    'inline-flex shrink-0 items-center justify-center gap-2 px-3 py-2 rounded-md border border-dashed border-border ' +
+    'hover:border-brand/50 hover:bg-muted/50 cursor-pointer transition-colors text-sm';
 const DRAG_OVER_CLASSES = ['ring-2', 'ring-brand/50'];
 
 function imageFilesFromFileList(list) {
@@ -52,8 +57,8 @@ const plugin = {
     id: 'disputeScreenshotUploadImprovement',
     name: 'Dispute Screenshot Upload Improvement',
     description:
-        'Replaces the resolution screenshot control with a full-width zone supporting click, drag-and-drop, and paste; forwards files to the native input',
-    _version: '1.1',
+        'Replaces the resolution screenshot control with drag-drop/upload and paste-image controls; forwards files to the native input',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -76,12 +81,16 @@ const plugin = {
         state.missingLogged = false;
 
         const { label, input } = found;
-        if (label.previousElementSibling?.getAttribute(UPLOAD_CONTROL_ATTR)) {
-            this.ensurePasteListener(state);
-            return;
+        const zone = label.parentElement;
+        if (zone) {
+            this.removeDuplicateImprovementControls(zone, label);
+            if (zone.querySelector(`[${CONTROLS_WRAP_ATTR}]`) && zone.contains(label)) {
+                this.ensurePasteListener(state);
+                return;
+            }
         }
 
-        const innerWrap = label.parentElement;
+        const innerWrap = zone;
         if (innerWrap && !innerWrap.hasAttribute(ZONE_WRAP_ATTR)) {
             innerWrap.setAttribute(ZONE_WRAP_ATTR, '1');
             innerWrap.classList.add('relative');
@@ -90,14 +99,18 @@ const plugin = {
         label.setAttribute(NATIVE_LABEL_ATTR, '1');
         input.setAttribute(FILE_INPUT_ATTR, '1');
 
+        const row = document.createElement('div');
+        row.setAttribute(CONTROLS_WRAP_ATTR, '1');
+        row.setAttribute('data-fleet-plugin', this.id);
+        row.className = 'flex flex-row flex-wrap gap-2 w-full min-w-0';
+
         const uploadControl = document.createElement('button');
         uploadControl.type = 'button';
         uploadControl.setAttribute(UPLOAD_CONTROL_ATTR, '1');
-        uploadControl.setAttribute('data-fleet-plugin', this.id);
         uploadControl.className = UPLOAD_CONTROL_CLASS;
         uploadControl.setAttribute(
             'aria-label',
-            'Add screenshots — click to choose files, or drop / paste images here'
+            'Drag and drop images here or click to upload screenshots'
         );
         uploadControl.innerHTML = `
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 shrink-0" aria-hidden="true">
@@ -107,7 +120,7 @@ const plugin = {
   <circle cx="9" cy="9" r="2"></circle>
   <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
 </svg>
-<span class="text-sm">Add screenshots</span>
+<span class="text-sm whitespace-nowrap">Drag &amp; Drop/Upload</span>
 `;
 
         let dragDepth = 0;
@@ -146,13 +159,85 @@ const plugin = {
         uploadControl.addEventListener('dragover', onDragOver);
         uploadControl.addEventListener('drop', onDrop);
 
-        label.parentNode.insertBefore(uploadControl, label);
+        const pasteBtn = document.createElement('button');
+        pasteBtn.type = 'button';
+        pasteBtn.setAttribute(PASTE_BUTTON_ATTR, '1');
+        pasteBtn.className = PASTE_BUTTON_CLASS;
+        pasteBtn.textContent = 'Paste Image';
+        pasteBtn.setAttribute('aria-label', 'Paste image from clipboard');
+        pasteBtn.addEventListener('click', () => {
+            this.pasteImageFromClipboardApi(input);
+        });
+
+        row.appendChild(uploadControl);
+        row.appendChild(pasteBtn);
+        label.parentNode.insertBefore(row, label);
 
         this.ensurePasteListener(state);
 
         if (!state.injectedLogged) {
-            Logger.log('Dispute screenshot upload improvement: full-width control injected');
+            Logger.log('Dispute screenshot upload improvement: controls row injected');
             state.injectedLogged = true;
+        }
+    },
+
+    /**
+     * React inserts the thumbnail row between our controls and the label, so
+     * label.previousElementSibling is no longer the upload button. Scope checks
+     * to the zone and remove any stray duplicate controls from older runs.
+     */
+    removeDuplicateImprovementControls(zone, label) {
+        if (!zone.contains(label)) return;
+
+        const wraps = zone.querySelectorAll(`[${CONTROLS_WRAP_ATTR}]`);
+        for (let i = 1; i < wraps.length; i++) {
+            wraps[i].remove();
+        }
+
+        const primaryWrap = zone.querySelector(`[${CONTROLS_WRAP_ATTR}]`);
+        if (primaryWrap) {
+            zone.querySelectorAll(`button[${UPLOAD_CONTROL_ATTR}]`).forEach(btn => {
+                if (!primaryWrap.contains(btn)) btn.remove();
+            });
+            zone.querySelectorAll(`button[${PASTE_BUTTON_ATTR}]`).forEach(btn => {
+                if (!primaryWrap.contains(btn)) btn.remove();
+            });
+            return;
+        }
+
+        zone.querySelectorAll(`button[${UPLOAD_CONTROL_ATTR}]`).forEach(btn => btn.remove());
+        zone.querySelectorAll(`button[${PASTE_BUTTON_ATTR}]`).forEach(btn => btn.remove());
+    },
+
+    async pasteImageFromClipboardApi(input) {
+        if (!navigator.clipboard || typeof navigator.clipboard.read !== 'function') {
+            Logger.warn(
+                'Dispute screenshot upload improvement: Clipboard read API not available in this browser'
+            );
+            return;
+        }
+        try {
+            const items = await navigator.clipboard.read();
+            const files = [];
+            for (const item of items) {
+                for (const type of item.types) {
+                    if (!type.startsWith('image/')) continue;
+                    const blob = await item.getType(type);
+                    const sub = type.split('/')[1] || 'png';
+                    const safeExt = sub.replace(/[^a-z0-9]/gi, '') || 'png';
+                    files.push(
+                        new File([blob], `paste-${Date.now()}.${safeExt}`, { type: blob.type || type })
+                    );
+                    break;
+                }
+            }
+            if (!files.length) {
+                Logger.info('Dispute screenshot upload improvement: clipboard had no image');
+                return;
+            }
+            this.mergeIntoFileInput(input, files);
+        } catch (err) {
+            Logger.error('Dispute screenshot upload improvement: clipboard read failed', err);
         }
     },
 

--- a/plugins/archetypes/dispute-detail/main/dispute-screenshot-upload-improvement.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-screenshot-upload-improvement.js
@@ -1,0 +1,250 @@
+// ============= dispute-screenshot-upload-improvement.js =============
+// Full-width drop/paste/click zone that forwards image files to the native
+// dispute resolution screenshot <input type="file"> (original label visually hidden).
+
+const STYLE_ID = 'fleet-dispute-screenshot-upload-improvement-style';
+const UPLOAD_CONTROL_ATTR = 'data-fleet-screenshot-upload-improvement';
+const NATIVE_LABEL_ATTR = 'data-fleet-screenshot-native-label';
+const FILE_INPUT_ATTR = 'data-fleet-screenshot-forward-input';
+const ZONE_WRAP_ATTR = 'data-fleet-screenshot-zone';
+
+const MAX_FILES = 5;
+const MAX_BYTES = 5 * 1024 * 1024;
+
+const UPLOAD_CONTROL_CLASS =
+    'flex w-full items-center gap-2 px-3 py-2 rounded-md border border-dashed border-border ' +
+    'hover:border-brand/50 hover:bg-muted/50 cursor-pointer transition-colors';
+const DRAG_OVER_CLASSES = ['ring-2', 'ring-brand/50'];
+
+function imageFilesFromFileList(list) {
+    if (!list || !list.length) return [];
+    return Array.from(list).filter(f => f.type && f.type.startsWith('image/'));
+}
+
+function imageFilesFromClipboard(clipboardData) {
+    if (!clipboardData) return [];
+    const fromFiles = imageFilesFromFileList(clipboardData.files);
+    if (fromFiles.length) return fromFiles;
+    const items = clipboardData.items;
+    if (!items) return [];
+    const out = [];
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.kind !== 'file') continue;
+        const f = item.getAsFile();
+        if (f && f.type.startsWith('image/')) out.push(f);
+    }
+    return out;
+}
+
+function shouldIgnorePasteTarget(target) {
+    if (!target || target.nodeType !== Node.ELEMENT_NODE) return false;
+    const el = target;
+    if (el.closest('textarea, select, [contenteditable="true"]')) return true;
+    const inp = el.closest('input');
+    if (!inp) return false;
+    const type = (inp.getAttribute('type') || 'text').toLowerCase();
+    const passthrough = new Set(['file', 'button', 'submit', 'reset', 'checkbox', 'radio', 'hidden']);
+    return !passthrough.has(type);
+}
+
+const plugin = {
+    id: 'disputeScreenshotUploadImprovement',
+    name: 'Dispute Screenshot Upload Improvement',
+    description:
+        'Replaces the resolution screenshot control with a full-width zone supporting click, drag-and-drop, and paste; forwards files to the native input',
+    _version: '1.1',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleReady: false,
+        missingLogged: false,
+        injectedLogged: false,
+        pasteListenerAttached: false
+    },
+
+    onMutation(state) {
+        this.ensureStyles(state);
+        const found = this.findNativeScreenshotControl();
+        if (!found) {
+            if (!state.missingLogged) {
+                Logger.debug('Dispute screenshot upload improvement: native file control not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        const { label, input } = found;
+        if (label.previousElementSibling?.getAttribute(UPLOAD_CONTROL_ATTR)) {
+            this.ensurePasteListener(state);
+            return;
+        }
+
+        const innerWrap = label.parentElement;
+        if (innerWrap && !innerWrap.hasAttribute(ZONE_WRAP_ATTR)) {
+            innerWrap.setAttribute(ZONE_WRAP_ATTR, '1');
+            innerWrap.classList.add('relative');
+        }
+
+        label.setAttribute(NATIVE_LABEL_ATTR, '1');
+        input.setAttribute(FILE_INPUT_ATTR, '1');
+
+        const uploadControl = document.createElement('button');
+        uploadControl.type = 'button';
+        uploadControl.setAttribute(UPLOAD_CONTROL_ATTR, '1');
+        uploadControl.setAttribute('data-fleet-plugin', this.id);
+        uploadControl.className = UPLOAD_CONTROL_CLASS;
+        uploadControl.setAttribute(
+            'aria-label',
+            'Add screenshots — click to choose files, or drop / paste images here'
+        );
+        uploadControl.innerHTML = `
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 shrink-0" aria-hidden="true">
+  <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"></path>
+  <line x1="16" x2="22" y1="5" y2="5"></line>
+  <line x1="19" x2="19" y1="2" y2="8"></line>
+  <circle cx="9" cy="9" r="2"></circle>
+  <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
+</svg>
+<span class="text-sm">Add screenshots</span>
+`;
+
+        let dragDepth = 0;
+        const onDragEnter = e => {
+            e.preventDefault();
+            e.stopPropagation();
+            dragDepth++;
+            uploadControl.classList.add(...DRAG_OVER_CLASSES);
+        };
+        const onDragLeave = e => {
+            e.preventDefault();
+            e.stopPropagation();
+            dragDepth = Math.max(0, dragDepth - 1);
+            if (dragDepth === 0) uploadControl.classList.remove(...DRAG_OVER_CLASSES);
+        };
+        const onDragOver = e => {
+            e.preventDefault();
+            e.stopPropagation();
+        };
+        const onDrop = e => {
+            e.preventDefault();
+            e.stopPropagation();
+            dragDepth = 0;
+            uploadControl.classList.remove(...DRAG_OVER_CLASSES);
+            const files = imageFilesFromFileList(e.dataTransfer && e.dataTransfer.files);
+            if (files.length) {
+                this.mergeIntoFileInput(input, files);
+            }
+        };
+
+        uploadControl.addEventListener('click', () => {
+            input.click();
+        });
+        uploadControl.addEventListener('dragenter', onDragEnter);
+        uploadControl.addEventListener('dragleave', onDragLeave);
+        uploadControl.addEventListener('dragover', onDragOver);
+        uploadControl.addEventListener('drop', onDrop);
+
+        label.parentNode.insertBefore(uploadControl, label);
+
+        this.ensurePasteListener(state);
+
+        if (!state.injectedLogged) {
+            Logger.log('Dispute screenshot upload improvement: full-width control injected');
+            state.injectedLogged = true;
+        }
+    },
+
+    ensurePasteListener(state) {
+        if (state.pasteListenerAttached) return;
+        state.pasteListenerAttached = true;
+        document.addEventListener(
+            'paste',
+            ev => {
+                const files = imageFilesFromClipboard(ev.clipboardData);
+                if (!files.length) return;
+                if (shouldIgnorePasteTarget(ev.target)) return;
+                const input = document.querySelector(`input[${FILE_INPUT_ATTR}]`);
+                if (!input || !document.contains(input)) return;
+                ev.preventDefault();
+                ev.stopPropagation();
+                this.mergeIntoFileInput(input, files);
+            },
+            true
+        );
+        Logger.debug('Dispute screenshot upload improvement: document paste listener attached');
+    },
+
+    findNativeScreenshotControl() {
+        const labels = document.querySelectorAll('label');
+        for (const label of labels) {
+            const input = label.querySelector('input[type="file"][accept*="image"]');
+            if (!input || !input.multiple) continue;
+            const span = label.querySelector('span.text-sm');
+            const t = ((span && span.textContent) || '').trim().replace(/\s+/g, ' ');
+            if (t.includes('Add screenshots')) {
+                return { label, input };
+            }
+        }
+        return null;
+    },
+
+    ensureStyles(state) {
+        if (state.styleReady && document.getElementById(STYLE_ID)) return;
+        let style = document.getElementById(STYLE_ID);
+        if (!style) {
+            style = document.createElement('style');
+            style.id = STYLE_ID;
+            style.setAttribute('data-fleet-plugin', this.id);
+            document.head.appendChild(style);
+        }
+        style.textContent = `
+label[${NATIVE_LABEL_ATTR}] {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    clip-path: inset(50%) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+`;
+        state.styleReady = true;
+    },
+
+    mergeIntoFileInput(input, newFiles) {
+        const dt = new DataTransfer();
+        const existing = Array.from(input.files || []);
+        for (const f of existing) {
+            if (dt.items.length >= MAX_FILES) break;
+            dt.items.add(f);
+        }
+        for (const f of newFiles) {
+            if (f.size > MAX_BYTES) {
+                Logger.warn(
+                    `Dispute screenshot upload improvement: skipped "${f.name}" (over ${MAX_BYTES / (1024 * 1024)}MB)`
+                );
+                continue;
+            }
+            if (dt.items.length >= MAX_FILES) {
+                Logger.warn(
+                    `Dispute screenshot upload improvement: max ${MAX_FILES} screenshots; extra file(s) ignored`
+                );
+                break;
+            }
+            dt.items.add(f);
+        }
+        const beforeLen = input.files ? input.files.length : 0;
+        if (dt.files.length === beforeLen) {
+            return;
+        }
+        input.files = dt.files;
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        Logger.debug(`Dispute screenshot upload improvement: ${input.files.length} file(s) on native input`);
+    }
+};

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -6,7 +6,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '6.7',
+    _version: '6.8',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
     
@@ -54,6 +54,8 @@ const plugin = {
         const isBound = settingsBtn.dataset.wfSettingsBound === 'true';
         
         if (!isBound || !isAlreadyPulsing) {
+            const bgTranslucent = 'color-mix(in srgb, var(--background, white) 30%, transparent)';
+            const bgOpaque = 'var(--background, white)';
             const baseStyles = `
                 position: fixed;
                 bottom: 20px;
@@ -61,7 +63,7 @@ const plugin = {
                 width: 48px;
                 height: 48px;
                 border-radius: 50%;
-                background: var(--background, white);
+                background: ${shouldPulse ? bgOpaque : bgTranslucent};
                 border: 1px solid #60a5fa;
                 box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
                 display: flex;
@@ -69,7 +71,7 @@ const plugin = {
                 justify-content: center;
                 cursor: pointer;
                 z-index: 9999;
-                transition: ${shouldPulse ? 'border 1s ease, box-shadow 1s ease' : 'all 0.2s'};
+                transition: ${shouldPulse ? 'border 1s ease, box-shadow 1s ease' : 'background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease'};
             `;
             
             settingsBtn.style.cssText = baseStyles;
@@ -99,6 +101,7 @@ const plugin = {
         settingsBtn.dataset.wfSettingsBound = 'true';
 
         settingsBtn.addEventListener('mouseenter', () => {
+            settingsBtn.style.background = 'var(--background, white)';
             settingsBtn.style.transform = 'scale(1.1)';
             settingsBtn.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.15)';
         });
@@ -106,6 +109,13 @@ const plugin = {
         settingsBtn.addEventListener('mouseleave', () => {
             settingsBtn.style.transform = 'scale(1)';
             settingsBtn.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.1)';
+            const solidBg =
+                Context.isOutdated ||
+                (Context.isDevBranch && this._getPulseOverrideEnabled()) ||
+                settingsBtn.classList.contains('wf-settings-outdated');
+            settingsBtn.style.background = solidBg
+                ? 'var(--background, white)'
+                : 'color-mix(in srgb, var(--background, white) 30%, transparent)';
         });
 
         settingsBtn.addEventListener('click', () => this._toggleModal());
@@ -123,7 +133,8 @@ const plugin = {
         // Ensure smooth transitions
         settingsBtn.style.transition = 'border 1s ease, box-shadow 1s ease';
         
-        // Set initial state (start with red outline)
+        // Set initial state (start with red outline); keep fill solid while update is highlighted
+        settingsBtn.style.background = 'var(--background, white)';
         settingsBtn.style.border = '2px solid #dc2626';
         settingsBtn.style.boxShadow = '0 2px 8px rgba(220, 38, 38, 0.4)';
         
@@ -149,6 +160,12 @@ const plugin = {
         if (settingsBtn) {
             settingsBtn.style.border = '1px solid #60a5fa';
             settingsBtn.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.1)';
+            if (settingsBtn.matches(':hover')) {
+                settingsBtn.style.background = 'var(--background, white)';
+            } else {
+                settingsBtn.style.background =
+                    'color-mix(in srgb, var(--background, white) 30%, transparent)';
+            }
         }
     },
     


### PR DESCRIPTION
## Summary

This PR improves the dispute-detail workflow: the resolution action menu is simplified by moving **Flag as Bug** out on its own, screenshot handling is reworked under a renamed upload-improvement plugin (with safer row behavior and a **Paste Image** affordance), and two new UX plugins surface the **scenario near the prompt** and add an **ephemeral QA scratchpad**. Core settings UI gets a minor visual tweak (translucent settings button fill by default), with README and feature docs updated to match `archetypes.json`.

## Changes

- **`dispute-resolution-action-menu.js`**: Split **Flag as Bug** from the main resolution menu so actions stay focused; related wiring and behavior updates.
- **`dispute-screenshot-upload-improvement.js`**: Renamed/refactored from the prior screenshot plugin; upload row idempotency fixes plus **Paste Image** support.
- **`dispute-scenario-near-prompt.js`**: New plugin to place scenario context adjacent to the prompt for quicker scanning.
- **`dispute-prompt-scratchpad.js`**: New ephemeral scratchpad for QA-style notes (placeholder and spacing polish in a follow-up commit).
- **`settings-ui.js`**: Translucent fill for the settings control by default (version 6.8 per commit).
- **`fleet.user.js`**, **`archetypes.json`**: Load list and bootstrap alignment for the new and renamed plugins.
- **`README.md`**, **`docs/settings-modal/features-tab.md`**: Documentation synced with shipped features.

## New / notable plugins

| Plugin | Role |
|--------|------|
| `dispute-scenario-near-prompt.js` | Shows scenario content near the prompt on dispute detail. |
| `dispute-prompt-scratchpad.js` | Lightweight scratchpad for QA notes (ephemeral). |
| `dispute-screenshot-upload-improvement.js` | Screenshot/upload row improvements; Paste Image; replaces prior screenshot-focused plugin. |

## Commit history

- `4a25e40` fix(dispute-detail): QA Scratchpad placeholder + margin above toggle
- `51648ea` feat(dispute-detail): scenario above prompt + ephemeral scratchpad
- `6ec5c17` settings-ui (6.8): translucent settings button fill by default
- `bbee9c2` fix(dispute-detail): screenshot upload row idempotency + Paste Image button
- `0261eff` refactor(dispute-detail): rename screenshot plugin to upload improvement
- `0933517` feat(dispute-detail): split Flag as Bug out of resolution action menu

## Stats

```
 README.md                                          |   3 +-
 archetypes.json                                    |  30 +-
 docs/settings-modal/features-tab.md                |   7 +-
 fleet.user.js                                      |   8 +-
 .../main/dispute-prompt-scratchpad.js              | 113 +++++++
 .../main/dispute-resolution-action-menu.js         | 119 ++++++--
 .../main/dispute-scenario-near-prompt.js           | 195 ++++++++++++
 .../main/dispute-screenshot-upload-improvement.js  | 335 +++++++++++++++++++++
 plugins/core/main/settings-ui.js                   |  25 +-
 9 files changed, 791 insertions(+), 44 deletions(-)
```
