### PR TITLE
Add no-vnc archetype with clipboard bridge for noVNC pages

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -2,7 +2,7 @@
   "version": "7.2.1",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.59",
+  "archetypesVersion": "7.60",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -583,8 +583,8 @@
       "plugins": [
         {
           "name": "clipboard-bridge.js",
-          "version": "1.0",
-          "hash": "sha256-3259d9c0519adc7c098d78a10c8469daffaf78b7a630d698b3684ca53cba3478",
+          "version": "1.1",
+          "hash": "sha256-330f7ba1459c96301f153928091e5e1e0026c7dc226626e21a83a4d5061a8bbe",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,8 +1,8 @@
 {
-  "version": "7.2.0",
+  "version": "7.2.1",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.58",
+  "archetypesVersion": "7.59",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,8 +1,8 @@
 {
-  "version": "7.1.7",
+  "version": "7.2.0",
   "coreOnlyMode": false,
   "extensionPingEveryLoad": false,
-  "archetypesVersion": "7.56",
+  "archetypesVersion": "7.58",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -573,6 +573,21 @@
       "urlPattern": "work/problems/view-task*",
       "disambiguationSelectors": [],
       "plugins": []
+    },
+    {
+      "id": "no-vnc",
+      "name": "noVNC Instance",
+      "description": "noVNC remote desktop instances on fleet environment subdomains",
+      "urlPattern": "_novnc",
+      "disambiguationSelectors": [],
+      "plugins": [
+        {
+          "name": "clipboard-bridge.js",
+          "version": "1.0",
+          "hash": "sha256-3259d9c0519adc7c098d78a10c8469daffaf78b7a630d698b3684ca53cba3478",
+          "log": false
+        }
+      ]
     }
   ],
   "devArchetypes": [

--- a/bookmarklet-clipboard-floater.js
+++ b/bookmarklet-clipboard-floater.js
@@ -1,0 +1,496 @@
+javascript:(function () {
+  /* Floating clipboard UI + noVNC bridge: ⌘C/⌘V, Ctrl+Shift+C (Extract), Ctrl+Shift+F (Overwrite). Bookmark bar: one-line javascript: URL. */
+  var ROOT_ID = "fleet-novnc-clipboard-floater";
+  var Z = "2147483646";
+
+  if (window._v) {
+    document.removeEventListener("keydown", window._v, true);
+  }
+
+  function clipEl() {
+    return document.getElementById("noVNC_clipboard_text");
+  }
+  function getRfb() {
+    return (
+      window.rfb ||
+      window._rfb ||
+      (window.UI && window.UI.rfb) ||
+      (window.APP && window.APP.rfb) ||
+      (window.noVNC && window.noVNC.rfb) ||
+      null
+    );
+  }
+  function sleep(ms) {
+    return new Promise(function (r) {
+      setTimeout(r, ms);
+    });
+  }
+  function focusVncTarget() {
+    var rfb = getRfb();
+    if (rfb && typeof rfb.focus === "function") {
+      try {
+        rfb.focus();
+        return;
+      } catch (e0) {}
+    }
+    var c = document.querySelector("canvas");
+    if (c && typeof c.focus === "function") {
+      try {
+        c.focus();
+      } catch (e1) {}
+    }
+  }
+  /** Truncation for button toasts; empty becomes “(empty)”. */
+  function truncPreview(t) {
+    if (t == null || String(t).length === 0) {
+      return "(empty)";
+    }
+    t = String(t);
+    return t.length > 40 ? t.slice(0, 40) + "\u2026" : t;
+  }
+  /** Truncation for Cmd+C / Cmd+V bridge toasts; empty stays blank. */
+  function truncKey(t) {
+    t = t == null ? "" : String(t);
+    if (!t.length) {
+      return "";
+    }
+    return t.length > 40 ? t.slice(0, 40) + "\u2026" : t;
+  }
+  function fireKey(t, y, o) {
+    t.dispatchEvent(
+      new KeyboardEvent(
+        y,
+        Object.assign({ bubbles: true, cancelable: true, composed: true }, o)
+      )
+    );
+  }
+  function sendCtrlDom(k) {
+    var t =
+      document.activeElement ||
+      document.querySelector("canvas") ||
+      document.body ||
+      document.documentElement;
+    fireKey(t, "keydown", { key: "Control", code: "ControlLeft", ctrlKey: true });
+    fireKey(t, "keydown", {
+      key: k,
+      code: "Key" + k.toUpperCase(),
+      ctrlKey: true,
+    });
+    fireKey(t, "keyup", {
+      key: k,
+      code: "Key" + k.toUpperCase(),
+      ctrlKey: true,
+    });
+    fireKey(t, "keyup", { key: "Control", code: "ControlLeft" });
+  }
+  function sendCtrlRfb(k) {
+    var rf = getRfb();
+    if (!rf || typeof rf.sendKey !== "function") {
+      return false;
+    }
+    var ctrl = 0xffe3;
+    var ch = k.toLowerCase().charCodeAt(0);
+    rf.sendKey(ctrl, "ControlLeft", true);
+    rf.sendKey(ch, "Key" + k.toUpperCase(), true);
+    rf.sendKey(ch, "Key" + k.toUpperCase(), false);
+    rf.sendKey(ctrl, "ControlLeft", false);
+    return true;
+  }
+  function toast(m) {
+    var d = document.createElement("div");
+    d.textContent = m;
+    d.style.cssText =
+      "position:fixed;top:12px;right:12px;z-index:" +
+      Z +
+      ";background:rgba(0,0,0,0.88);color:#fff;font:12px/1.4 system-ui,Segoe UI,sans-serif;padding:10px 12px;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,0.35);max-width:min(420px,92vw);word-break:break-word;white-space:pre-wrap;";
+    document.body.appendChild(d);
+    setTimeout(function () {
+      d.remove();
+    }, 2200);
+  }
+
+  /** Prefer text/plain blob (tabs/line breaks); used for Cmd+V and Overwrite. */
+  async function readClipboardText() {
+    try {
+      var items = await navigator.clipboard.read();
+      for (var i = 0; i < items.length; i++) {
+        var types = items[i].types || [];
+        for (var j = 0; j < types.length; j++) {
+          if (types[j] === "text/plain") {
+            var blob = await items[i].getType("text/plain");
+            return await blob.text();
+          }
+        }
+      }
+    } catch (e2) {}
+    return await navigator.clipboard.readText();
+  }
+
+  async function syncRemoteClipboard(el, merged, caret, editingClipboard) {
+    if (editingClipboard) {
+      try {
+        el.focus();
+      } catch (eFocus) {}
+    }
+    var rf = getRfb();
+    if (rf && typeof rf.clipboardPasteFrom === "function") {
+      el.value = merged;
+      if (editingClipboard && typeof el.setSelectionRange === "function") {
+        try {
+          el.setSelectionRange(caret, caret);
+        } catch (eSel) {}
+      }
+      rf.clipboardPasteFrom("");
+      await sleep(12);
+      rf.clipboardPasteFrom(merged);
+      return;
+    }
+    el.value = "";
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    await sleep(12);
+    el.value = merged;
+    if (editingClipboard && typeof el.setSelectionRange === "function") {
+      try {
+        el.setSelectionRange(caret, caret);
+      } catch (eSel2) {}
+    }
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  async function runPasteFromClipboard() {
+    var elSnap = clipEl();
+    var editingClipboard = !!(elSnap && document.activeElement === elSnap);
+    var text = "";
+    try {
+      text = await readClipboardText();
+    } catch (err) {
+      toast("PASTE fail (clipboard)");
+      focusVncTarget();
+      return;
+    }
+    var el = clipEl();
+    if (!el) {
+      toast("PASTE fail (noVNC el)");
+      focusVncTarget();
+      return;
+    }
+    var cur = el.value || "";
+    var merged;
+    var caret;
+    if (editingClipboard) {
+      var start =
+        typeof el.selectionStart === "number" ? el.selectionStart : cur.length;
+      var end =
+        typeof el.selectionEnd === "number" ? el.selectionEnd : cur.length;
+      if (start > end) {
+        var swap = start;
+        start = end;
+        end = swap;
+      }
+      merged = cur.slice(0, start) + text + cur.slice(end);
+      caret = start + text.length;
+    } else {
+      merged = text;
+      caret = text.length;
+    }
+    await syncRemoteClipboard(el, merged, caret, editingClipboard);
+    await sleep(75);
+    var ok = sendCtrlRfb("v");
+    if (!ok) {
+      sendCtrlDom("v");
+    }
+    toast((ok ? "PASTE " : "PASTE? ") + "\u2192 " + truncKey(merged));
+    focusVncTarget();
+  }
+
+  /** Serialize paste, overwrite, and extract so clipboard I/O does not interleave. */
+  var clipQueue = Promise.resolve();
+
+  async function runOverwriteFromShortcut() {
+    try {
+      var t = await readClipboardText();
+      await pushOsTextToVmClipboard(typeof t === "string" ? t : "");
+    } catch (eOw) {
+      toast("Overwrite failed: could not read system clipboard.");
+      focusVncTarget();
+    }
+  }
+
+  async function runCopyVmToHost() {
+    if (!sendCtrlRfb("c")) {
+      sendCtrlDom("c");
+    }
+    await sleep(150);
+    var el = clipEl();
+    var val = el ? el.value || "" : "";
+    if (val) {
+      try {
+        await navigator.clipboard.writeText(val);
+      } catch (eW) {
+        toast("COPY fail (could not write system clipboard)");
+        focusVncTarget();
+        return;
+      }
+    }
+    toast("COPY \u2192 " + truncKey(val));
+    focusVncTarget();
+  }
+
+  /** Push plain text to the virtual machine via noVNC (no Ctrl+V — updates remote clipboard only). */
+  async function pushOsTextToVmClipboard(text) {
+    var el = clipEl();
+    if (!el) {
+      toast("Overwrite failed: noVNC clipboard field (#noVNC_clipboard_text) not found.");
+      focusVncTarget();
+      return;
+    }
+    var merged = text;
+    var rfb = getRfb();
+    el.value = merged;
+    if (rfb && typeof rfb.clipboardPasteFrom === "function") {
+      rfb.clipboardPasteFrom("");
+      await sleep(12);
+      rfb.clipboardPasteFrom(merged);
+    } else {
+      el.value = "";
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+      await sleep(12);
+      el.value = merged;
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+    focusVncTarget();
+    toast(
+      "Virtual machine clipboard updated from this computer.\n\u2192 " +
+        truncPreview(merged)
+    );
+  }
+
+  async function extractVmTextToOs() {
+    var el = clipEl();
+    if (!el) {
+      toast("Extract failed: noVNC clipboard field not found.");
+      focusVncTarget();
+      return;
+    }
+    var v = el.value || "";
+    if (!v) {
+      toast(
+        "Nothing to extract yet. Copy inside the virtual machine first, then try again."
+      );
+      focusVncTarget();
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(v);
+      toast(
+        "Copied virtual machine clipboard to this computer.\n\u2192 " +
+          truncPreview(v)
+      );
+      focusVncTarget();
+    } catch (e3) {
+      toast("Extract failed: could not write to system clipboard.");
+      focusVncTarget();
+    }
+  }
+
+  var old = document.getElementById(ROOT_ID);
+  if (old) {
+    if (window.__fleetClipFloaterTeardown) {
+      try {
+        window.__fleetClipFloaterTeardown();
+      } catch (e4) {}
+    }
+    old.remove();
+  }
+
+  var root = document.createElement("div");
+  root.id = ROOT_ID;
+  root.style.cssText =
+    "position:fixed;left:16px;top:120px;width:280px;z-index:" +
+    Z +
+    ";font:13px/1.45 system-ui,Segoe UI,sans-serif;color:#e8e8e8;background:linear-gradient(160deg,#1e1e24 0%,#121218 100%);border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 12px 40px rgba(0,0,0,0.55);overflow:hidden;user-select:none;";
+
+  var header = document.createElement("div");
+  header.textContent = "Clipboard bridge";
+  header.style.cssText =
+    "cursor:grab;padding:10px 12px;font-weight:600;font-size:12px;letter-spacing:0.02em;color:#fff;background:rgba(255,255,255,0.06);border-bottom:1px solid rgba(255,255,255,0.08);";
+
+  var body = document.createElement("div");
+  body.style.cssText = "padding:12px;user-select:text;";
+  body.style.userSelect = "text";
+
+  function btn(label) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.textContent = label;
+    b.style.cssText =
+      "display:block;width:100%;margin:0 0 8px 0;padding:9px 10px;border-radius:8px;border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);color:#f2f2f2;font:inherit;font-weight:500;cursor:pointer;";
+    b.onmouseenter = function () {
+      b.style.background = "rgba(255,255,255,0.14)";
+    };
+    b.onmouseleave = function () {
+      b.style.background = "rgba(255,255,255,0.08)";
+    };
+    return b;
+  }
+
+  var bExtract = btn("Extract VM Clipboard");
+  var bOverwrite = btn("Overwrite VM Clipboard");
+
+  var details = document.createElement("details");
+  details.style.cssText =
+    "margin:4px 0 0 0;border-top:1px solid rgba(255,255,255,0.08);padding-top:10px;";
+  var summary = document.createElement("summary");
+  summary.textContent = "How this works";
+  summary.style.cssText =
+    "cursor:pointer;font-size:12px;color:#b0b0b8;outline:none;user-select:none;";
+  var help = document.createElement("div");
+  help.style.cssText =
+    "margin-top:10px;font-size:11px;color:#a5a5ad;line-height:1.55;user-select:text;";
+  function pBlock(strongLabel, rest) {
+    var p = document.createElement("p");
+    p.style.margin = "0 0 8px 0";
+    var s = document.createElement("strong");
+    s.style.color = "#ddd";
+    s.textContent = strongLabel;
+    p.appendChild(s);
+    p.appendChild(document.createTextNode(" " + rest));
+    return p;
+  }
+  help.appendChild(
+    pBlock(
+      "Extract Clipboard",
+      "copies the text noVNC currently holds for the virtual machine into this computer’s system clipboard. Use the virtual machine’s normal copy first so that buffer fills, then click Extract."
+    )
+  );
+  help.appendChild(
+    pBlock(
+      "Overwrite Clipboard",
+      "takes plain text from this computer’s clipboard and pushes it into noVNC’s virtual machine clipboard buffer. Then use the virtual machine’s normal paste."
+    )
+  );
+  help.appendChild(
+    pBlock(
+      "Keyboard",
+      "⌘+C sends Ctrl+C to the virtual machine, then copies noVNC’s buffer to this computer. ⌘+V pushes this computer’s clipboard into the virtual machine and sends Ctrl+V. Ctrl+Shift+F is the same as Overwrite VM Clipboard. Ctrl+Shift+C is the same as Extract VM Clipboard."
+    )
+  );
+  var p3 = document.createElement("p");
+  p3.style.margin = "0";
+  p3.textContent =
+    "Always combine these controls with the virtual machine’s native copy/paste: copy in the virtual machine → Extract (or Ctrl+Shift+C) to the host; copy on the host → Overwrite (or Ctrl+Shift+F) → paste in the virtual machine (or ⌘+V).";
+  help.appendChild(p3);
+
+  details.appendChild(summary);
+  details.appendChild(help);
+
+  body.appendChild(bExtract);
+  body.appendChild(bOverwrite);
+  body.appendChild(details);
+
+  root.appendChild(header);
+  root.appendChild(body);
+  document.body.appendChild(root);
+
+  bExtract.addEventListener("click", function () {
+    clipQueue = clipQueue.then(function () {
+      return extractVmTextToOs();
+    }).catch(function () {});
+  });
+  bOverwrite.addEventListener("click", function () {
+    clipQueue = clipQueue
+      .then(runOverwriteFromShortcut)
+      .catch(function () {});
+  });
+
+  var drag = false;
+  var ox = 0;
+  var oy = 0;
+  function onMove(ev) {
+    if (!drag) {
+      return;
+    }
+    var x = ev.clientX - ox;
+    var y = ev.clientY - oy;
+    root.style.left = Math.max(0, x) + "px";
+    root.style.top = Math.max(0, y) + "px";
+  }
+  function onUp() {
+    drag = false;
+    header.style.cursor = "grab";
+    document.removeEventListener("mousemove", onMove, true);
+    document.removeEventListener("mouseup", onUp, true);
+  }
+  header.addEventListener("mousedown", function (ev) {
+    if (ev.button !== 0) {
+      return;
+    }
+    drag = true;
+    header.style.cursor = "grabbing";
+    var r = root.getBoundingClientRect();
+    ox = ev.clientX - r.left;
+    oy = ev.clientY - r.top;
+    document.addEventListener("mousemove", onMove, true);
+    document.addEventListener("mouseup", onUp, true);
+    ev.preventDefault();
+  });
+
+  window._v = async function (e) {
+    var key = (e.key || "").toLowerCase();
+    if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === "KeyF") {
+      if (e.repeat) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue.then(runOverwriteFromShortcut).catch(function () {});
+      return;
+    }
+    if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === "KeyC") {
+      if (e.repeat) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue
+        .then(function () {
+          return extractVmTextToOs();
+        })
+        .catch(function () {});
+      return;
+    }
+    if (e.metaKey && !e.ctrlKey && !e.altKey && key === "c") {
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue.then(runCopyVmToHost).catch(function () {});
+      return;
+    }
+    if (e.metaKey && !e.ctrlKey && !e.altKey && key === "v") {
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue.then(runPasteFromClipboard).catch(function () {});
+      return;
+    }
+  };
+  document.addEventListener("keydown", window._v, true);
+
+  window.__fleetClipFloaterTeardown = function () {
+    document.removeEventListener("mousemove", onMove, true);
+    document.removeEventListener("mouseup", onUp, true);
+    if (window._v) {
+      document.removeEventListener("keydown", window._v, true);
+      window._v = null;
+    }
+    if (root && root.parentNode) {
+      root.parentNode.removeChild(root);
+    }
+  };
+
+  toast(
+    "Clipboard bridge ready — drag the title bar. ⌘C/⌘V, Ctrl+Shift+C/F."
+  );
+})();

--- a/dev/fleet-godmode.user.js
+++ b/dev/fleet-godmode.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         GODMODE - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
-// @version      2.0
+// @version      2.1
 // @description  Dev-only key: allows using dev builds of Fleet UX Enhancer. Install only if you are a dev.
 // @icon         https://github.com/favicon.ico
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
 // @match        https://fleetai.com/*
+// @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
 // @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-godmode.user.js
 // @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-godmode.user.js

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,12 +2,12 @@
 // ==UserScript==
 // @name         [feat/add-rcp] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      7.2.0
+// @version      7.2.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
 // @match        https://fleetai.com/*
-// @match        https://*.env.fleet-prod-fow-us-east-1.fleetai.com/*
+// @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @icon         https://www.fleetai.com/favicon.ico
 // @grant        GM_getValue
 // @grant        GM_setValue
@@ -30,7 +30,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '7.2.0';
+    const VERSION = '7.2.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -42,7 +42,7 @@
 
     // noVNC instances run on a separate subdomain origin; return a synthetic path so
     // the archetype detection pipeline can still match them via urlPattern.
-    const NOVNC_HOST_PATTERN = /\.env\.fleet-prod-fow-us-east-1\.fleetai\.com$/;
+    const NOVNC_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
     const NOVNC_SYNTHETIC_PATH = '_novnc';
     
     // GitHub repository configuration

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/add-rcp] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.2.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -49,7 +49,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/add-rcp',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,11 +2,12 @@
 // ==UserScript==
 // @name         [feat/add-rcp] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      7.1.7
+// @version      7.2.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
 // @match        https://fleetai.com/*
+// @match        https://*.env.fleet-prod-fow-us-east-1.fleetai.com/*
 // @icon         https://www.fleetai.com/favicon.ico
 // @grant        GM_getValue
 // @grant        GM_setValue
@@ -29,7 +30,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '7.1.7';
+    const VERSION = '7.2.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -38,6 +39,11 @@
     
     // Base URL that matches the @match pattern (without trailing wildcard)
     const BASE_URL = 'https://www.fleetai.com/';
+
+    // noVNC instances run on a separate subdomain origin; return a synthetic path so
+    // the archetype detection pipeline can still match them via urlPattern.
+    const NOVNC_HOST_PATTERN = /\.env\.fleet-prod-fow-us-east-1\.fleetai\.com$/;
+    const NOVNC_SYNTHETIC_PATH = '_novnc';
     
     // GitHub repository configuration
     const GITHUB_CONFIG = {
@@ -410,6 +416,16 @@
                 }
                 return path;
             }
