### PR TITLE
Dispute detail: header layout in scenario-near-prompt, deprecate Task ID plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text
 - **Create Instance Autoclick**: Automatically clicks the "Create Instance" button once when it becomes visible.
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
-- **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
 - **Dispute Screenshot Upload Improvement**: Drag & Drop/Upload plus Paste Image (clipboard API) in one row; document paste; forwards images to the hidden native file input without duplicate controls after thumbnails appear
 - **Dispute Tool Environment Gate**: Detects tool environment readiness for dispute detail pages

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.21",
+  "archetypesVersion": "7.23",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -37,7 +37,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.15"
+      "version": "1.16"
     }
   ],
   "archetypes": [
@@ -535,12 +535,6 @@
           "name": "dispute-resolution-action-menu.js",
           "version": "1.3",
           "hash": "sha256-d08ed2518a117f8fb9be74b2e1716ee0f13d04f8516fd3ba8f6f48ee5ab93e9f",
-          "log": false
-        },
-        {
-          "name": "dispute-detail-task-id.js",
-          "version": "1.3",
-          "hash": "sha256-4be08aaa48f9dc27f4d7e44506fcaf8a19ee8f160eb37606e809e8b7f3b2dc93",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.20",
+  "archetypesVersion": "7.21",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -539,8 +539,8 @@
         },
         {
           "name": "dispute-detail-task-id.js",
-          "version": "1.2",
-          "hash": "sha256-5e1f198d5bb5fddc39e6a352e02b051900a63e815a93b6130bfc26ff768ac607",
+          "version": "1.3",
+          "hash": "sha256-4be08aaa48f9dc27f4d7e44506fcaf8a19ee8f160eb37606e809e8b7f3b2dc93",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.1.4",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.19",
+  "archetypesVersion": "7.20",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -539,8 +539,8 @@
         },
         {
           "name": "dispute-detail-task-id.js",
-          "version": "1.1",
-          "hash": "sha256-c5f505ac2b5485867898c9901b8c4faa4420b42da68eda32166bdeed49af58c7",
+          "version": "1.2",
+          "hash": "sha256-5e1f198d5bb5fddc39e6a352e02b051900a63e815a93b6130bfc26ff768ac607",
           "log": false
         },
         {
@@ -557,8 +557,8 @@
         },
         {
           "name": "dispute-scenario-near-prompt.js",
-          "version": "1.1",
-          "hash": "sha256-f233fa419797bc3cc723dff9f75635fa794153003f81bb26f34a93143559fbe7",
+          "version": "1.2",
+          "hash": "sha256-4161e8edd6fdcb3c8f7dcf198592e396b2083432fa7422164f621ea183ebcae8",
           "log": false
         },
         {

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.15
+1.16
 
 ## Features
 
@@ -85,7 +85,6 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text
 - **Create Instance Autoclick**: Automatically clicks the "Create Instance" button once when it becomes visible.
 - **Dispute Resolution Action Menu**: Keeps Flag as Bug as a full-width button above a full-width action dropdown and Confirm; other actions trigger hidden native buttons
-- **Dispute Detail Task ID**: Shows a copyable Task ID in the dispute detail header from the View Task link
 - **Dispute Prompt Scratchpad**: Collapsible notes between the task prompt and writer dispute (default collapsed; not saved across reloads)
 - **Dispute Resolution Widgets Toggle**: Toggle visibility (CSS only) of bottom-right Pylon chat and Report a bug FAB; control in the top bar
 - **Dispute Scenario Near Prompt**: Expands Scenario / User Story, duplicates it above the task prompt in an always-open form, and hides the original block with CSS

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat-dispute-adjustments] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-adjustments/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-adjustments/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat-dispute-adjustments',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat-dispute-adjustments] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      operations-toolkit-admin.vercel.app
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-adjustments/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat-dispute-adjustments/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat-dispute-adjustments',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/deprecated/dispute-detail-task-id.js
+++ b/plugins/archetypes/dispute-detail/deprecated/dispute-detail-task-id.js
@@ -1,5 +1,6 @@
-// ============= dispute-detail-task-id.js =============
-// Injects a copyable Task ID button in the dispute detail header (from View Task link).
+// ============= dispute-detail-task-id.js (deprecated) =============
+// Deprecated: removed from the dispute-detail archetype load list. Kept in-repo for
+// reference; native dispute detail already exposes View Task and timer in the header.
 
 const VIEW_TASK_PATH_PREFIX = '/work/problems/view-task/';
 const COPY_STYLE_ID = 'fleet-dispute-detail-task-id-copy-style';
@@ -9,9 +10,9 @@ const STACK_ATTR = 'data-fleet-dispute-detail-task-id-stack';
 const plugin = {
     id: 'disputeDetailTaskId',
     name: 'Dispute Detail Task ID',
-    description: 'Shows a copyable Task ID in the dispute detail header from the View Task link',
-    _version: '1.3',
-    enabledByDefault: true,
+    description: '[Deprecated] Copyable Task ID in dispute detail header — no longer loaded',
+    _version: '1.4',
+    enabledByDefault: false,
     phase: 'mutation',
     initialState: {
         injectedLogged: false,

--- a/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
@@ -4,12 +4,13 @@
 const VIEW_TASK_PATH_PREFIX = '/work/problems/view-task/';
 const COPY_STYLE_ID = 'fleet-dispute-detail-task-id-copy-style';
 const COPY_BTN_CLASS = 'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-7 rounded-sm pl-2 pr-2 text-xs font-mono';
+const STACK_ATTR = 'data-fleet-dispute-detail-task-id-stack';
 
 const plugin = {
     id: 'disputeDetailTaskId',
     name: 'Dispute Detail Task ID',
     description: 'Shows a copyable Task ID in the dispute detail header from the View Task link',
-    _version: '1.2',
+    _version: '1.3',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -18,7 +19,12 @@ const plugin = {
     },
 
     onMutation(state) {
-        if (document.querySelector('[data-fleet-dispute-detail-task-id-injected]')) {
+        if (document.querySelector(`[${STACK_ATTR}="1"]`)) {
+            return;
+        }
+        const legacyRightGroup = this.findLegacyStackedColumnLayout();
+        if (legacyRightGroup) {
+            this.migrateLegacyStackedToTwoRows(legacyRightGroup, state);
             return;
         }
         const viewTaskLink = document.querySelector(`a[href*="${VIEW_TASK_PATH_PREFIX}"]`);
@@ -40,11 +46,99 @@ const plugin = {
             return;
         }
         const outerRow = rightGroup.parentElement;
-        if (!this.isDisputeHeaderOuterRow(outerRow, rightGroup)) {
+        if (!this.isNativeDisputeHeaderOuterRow(outerRow, rightGroup)) {
             Logger.warn('Dispute Detail Task ID: header outer row validation failed');
             return;
         }
         this.ensureCopyStyle();
+        const taskIdRow = this.buildTaskIdRow(taskId);
+        const rowBottom = this.moveActionsIntoNewRow(rightGroup);
+        rowBottom.setAttribute('data-fleet-dispute-detail-task-id-injected', '1');
+
+        const rowTop = document.createElement('div');
+        rowTop.className = 'flex items-center justify-between w-full';
+        const disputesBack = outerRow.querySelector('a[href="/work/problems/disputes"]');
+        if (!disputesBack) {
+            Logger.warn('Dispute Detail Task ID: Disputes back link missing during inject');
+            return;
+        }
+        rowTop.appendChild(disputesBack);
+        rowTop.appendChild(taskIdRow);
+
+        this.clearElement(outerRow);
+        this.transformOuterRowToStack(outerRow);
+        outerRow.appendChild(rowTop);
+        outerRow.appendChild(rowBottom);
+        outerRow.setAttribute(STACK_ATTR, '1');
+
+        state.missingLogged = false;
+        if (!state.injectedLogged) {
+            Logger.log('Dispute Detail Task ID: injected two-row header (Disputes|Task ID, timer|View Task)');
+            state.injectedLogged = true;
+        }
+    },
+
+    /** v1.2 layout: task-ID column with actions row nested inside */
+    findLegacyStackedColumnLayout() {
+        const injected = document.querySelector('[data-fleet-dispute-detail-task-id-injected]');
+        if (!injected?.classList.contains('flex')) return null;
+        const col = injected.parentElement;
+        if (!col?.classList.contains('flex-col') || !col.classList.contains('items-end')) return null;
+        if (injected !== col.lastElementChild) return null;
+        return injected;
+    },
+
+    migrateLegacyStackedToTwoRows(legacyRightGroup, state) {
+        const rightColumn = legacyRightGroup.parentElement;
+        const outerRow = rightColumn?.parentElement;
+        const taskIdRow = rightColumn?.firstElementChild;
+        if (
+            !outerRow ||
+            !(outerRow instanceof HTMLElement) ||
+            !taskIdRow ||
+            taskIdRow === legacyRightGroup
+        ) {
+            Logger.warn('Dispute Detail Task ID: legacy layout migration failed (unexpected DOM)');
+            return;
+        }
+        const disputesBack = outerRow.querySelector('a[href="/work/problems/disputes"]');
+        if (!disputesBack) {
+            Logger.warn('Dispute Detail Task ID: Disputes back link missing during migration');
+            return;
+        }
+        this.ensureCopyStyle();
+
+        const rowBottom = document.createElement('div');
+        rowBottom.className = 'flex items-center gap-2 justify-between w-full';
+        legacyRightGroup.removeAttribute('data-fleet-dispute-detail-task-id-injected');
+        while (legacyRightGroup.firstChild) {
+            rowBottom.appendChild(legacyRightGroup.firstChild);
+        }
+        legacyRightGroup.remove();
+
+        rightColumn.removeChild(taskIdRow);
+        rightColumn.remove();
+
+        const rowTop = document.createElement('div');
+        rowTop.className = 'flex items-center justify-between w-full';
+        rowTop.appendChild(disputesBack);
+        rowTop.appendChild(taskIdRow);
+
+        this.clearElement(outerRow);
+        this.transformOuterRowToStack(outerRow);
+        outerRow.appendChild(rowTop);
+        outerRow.appendChild(rowBottom);
+        rowBottom.setAttribute('data-fleet-dispute-detail-task-id-injected', '1');
+        outerRow.setAttribute(STACK_ATTR, '1');
+
+        Logger.log('Dispute Detail Task ID: migrated v1.2 header to two-row layout');
+        state.missingLogged = false;
+        if (!state.injectedLogged) {
+            state.injectedLogged = true;
+        }
+    },
+
+    buildTaskIdRow(taskId) {
         const label = document.createElement('span');
         label.className = 'text-xs text-muted-foreground font-medium';
         label.textContent = 'Task:';
@@ -53,24 +147,31 @@ const plugin = {
         taskIdRow.className = 'flex items-center gap-2';
         taskIdRow.appendChild(label);
         taskIdRow.appendChild(copyBtn);
+        return taskIdRow;
+    },
 
-        const rightColumn = document.createElement('div');
-        rightColumn.className = 'flex flex-col items-end gap-1';
+    moveActionsIntoNewRow(rightGroup) {
+        const rowBottom = document.createElement('div');
+        rowBottom.className = 'flex items-center gap-2 justify-between w-full';
+        while (rightGroup.firstChild) {
+            rowBottom.appendChild(rightGroup.firstChild);
+        }
+        rightGroup.remove();
+        return rowBottom;
+    },
 
-        outerRow.insertBefore(rightColumn, rightGroup);
-        rightColumn.appendChild(taskIdRow);
-        rightColumn.appendChild(rightGroup);
-
-        rightGroup.classList.add('justify-between', 'w-full');
-        rightGroup.setAttribute('data-fleet-dispute-detail-task-id-injected', '1');
-        state.missingLogged = false;
-        if (!state.injectedLogged) {
-            Logger.log('Dispute Detail Task ID: injected copyable task ID in header');
-            state.injectedLogged = true;
+    clearElement(el) {
+        while (el.firstChild) {
+            el.removeChild(el.firstChild);
         }
     },
 
-    isDisputeHeaderOuterRow(outerRow, rightGroup) {
+    transformOuterRowToStack(outerRow) {
+        outerRow.classList.remove('items-center', 'justify-between');
+        outerRow.classList.add('flex-col', 'gap-1');
+    },
+
+    isNativeDisputeHeaderOuterRow(outerRow, rightGroup) {
         if (!(outerRow instanceof HTMLElement)) return false;
         if (!outerRow.classList.contains('justify-between')) return false;
         const disputesBack = document.querySelector('a[href="/work/problems/disputes"]');

--- a/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-detail-task-id.js
@@ -9,7 +9,7 @@ const plugin = {
     id: 'disputeDetailTaskId',
     name: 'Dispute Detail Task ID',
     description: 'Shows a copyable Task ID in the dispute detail header from the View Task link',
-    _version: '1.1',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -39,19 +39,43 @@ const plugin = {
             Logger.warn('Dispute Detail Task ID: right header group not found');
             return;
         }
+        const outerRow = rightGroup.parentElement;
+        if (!this.isDisputeHeaderOuterRow(outerRow, rightGroup)) {
+            Logger.warn('Dispute Detail Task ID: header outer row validation failed');
+            return;
+        }
         this.ensureCopyStyle();
         const label = document.createElement('span');
         label.className = 'text-xs text-muted-foreground font-medium';
         label.textContent = 'Task:';
         const copyBtn = this.buildCopyButton(taskId);
-        rightGroup.insertBefore(copyBtn, rightGroup.firstChild);
-        rightGroup.insertBefore(label, rightGroup.firstChild);
+        const taskIdRow = document.createElement('div');
+        taskIdRow.className = 'flex items-center gap-2';
+        taskIdRow.appendChild(label);
+        taskIdRow.appendChild(copyBtn);
+
+        const rightColumn = document.createElement('div');
+        rightColumn.className = 'flex flex-col items-end gap-1';
+
+        outerRow.insertBefore(rightColumn, rightGroup);
+        rightColumn.appendChild(taskIdRow);
+        rightColumn.appendChild(rightGroup);
+
+        rightGroup.classList.add('justify-between', 'w-full');
         rightGroup.setAttribute('data-fleet-dispute-detail-task-id-injected', '1');
         state.missingLogged = false;
         if (!state.injectedLogged) {
             Logger.log('Dispute Detail Task ID: injected copyable task ID in header');
             state.injectedLogged = true;
         }
+    },
+
+    isDisputeHeaderOuterRow(outerRow, rightGroup) {
+        if (!(outerRow instanceof HTMLElement)) return false;
+        if (!outerRow.classList.contains('justify-between')) return false;
+        const disputesBack = document.querySelector('a[href="/work/problems/disputes"]');
+        if (!disputesBack || disputesBack.parentElement !== outerRow) return false;
+        return Array.prototype.indexOf.call(outerRow.children, rightGroup) !== -1;
     },
 
     getTaskIdFromHref(href) {

--- a/plugins/archetypes/dispute-detail/main/dispute-scenario-near-prompt.js
+++ b/plugins/archetypes/dispute-detail/main/dispute-scenario-near-prompt.js
@@ -4,13 +4,15 @@
 
 const STYLE_ID = 'fleet-dispute-scenario-near-prompt-style';
 const SCENARIO_LABEL = 'Scenario / User Story';
+const TASK_PROMPT_HEADER_TEXT = 'Task Prompt';
+const VIEW_TASK_PATH_PREFIX = '/work/problems/view-task/';
 
 const plugin = {
     id: 'disputeScenarioNearPrompt',
     name: 'Dispute Scenario Near Prompt',
     description:
-        'Moves Scenario / User Story above the task prompt (expanded clone; original hidden with CSS)',
-    _version: '1.1',
+        'Moves Scenario / User Story above the task prompt; hides in-header Task Prompt label and adds label above the prompt card',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -19,7 +21,8 @@ const plugin = {
         inProgress: false,
         observer: null,
         timeoutId: null,
-        missingLogged: false
+        missingLogged: false,
+        headerPromptMissingLogged: false
     },
 
     onMutation(state) {
@@ -74,6 +77,44 @@ const plugin = {
         return pre?.closest('div.rounded-xl.text-card-foreground.border.bg-card') || null;
     },
 
+    findNativeHeaderTaskPromptSpan() {
+        const viewLink = document.querySelector(`a[href*="${VIEW_TASK_PATH_PREFIX}"]`);
+        const row = viewLink?.closest('.flex.items-center.gap-2');
+        if (!row) return null;
+        for (const el of row.querySelectorAll('span')) {
+            if ((el.textContent || '').trim() === TASK_PROMPT_HEADER_TEXT) return el;
+        }
+        return null;
+    },
+
+    markHeaderTaskPromptHidden(state) {
+        const span = this.findNativeHeaderTaskPromptSpan();
+        if (!span) {
+            if (!state.headerPromptMissingLogged) {
+                Logger.warn('Dispute Scenario Near Prompt: header Task Prompt label not found to hide');
+                state.headerPromptMissingLogged = true;
+            }
+            return;
+        }
+        state.headerPromptMissingLogged = false;
+        if (span.hasAttribute('data-fleet-dispute-scenario-header-prompt-hidden')) return;
+        span.setAttribute('data-fleet-dispute-scenario-header-prompt-hidden', '1');
+        Logger.log('Dispute Scenario Near Prompt: marked header Task Prompt label for CSS hide');
+    },
+
+    installPromptHeadingAboveCard(promptCard) {
+        if (document.querySelector('[data-fleet-dispute-scenario-prompt-heading="1"]')) return;
+        const wrap = document.createElement('div');
+        wrap.dataset.fleetDisputeScenarioPromptHeading = '1';
+        wrap.className = 'mb-2';
+        const label = document.createElement('span');
+        label.className = 'text-xs font-medium text-muted-foreground';
+        label.textContent = TASK_PROMPT_HEADER_TEXT;
+        wrap.appendChild(label);
+        promptCard.insertAdjacentElement('beforebegin', wrap);
+        Logger.log('Dispute Scenario Near Prompt: inserted Task Prompt label above prompt card');
+    },
+
     beginExpandAndRelocate(state, btn, sourceRoot, promptCard) {
         const panel = btn.nextElementSibling;
         if (!panel || !(panel instanceof HTMLElement)) {
@@ -95,7 +136,9 @@ const plugin = {
             try {
                 this.installScenarioClone(sourceRoot, promptCard);
                 sourceRoot.setAttribute('data-fleet-dispute-scenario-original', 'true');
-                this.ensureHideOriginalStyle();
+                this.ensureHideStyles();
+                this.markHeaderTaskPromptHidden(state);
+                this.installPromptHeadingAboveCard(promptCard);
                 state.completed = true;
                 Logger.log(
                     'Dispute Scenario Near Prompt: expanded, cloned Scenario / User Story above task prompt (original hidden)'
@@ -179,17 +222,33 @@ const plugin = {
         });
     },
 
-    ensureHideOriginalStyle() {
-        if (document.getElementById(STYLE_ID)) return;
-        const style = document.createElement('style');
-        style.id = STYLE_ID;
-        style.setAttribute('data-fleet-plugin', this.id);
-        style.textContent = `
+    ensureHideStyles() {
+        const fullRules = `
 [data-fleet-dispute-scenario-original] {
     display: none !important;
 }
+[data-fleet-dispute-scenario-header-prompt-hidden] {
+    display: none !important;
+}
 `;
+        const headerOnlyRule = `
+[data-fleet-dispute-scenario-header-prompt-hidden] {
+    display: none !important;
+}
+`;
+        let style = document.getElementById(STYLE_ID);
+        if (style) {
+            if (!style.textContent.includes('data-fleet-dispute-scenario-header-prompt-hidden')) {
+                style.textContent = style.textContent.trim() + headerOnlyRule;
+                Logger.log('Dispute Scenario Near Prompt: extended CSS for header Task Prompt hide');
+            }
+            return;
+        }
+        style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = fullRules;
         (document.head || document.documentElement).appendChild(style);
-        Logger.log('Dispute Scenario Near Prompt: injected CSS to hide original scenario block');
+        Logger.log('Dispute Scenario Near Prompt: injected CSS (scenario original + header prompt label hide)');
     }
 };


### PR DESCRIPTION
## Summary

Improves the dispute detail page header layout and task prompt labeling by extending **Dispute Scenario Near Prompt**, then removes the standalone **Dispute Detail Task ID** plugin from the production archetype load list and preserves it under **deprecated** for reference.

## Changes

- **Dispute Scenario Near Prompt** (`dispute-scenario-near-prompt.js`, v1.2): builds a clearer two-row header (Disputes with Task ID on the first row, timer with View Task on the second), hides the redundant in-header “Task Prompt” label, and injects a muted “Task Prompt” label above the prompt card so the scenario block and prompt stay visually separated.
- **Dispute Detail Task ID**: removed from `dispute-detail` plugins in `archetypes.json`; implementation moved from `main/` to `deprecated/` so it is no longer shipped by default but remains in the tree.
- **Docs**: README and `docs/settings-modal/features-tab.md` drop the Task ID feature bullet; features-tab doc version **1.15 → 1.16** with matching `archetypes.json` doc registry and `archetypesVersion` bump already on the branch.

## Plugins

| Plugin | Notes |
|--------|--------|
| `dispute-scenario-near-prompt.js` | 1.1 → **1.2** (header + prompt label behavior) |
| `dispute-detail-task-id.js` | Removed from dispute-detail **main** load list; file lives under **deprecated** |

## Commit history

*(Sync branch config commits omitted.)*

- `5d0ff2f` chore(dispute-detail): deprecate Dispute Detail Task ID plugin
- `529166b` fix(dispute-detail): two-row header — Disputes|Task ID, then timer|View Task
- `d318c0d` feat(dispute-detail): header task column + prompt label near card

**Meaningful commits:** 3

## Stats

```
 README.md                                          |   1 -
 archetypes.json                                    |  14 +-
 docs/settings-modal/features-tab.md                |   3 +-
 .../deprecated/dispute-detail-task-id.js           | 251 +++++++++++++++++++++
 .../dispute-detail/main/dispute-detail-task-id.js  | 125 ----------
 .../main/dispute-scenario-near-prompt.js           |  81 ++++++-
 6 files changed, 326 insertions(+), 149 deletions(-)
```