+
+            // noVNC instances live on a separate subdomain origin — return a synthetic
+            // path constant so detectArchetype() can still match the no-vnc archetype.
+            try {
+                const hostname = new URL(fullUrl).hostname;
+                if (NOVNC_HOST_PATTERN.test(hostname)) {
+                    return NOVNC_SYNTHETIC_PATH;
+                }
+            } catch (e) {}
+
             return '';
         },
         

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/add-rcp] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.1.7
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -43,7 +43,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/add-rcp',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/no-vnc/main/clipboard-bridge.js
+++ b/plugins/archetypes/no-vnc/main/clipboard-bridge.js
@@ -1,0 +1,500 @@
+// clipboard-bridge.js — noVNC clipboard bridge: floating UI + ⌘C/⌘V + Ctrl+Shift+C/F
+// Converted from bookmarklet-clipboard-floater.js for auto-loading on no-vnc archetype pages.
+
+var ROOT_ID = "fleet-novnc-clipboard-floater";
+var Z = "2147483646";
+
+function _clipEl() {
+  return document.getElementById("noVNC_clipboard_text");
+}
+function _getRfb() {
+  return (
+    window.rfb ||
+    window._rfb ||
+    (window.UI && window.UI.rfb) ||
+    (window.APP && window.APP.rfb) ||
+    (window.noVNC && window.noVNC.rfb) ||
+    null
+  );
+}
+function _sleep(ms) {
+  return new Promise(function (r) {
+    setTimeout(r, ms);
+  });
+}
+function _focusVncTarget() {
+  var rfb = _getRfb();
+  if (rfb && typeof rfb.focus === "function") {
+    try {
+      rfb.focus();
+      return;
+    } catch (e0) {}
+  }
+  var c = document.querySelector("canvas");
+  if (c && typeof c.focus === "function") {
+    try {
+      c.focus();
+    } catch (e1) {}
+  }
+}
+/** Truncation for button toasts; empty becomes "(empty)". */
+function _truncPreview(t) {
+  if (t == null || String(t).length === 0) {
+    return "(empty)";
+  }
+  t = String(t);
+  return t.length > 40 ? t.slice(0, 40) + "\u2026" : t;
+}
+/** Truncation for Cmd+C / Cmd+V bridge toasts; empty stays blank. */
+function _truncKey(t) {
+  t = t == null ? "" : String(t);
+  if (!t.length) {
+    return "";
+  }
+  return t.length > 40 ? t.slice(0, 40) + "\u2026" : t;
+}
+function _fireKey(t, y, o) {
+  t.dispatchEvent(
+    new KeyboardEvent(
+      y,
+      Object.assign({ bubbles: true, cancelable: true, composed: true }, o)
+    )
+  );
+}
+function _sendCtrlDom(k) {
+  var t =
+    document.activeElement ||
+    document.querySelector("canvas") ||
+    document.body ||
+    document.documentElement;
+  _fireKey(t, "keydown", { key: "Control", code: "ControlLeft", ctrlKey: true });
+  _fireKey(t, "keydown", { key: k, code: "Key" + k.toUpperCase(), ctrlKey: true });
+  _fireKey(t, "keyup",   { key: k, code: "Key" + k.toUpperCase(), ctrlKey: true });
+  _fireKey(t, "keyup",   { key: "Control", code: "ControlLeft" });
+}
+function _sendCtrlRfb(k) {
+  var rf = _getRfb();
+  if (!rf || typeof rf.sendKey !== "function") {
+    return false;
+  }
+  var ctrl = 0xffe3;
+  var ch = k.toLowerCase().charCodeAt(0);
+  rf.sendKey(ctrl, "ControlLeft", true);
+  rf.sendKey(ch, "Key" + k.toUpperCase(), true);
+  rf.sendKey(ch, "Key" + k.toUpperCase(), false);
+  rf.sendKey(ctrl, "ControlLeft", false);
+  return true;
+}
+function _toast(m) {
+  var d = document.createElement("div");
+  d.textContent = m;
+  d.style.cssText =
+    "position:fixed;top:12px;right:12px;z-index:" +
+    Z +
+    ";background:rgba(0,0,0,0.88);color:#fff;font:12px/1.4 system-ui,Segoe UI,sans-serif;padding:10px 12px;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,0.35);max-width:min(420px,92vw);word-break:break-word;white-space:pre-wrap;";
+  document.body.appendChild(d);
+  setTimeout(function () {
+    d.remove();
+  }, 2200);
+}
+
+/** Prefer text/plain blob (tabs/line breaks); used for Cmd+V and Overwrite. */
+async function _readClipboardText() {
+  try {
+    var items = await navigator.clipboard.read();
+    for (var i = 0; i < items.length; i++) {
+      var types = items[i].types || [];
+      for (var j = 0; j < types.length; j++) {
+        if (types[j] === "text/plain") {
+          var blob = await items[i].getType("text/plain");
+          return await blob.text();
+        }
+      }
+    }
+  } catch (e2) {}
+  return await navigator.clipboard.readText();
+}
+
+async function _syncRemoteClipboard(el, merged, caret, editingClipboard) {
+  if (editingClipboard) {
+    try {
+      el.focus();
+    } catch (eFocus) {}
+  }
+  var rf = _getRfb();
+  if (rf && typeof rf.clipboardPasteFrom === "function") {
+    el.value = merged;
+    if (editingClipboard && typeof el.setSelectionRange === "function") {
+      try {
+        el.setSelectionRange(caret, caret);
+      } catch (eSel) {}
+    }
+    rf.clipboardPasteFrom("");
+    await _sleep(12);
+    rf.clipboardPasteFrom(merged);
+    return;
+  }
+  el.value = "";
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+  await _sleep(12);
+  el.value = merged;
+  if (editingClipboard && typeof el.setSelectionRange === "function") {
+    try {
+      el.setSelectionRange(caret, caret);
+    } catch (eSel2) {}
+  }
+  el.dispatchEvent(new Event("change", { bubbles: true }));
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function _runPasteFromClipboard() {
+  var elSnap = _clipEl();
+  var editingClipboard = !!(elSnap && document.activeElement === elSnap);
+  var text = "";
+  try {
+    text = await _readClipboardText();
+  } catch (err) {
+    _toast("PASTE fail (clipboard)");
+    _focusVncTarget();
+    return;
+  }
+  var el = _clipEl();
+  if (!el) {
+    _toast("PASTE fail (noVNC el)");
+    _focusVncTarget();
+    return;
+  }
+  var cur = el.value || "";
+  var merged;
+  var caret;
+  if (editingClipboard) {
+    var start =
+      typeof el.selectionStart === "number" ? el.selectionStart : cur.length;
+    var end =
+      typeof el.selectionEnd === "number" ? el.selectionEnd : cur.length;
+    if (start > end) {
+      var swap = start;
+      start = end;
+      end = swap;
+    }
+    merged = cur.slice(0, start) + text + cur.slice(end);
+    caret = start + text.length;
+  } else {
+    merged = text;
+    caret = text.length;
+  }
+  await _syncRemoteClipboard(el, merged, caret, editingClipboard);
+  await _sleep(75);
+  var ok = _sendCtrlRfb("v");
+  if (!ok) {
+    _sendCtrlDom("v");
+  }
+  _toast((ok ? "PASTE " : "PASTE? ") + "\u2192 " + _truncKey(merged));
+  _focusVncTarget();
+}
+
+async function _runOverwriteFromShortcut() {
+  try {
+    var t = await _readClipboardText();
+    await _pushOsTextToVmClipboard(typeof t === "string" ? t : "");
+  } catch (eOw) {
+    _toast("Overwrite failed: could not read system clipboard.");
+    _focusVncTarget();
+  }
+}
+
+async function _runCopyVmToHost() {
+  if (!_sendCtrlRfb("c")) {
+    _sendCtrlDom("c");
+  }
+  await _sleep(150);
+  var el = _clipEl();
+  var val = el ? el.value || "" : "";
+  if (val) {
+    try {
+      await navigator.clipboard.writeText(val);
+    } catch (eW) {
+      _toast("COPY fail (could not write system clipboard)");
+      _focusVncTarget();
+      return;
+    }
+  }
+  _toast("COPY \u2192 " + _truncKey(val));
+  _focusVncTarget();
+}
+
+/** Push plain text to the virtual machine via noVNC (no Ctrl+V — updates remote clipboard only). */
+async function _pushOsTextToVmClipboard(text) {
+  var el = _clipEl();
+  if (!el) {
+    _toast("Overwrite failed: noVNC clipboard field (#noVNC_clipboard_text) not found.");
+    _focusVncTarget();
+    return;
+  }
+  var merged = text;
+  var rfb = _getRfb();
+  el.value = merged;
+  if (rfb && typeof rfb.clipboardPasteFrom === "function") {
+    rfb.clipboardPasteFrom("");
+    await _sleep(12);
+    rfb.clipboardPasteFrom(merged);
+  } else {
+    el.value = "";
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    await _sleep(12);
+    el.value = merged;
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+  _focusVncTarget();
+  _toast(
+    "Virtual machine clipboard updated from this computer.\n\u2192 " +
+      _truncPreview(merged)
+  );
+}
+
+async function _extractVmTextToOs() {
+  var el = _clipEl();
+  if (!el) {
+    _toast("Extract failed: noVNC clipboard field not found.");
+    _focusVncTarget();
+    return;
+  }
+  var v = el.value || "";
+  if (!v) {
+    _toast(
+      "Nothing to extract yet. Copy inside the virtual machine first, then try again."
+    );
+    _focusVncTarget();
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(v);
+    _toast(
+      "Copied virtual machine clipboard to this computer.\n\u2192 " +
+        _truncPreview(v)
+    );
+    _focusVncTarget();
+  } catch (e3) {
+    _toast("Extract failed: could not write to system clipboard.");
+    _focusVncTarget();
+  }
+}
+
+function _initClipboardBridge() {
+  // Remove any pre-existing instance (e.g. from a prior page load or bookmarklet run).
+  var old = document.getElementById(ROOT_ID);
+  if (old) {
+    if (window.__fleetClipFloaterTeardown) {
+      try {
+        window.__fleetClipFloaterTeardown();
+      } catch (e4) {}
+    }
+    old.remove();
+  }
+  if (window._v) {
+    document.removeEventListener("keydown", window._v, true);
+  }
+
+  /** Serialize paste, overwrite, and extract so clipboard I/O does not interleave. */
+  var clipQueue = Promise.resolve();
+
+  // ---- Floating panel ----
+  var root = document.createElement("div");
+  root.id = ROOT_ID;
+  root.style.cssText =
+    "position:fixed;left:16px;top:120px;width:280px;z-index:" +
+    Z +
+    ";font:13px/1.45 system-ui,Segoe UI,sans-serif;color:#e8e8e8;background:linear-gradient(160deg,#1e1e24 0%,#121218 100%);border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 12px 40px rgba(0,0,0,0.55);overflow:hidden;user-select:none;";
+
+  var headerEl = document.createElement("div");
+  headerEl.textContent = "Clipboard bridge";
+  headerEl.style.cssText =
+    "cursor:grab;padding:10px 12px;font-weight:600;font-size:12px;letter-spacing:0.02em;color:#fff;background:rgba(255,255,255,0.06);border-bottom:1px solid rgba(255,255,255,0.08);";
+
+  var bodyEl = document.createElement("div");
+  bodyEl.style.cssText = "padding:12px;user-select:text;";
+  bodyEl.style.userSelect = "text";
+
+  function btn(label) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.textContent = label;
+    b.style.cssText =
+      "display:block;width:100%;margin:0 0 8px 0;padding:9px 10px;border-radius:8px;border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);color:#f2f2f2;font:inherit;font-weight:500;cursor:pointer;";
+    b.onmouseenter = function () {
+      b.style.background = "rgba(255,255,255,0.14)";
+    };
+    b.onmouseleave = function () {
+      b.style.background = "rgba(255,255,255,0.08)";
+    };
+    return b;
+  }
+
+  var bExtract  = btn("Extract VM Clipboard");
+  var bOverwrite = btn("Overwrite VM Clipboard");
+
+  var details = document.createElement("details");
+  details.style.cssText =
+    "margin:4px 0 0 0;border-top:1px solid rgba(255,255,255,0.08);padding-top:10px;";
+  var summaryEl = document.createElement("summary");
+  summaryEl.textContent = "How this works";
+  summaryEl.style.cssText =
+    "cursor:pointer;font-size:12px;color:#b0b0b8;outline:none;user-select:none;";
+  var help = document.createElement("div");
+  help.style.cssText =
+    "margin-top:10px;font-size:11px;color:#a5a5ad;line-height:1.55;user-select:text;";
+
+  function pBlock(strongLabel, rest) {
+    var p = document.createElement("p");
+    p.style.margin = "0 0 8px 0";
+    var s = document.createElement("strong");
+    s.style.color = "#ddd";
+    s.textContent = strongLabel;
+    p.appendChild(s);
+    p.appendChild(document.createTextNode(" " + rest));
+    return p;
+  }
+  help.appendChild(
+    pBlock(
+      "Extract Clipboard",
+      "copies the text noVNC currently holds for the virtual machine into this computer\u2019s system clipboard. Use the virtual machine\u2019s normal copy first so that buffer fills, then click Extract."
+    )
+  );
+  help.appendChild(
+    pBlock(
+      "Overwrite Clipboard",
+      "takes plain text from this computer\u2019s clipboard and pushes it into noVNC\u2019s virtual machine clipboard buffer. Then use the virtual machine\u2019s normal paste."
+    )
+  );
+  help.appendChild(
+    pBlock(
+      "Keyboard",
+      "\u2318+C sends Ctrl+C to the virtual machine, then copies noVNC\u2019s buffer to this computer. \u2318+V pushes this computer\u2019s clipboard into the virtual machine and sends Ctrl+V. Ctrl+Shift+F is the same as Overwrite VM Clipboard. Ctrl+Shift+C is the same as Extract VM Clipboard."
+    )
+  );
+  var p3 = document.createElement("p");
+  p3.style.margin = "0";
+  p3.textContent =
+    "Always combine these controls with the virtual machine\u2019s native copy/paste: copy in the virtual machine \u2192 Extract (or Ctrl+Shift+C) to the host; copy on the host \u2192 Overwrite (or Ctrl+Shift+F) \u2192 paste in the virtual machine (or \u2318+V).";
+  help.appendChild(p3);
+
+  details.appendChild(summaryEl);
+  details.appendChild(help);
+  bodyEl.appendChild(bExtract);
+  bodyEl.appendChild(bOverwrite);
+  bodyEl.appendChild(details);
+  root.appendChild(headerEl);
+  root.appendChild(bodyEl);
+  document.body.appendChild(root);
+
+  // ---- Button listeners ----
+  bExtract.addEventListener("click", function () {
+    clipQueue = clipQueue
+      .then(function () { return _extractVmTextToOs(); })
+      .catch(function () {});
+  });
+  bOverwrite.addEventListener("click", function () {
+    clipQueue = clipQueue
+      .then(_runOverwriteFromShortcut)
+      .catch(function () {});
+  });
+
+  // ---- Drag ----
+  var drag = false;
+  var ox = 0;
+  var oy = 0;
+  function onMove(ev) {
+    if (!drag) { return; }
+    root.style.left = Math.max(0, ev.clientX - ox) + "px";
+    root.style.top  = Math.max(0, ev.clientY - oy) + "px";
+  }
+  function onUp() {
+    drag = false;
+    headerEl.style.cursor = "grab";
+    document.removeEventListener("mousemove", onMove, true);
+    document.removeEventListener("mouseup", onUp, true);
+  }
+  headerEl.addEventListener("mousedown", function (ev) {
+    if (ev.button !== 0) { return; }
+    drag = true;
+    headerEl.style.cursor = "grabbing";
+    var r = root.getBoundingClientRect();
+    ox = ev.clientX - r.left;
+    oy = ev.clientY - r.top;
+    document.addEventListener("mousemove", onMove, true);
+    document.addEventListener("mouseup", onUp, true);
+    ev.preventDefault();
+  });
+
+  // ---- Keyboard shortcuts ----
+  window._v = async function (e) {
+    var key = (e.key || "").toLowerCase();
+    if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === "KeyF") {
+      if (e.repeat) { return; }
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue.then(_runOverwriteFromShortcut).catch(function () {});
+      return;
+    }
+    if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === "KeyC") {
+      if (e.repeat) { return; }
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue
+        .then(function () { return _extractVmTextToOs(); })
+        .catch(function () {});
+      return;
+    }
+    if (e.metaKey && !e.ctrlKey && !e.altKey && key === "c") {
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue.then(_runCopyVmToHost).catch(function () {});
+      return;
+    }
+    if (e.metaKey && !e.ctrlKey && !e.altKey && key === "v") {
+      e.preventDefault();
+      e.stopPropagation();
+      clipQueue = clipQueue.then(_runPasteFromClipboard).catch(function () {});
+      return;
+    }
+  };
+  document.addEventListener("keydown", window._v, true);
+
+  // ---- Teardown ----
+  window.__fleetClipFloaterTeardown = function () {
+    document.removeEventListener("mousemove", onMove, true);
+    document.removeEventListener("mouseup", onUp, true);
+    if (window._v) {
+      document.removeEventListener("keydown", window._v, true);
+      window._v = null;
+    }
+    if (root && root.parentNode) {
+      root.parentNode.removeChild(root);
+    }
+  };
+
+  Logger.log("clipboard-bridge: floating panel and keyboard shortcuts active");
+  _toast("Clipboard bridge ready \u2014 drag the title bar. \u2318C/\u2318V, Ctrl+Shift+C/F.");
+}
+
+const plugin = {
+  id: "clipboard-bridge",
+  name: "noVNC Clipboard Bridge",
+  description:
+    "Floating clipboard bridge panel with ⌘C/⌘V and Ctrl+Shift+C/F shortcuts for noVNC sessions",
+  _version: "1.0",
+  enabledByDefault: true,
+  phase: "mutation",
+  initialState: { ready: false },
+
+  onMutation(state) {
+    if (state.ready) { return; }
+    if (!document.getElementById("noVNC_clipboard_text")) { return; }
+    state.ready = true;
+    Logger.log("clipboard-bridge: noVNC clipboard element detected, initialising bridge");
+    _initClipboardBridge();
+  },
+};

--- a/plugins/archetypes/no-vnc/main/clipboard-bridge.js
+++ b/plugins/archetypes/no-vnc/main/clipboard-bridge.js
@@ -283,6 +283,16 @@ async function _extractVmTextToOs() {
   }
 }
 
+var SHOW_FLOATING_BANNER_SUBOPTION_ID = "show-floating-banner";
+
+function _isFloatingBannerEnabled() {
+  return Storage.getSubOptionEnabled(
+    "clipboard-bridge",
+    SHOW_FLOATING_BANNER_SUBOPTION_ID,
+    true
+  );
+}
+
 function _initClipboardBridge() {
   // Remove any pre-existing instance (e.g. from a prior page load or bookmarklet run).
   var old = document.getElementById(ROOT_ID);
@@ -301,15 +311,23 @@ function _initClipboardBridge() {
   /** Serialize paste, overwrite, and extract so clipboard I/O does not interleave. */
   var clipQueue = Promise.resolve();
 
-  // ---- Floating panel ----
-  var root = document.createElement("div");
+  var showFloatingBanner = _isFloatingBannerEnabled();
+  var root = null;
+  var headerEl = null;
+  /** Drag handlers; stubs until panel is built so teardown can always remove listeners. */
+  var onMove = function () {};
+  var onUp = function () {};
+
+  // ---- Floating panel (optional; keyboard shortcuts always register below) ----
+  if (showFloatingBanner) {
+  root = document.createElement("div");
   root.id = ROOT_ID;
   root.style.cssText =
     "position:fixed;left:16px;top:120px;width:280px;z-index:" +
     Z +
     ";font:13px/1.45 system-ui,Segoe UI,sans-serif;color:#e8e8e8;background:linear-gradient(160deg,#1e1e24 0%,#121218 100%);border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 12px 40px rgba(0,0,0,0.55);overflow:hidden;user-select:none;";
 
-  var headerEl = document.createElement("div");
+  headerEl = document.createElement("div");
   headerEl.textContent = "Clipboard bridge";
   headerEl.style.cssText =
     "cursor:grab;padding:10px 12px;font-weight:600;font-size:12px;letter-spacing:0.02em;color:#fff;background:rgba(255,255,255,0.06);border-bottom:1px solid rgba(255,255,255,0.08);";
@@ -406,17 +424,17 @@ function _initClipboardBridge() {
   var drag = false;
   var ox = 0;
   var oy = 0;
-  function onMove(ev) {
+  onMove = function (ev) {
     if (!drag) { return; }
     root.style.left = Math.max(0, ev.clientX - ox) + "px";
     root.style.top  = Math.max(0, ev.clientY - oy) + "px";
-  }
-  function onUp() {
+  };
+  onUp = function () {
     drag = false;
     headerEl.style.cursor = "grab";
     document.removeEventListener("mousemove", onMove, true);
     document.removeEventListener("mouseup", onUp, true);
-  }
+  };
   headerEl.addEventListener("mousedown", function (ev) {
     if (ev.button !== 0) { return; }
     drag = true;
@@ -428,6 +446,8 @@ function _initClipboardBridge() {
     document.addEventListener("mouseup", onUp, true);
     ev.preventDefault();
   });
+
+  } /* end if (showFloatingBanner) */
 
   // ---- Keyboard shortcuts ----
   window._v = async function (e) {
@@ -476,18 +496,34 @@ function _initClipboardBridge() {
     }
   };
 
-  Logger.log("clipboard-bridge: floating panel and keyboard shortcuts active");
-  _toast("Clipboard bridge ready \u2014 drag the title bar. \u2318C/\u2318V, Ctrl+Shift+C/F.");
+  if (showFloatingBanner) {
+    Logger.log("clipboard-bridge: floating panel and keyboard shortcuts active");
+    _toast("Clipboard bridge ready \u2014 drag the title bar. \u2318C/\u2318V, Ctrl+Shift+C/F.");
+  } else {
+    Logger.log("clipboard-bridge: keyboard shortcuts active (floating banner hidden via settings)");
+    _toast(
+      "Clipboard bridge ready \u2014 \u2318C/\u2318V, Ctrl+Shift+C/F. Floating panel is hidden in settings."
+    );
+  }
 }
+
+const SHOW_FLOATING_BANNER_SUBOPTION = {
+  id: SHOW_FLOATING_BANNER_SUBOPTION_ID,
+  name: "Show floating banner",
+  description:
+    "When off, hides the draggable panel; ⌘C/⌘V and Ctrl+Shift+C/F still work.",
+  enabledByDefault: true,
+};
 
 const plugin = {
   id: "clipboard-bridge",
   name: "noVNC Clipboard Bridge",
   description:
     "Floating clipboard bridge panel with ⌘C/⌘V and Ctrl+Shift+C/F shortcuts for noVNC sessions",
-  _version: "1.0",
+  _version: "1.1",
   enabledByDefault: true,
   phase: "mutation",
+  subOptions: [SHOW_FLOATING_BANNER_SUBOPTION],
   initialState: { ready: false },
 
   onMutation(state) {


### PR DESCRIPTION
## Summary

This branch adds a **no-vnc** archetype for Fleet noVNC remote-desktop pages, centered on a **clipboard bridge** that improves copy/paste between the host clipboard and noVNC’s clipboard UI. The same behavior is available as a standalone **bookmarklet** for pages that do not load Fleet. Host matching was broadened so the userscript runs on environment subdomains (for example `.env.` patterns), and a **settings suboption** can hide the floating clipboard banner when users prefer a minimal UI.

## Changes

- **`archetypes.json` / `fleet.user.js`**: Register the new archetype and wire the clipboard bridge plugin; keep godmode metadata aligned.
- **`plugins/archetypes/no-vnc/main/clipboard-bridge.js`**: Injected UI and keyboard shortcuts (⌘C/⌘V, Ctrl+Shift+C/F-style flows) that sync with `noVNC_clipboard_text` and the RFB client where available, with toasts and optional banner hiding via settings.
- **`bookmarklet-clipboard-floater.js`**: Standalone bookmarklet version of the floater for use without Tampermonkey.
- **`dev/fleet-godmode.user.js`**: Minor alignment with the main script’s no-vnc metadata.

Earlier commits in this branch fixed **@include** / **NOVNC_HOST_PATTERN** so matching works across Fleet environment subdomains, then added the **hide floating clipboard banner** suboption.

## New plugins

| Archetype | Plugin | Version |
|-----------|--------|---------|
| no-vnc | clipboard-bridge.js | 1.1 |

## Commit history

- `083e746` — feat(no-vnc): add no-vnc archetype with clipboard bridge plugin
- `c1ba551` — fix(no-vnc): broaden @include and NOVNC_HOST_PATTERN to match any .env. subdomain
- `421cad3` — feat(no-vnc): suboption to hide floating clipboard banner

*(Excluded: `Sync branch config` commits.)*

## Stats

```
 archetypes.json                                    |  19 +-
 bookmarklet-clipboard-floater.js                   | 496 +++++++++++++++++++
 dev/fleet-godmode.user.js                          |   3 +-
 fleet.user.js                                      |  20 +-
 plugins/archetypes/no-vnc/main/clipboard-bridge.js | 536 +++++++++++++++++++++
 5 files changed, 1069 insertions(+), 5 deletions(-)
```
