### PR TITLE
Add computer-use prompt cache and embedded URL bar fit modules

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -265,6 +265,12 @@
           "log": false
         },
         {
+          "name": "embedded-urlbar-fit.js",
+          "version": "1.0",
+          "hash": "sha256-4962576fc240f13437bc4aa42a4c6afff5b17cf32d3caa9a916da84d6f83cec5",
+          "log": false
+        },
+        {
           "name": "remember-layout-proportions.js",
           "version": "1.0",
           "hash": "sha256-c958e9433ff34ed1519b194fc15d3d049c87a0bacc93a1942e6b980030a0a719",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.75",
+  "archetypesVersion": "7.76",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -18,8 +18,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.10",
-      "hash": "sha256-2d0ae302fe9a1d4edd5a311de3b23c0334e919675bebbea5777392d3952232ed",
+      "version": "2.11",
+      "hash": "sha256-dbaeeca750355752d6fe8bc32315a2c6f960a80ca04b7ff2b8abfd0104d5f7bf",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.71",
+  "archetypesVersion": "7.72",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -18,8 +18,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.9",
-      "hash": "sha256-d7283f301f13c35707de9fc645d42abe7a63ddfdd4dd0b29edf2abf07e8b1867",
+      "version": "2.10",
+      "hash": "sha256-2d0ae302fe9a1d4edd5a311de3b23c0334e919675bebbea5777392d3952232ed",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.72",
+  "archetypesVersion": "7.73",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -284,8 +284,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "1.1",
-          "hash": "sha256-3a1abd4547752bcfd21d27c56b633780b678f535bccec40f04eebc464603c2b6",
+          "version": "1.2",
+          "hash": "sha256-0b0f5a7a34169a614fadae6cdba69080912442ebcd393008a96491fcd6147b1d",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.73",
+  "archetypesVersion": "7.74",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -284,8 +284,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "1.2",
-          "hash": "sha256-0b0f5a7a34169a614fadae6cdba69080912442ebcd393008a96491fcd6147b1d",
+          "version": "1.3",
+          "hash": "sha256-1c7cb025385be4028c211b408b0a44d99c609056c8d178e7b6ff6665ae3354b7",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.76",
+  "archetypesVersion": "7.77",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -284,8 +284,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "1.4",
-          "hash": "sha256-eeda0ccbee468e37bbe8b92b8c2eeca313b3173b61496ec29c2732bbebe8ebfa",
+          "version": "2.0",
+          "hash": "sha256-4c7bf63ff9ce77cb20524e35783752ba093765cd2ecb30970dbd229e5ee0799c",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.74",
+  "archetypesVersion": "7.75",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -284,8 +284,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "1.3",
-          "hash": "sha256-1c7cb025385be4028c211b408b0a44d99c609056c8d178e7b6ff6665ae3354b7",
+          "version": "1.4",
+          "hash": "sha256-eeda0ccbee468e37bbe8b92b8c2eeca313b3173b61496ec29c2732bbebe8ebfa",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -281,6 +281,12 @@
           "version": "1.0",
           "hash": "sha256-2addda611dbd9139173df592f2afae4aca502a518954f00de07f4c1456d547ab",
           "log": false
+        },
+        {
+          "name": "prompt-cache.js",
+          "version": "1.0",
+          "hash": "sha256-4c02f995366d3b79ccb3960f7a30592c9b29af50f4156cb2a904b009221e8342",
+          "log": false
         }
       ]
     },

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.77",
+  "archetypesVersion": "7.78",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -310,6 +310,12 @@
           "log": false
         },
         {
+          "name": "embedded-urlbar-fit.js",
+          "version": "1.0",
+          "hash": "sha256-d21f89e1fc36b693a2f735f9284e22292fd12274ba93254f697520043dc7032a",
+          "log": false
+        },
+        {
           "name": "prompt-scratchpad.js",
           "version": "2.1",
           "hash": "sha256-64f89a9a1b7f2b2fc211a39ca811bff49dd4c2764c320f0a5906f9beb97845e7",
@@ -478,6 +484,12 @@
           "name": "corner-widgets-toggle.js",
           "version": "1.0",
           "hash": "sha256-14f09d82abf901ef6ec8de9b66575a666448f82ad9ccc20a6a7772f4d0cd7c29",
+          "log": false
+        },
+        {
+          "name": "embedded-urlbar-fit.js",
+          "version": "1.0",
+          "hash": "sha256-15d1ad0c1b968c8b39171db1f8e770804be302844724e9527a98559c1e0e5a48",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.70",
+  "archetypesVersion": "7.71",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -284,8 +284,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "1.0",
-          "hash": "sha256-4c02f995366d3b79ccb3960f7a30592c9b29af50f4156cb2a904b009221e8342",
+          "version": "1.1",
+          "hash": "sha256-3a1abd4547752bcfd21d27c56b633780b678f535bccec40f04eebc464603c2b6",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.78",
+  "archetypesVersion": "7.79",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -290,8 +290,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "2.0",
-          "hash": "sha256-4c7bf63ff9ce77cb20524e35783752ba093765cd2ecb30970dbd229e5ee0799c",
+          "version": "2.1",
+          "hash": "sha256-72f1976a126209865b84f467f960d4ccccf03c75fd24837669335e225053b20d",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.79",
+  "archetypesVersion": "7.80",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -290,8 +290,8 @@
         },
         {
           "name": "prompt-cache.js",
-          "version": "2.1",
-          "hash": "sha256-72f1976a126209865b84f467f960d4ccccf03c75fd24837669335e225053b20d",
+          "version": "2.2",
+          "hash": "sha256-b3abe9f96692af2f513f7e0a95aea210719f12610bc3d81e46ed0e019c7d3d8d",
           "log": false
         }
       ]

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/computer-use-prompt-cache] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/computer-use-prompt-cache',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/computer-use-prompt-cache] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/computer-use-prompt-cache',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/comp-use-revision/main/embedded-urlbar-fit.js
+++ b/plugins/archetypes/comp-use-revision/main/embedded-urlbar-fit.js
@@ -1,0 +1,62 @@
+// ============= embedded-urlbar-fit.js =============
+const plugin = {
+    id: 'compUseRevisionEmbeddedUrlbarFit',
+    name: 'Computer Use Revision Embedded URL Bar Fit',
+    description:
+        'Keeps embedded instance toolbar right-side controls visible by forcing URL segment to shrink/truncate',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, appliedLogged: false },
+
+    onMutation(state) {
+        const rows = Context.dom.queryAll('div.flex.items-center.gap-1.p-1.border-b.h-10.bg-background', {
+            context: `${this.id}.toolbarRows`
+        });
+
+        if (rows.length === 0) {
+            if (!state.missingLogged) {
+                Logger.debug('Embedded URL bar fit: no embedded toolbar rows found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        let fixedThisPass = 0;
+
+        rows.forEach((row) => {
+            const rowText = row.textContent || '';
+            if (!rowText.includes('Remote Copy') || !rowText.includes('Remote Paste')) return;
+
+            const directGroups = Array.from(row.children).filter(
+                (el) => el.tagName === 'DIV' && el.classList.contains('flex') && el.classList.contains('items-center')
+            );
+            if (directGroups.length < 3) return;
+
+            const middleGroup = directGroups[1];
+            const rightGroup = directGroups[2];
+
+            middleGroup.classList.add('min-w-0');
+            middleGroup.classList.add('overflow-hidden');
+            rightGroup.classList.add('shrink-0');
+
+            const urlPill = middleGroup.querySelector(':scope > div.flex-1');
+            if (urlPill) {
+                urlPill.classList.add('min-w-0');
+            }
+
+            const urlButton = middleGroup.querySelector('button.w-full');
+            if (urlButton) {
+                urlButton.classList.add('min-w-0');
+            }
+
+            fixedThisPass++;
+        });
+
+        if (fixedThisPass > 0 && !state.appliedLogged) {
+            Logger.log(`Embedded URL bar fit: adjusted ${fixedThisPass} toolbar row(s) this pass`);
+            state.appliedLogged = true;
+        }
+    }
+};

--- a/plugins/archetypes/comp-use-task-creation/main/embedded-urlbar-fit.js
+++ b/plugins/archetypes/comp-use-task-creation/main/embedded-urlbar-fit.js
@@ -1,0 +1,62 @@
+// ============= embedded-urlbar-fit.js =============
+const plugin = {
+    id: 'compUseTaskCreationEmbeddedUrlbarFit',
+    name: 'Computer Use Task Creation Embedded URL Bar Fit',
+    description:
+        'Keeps embedded instance toolbar right-side controls visible by forcing URL segment to shrink/truncate',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, appliedLogged: false },
+
+    onMutation(state) {
+        const rows = Context.dom.queryAll('div.flex.items-center.gap-1.p-1.border-b.h-10.bg-background', {
+            context: `${this.id}.toolbarRows`
+        });
+
+        if (rows.length === 0) {
+            if (!state.missingLogged) {
+                Logger.debug('Embedded URL bar fit: no embedded toolbar rows found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        let fixedThisPass = 0;
+
+        rows.forEach((row) => {
+            const rowText = row.textContent || '';
+            if (!rowText.includes('Remote Copy') || !rowText.includes('Remote Paste')) return;
+
+            const directGroups = Array.from(row.children).filter(
+                (el) => el.tagName === 'DIV' && el.classList.contains('flex') && el.classList.contains('items-center')
+            );
+            if (directGroups.length < 3) return;
+
+            const middleGroup = directGroups[1];
+            const rightGroup = directGroups[2];
+
+            middleGroup.classList.add('min-w-0');
+            middleGroup.classList.add('overflow-hidden');
+            rightGroup.classList.add('shrink-0');
+
+            const urlPill = middleGroup.querySelector(':scope > div.flex-1');
+            if (urlPill) {
+                urlPill.classList.add('min-w-0');
+            }
+
+            const urlButton = middleGroup.querySelector('button.w-full');
+            if (urlButton) {
+                urlButton.classList.add('min-w-0');
+            }
+
+            fixedThisPass++;
+        });
+
+        if (fixedThisPass > 0 && !state.appliedLogged) {
+            Logger.log(`Embedded URL bar fit: adjusted ${fixedThisPass} toolbar row(s) this pass`);
+            state.appliedLogged = true;
+        }
+    }
+};

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -8,7 +8,7 @@ const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -66,6 +66,7 @@ const plugin = {
 
     setup(state, textarea) {
         // 1 s debounce on every keystroke
+        // (CleanupRegistry.registerEventListener also calls addEventListener internally)
         const onInput = () => {
             this.setStatus(state, 'pending');
             if (state.saveDebounceTimer) clearTimeout(state.saveDebounceTimer);
@@ -74,7 +75,6 @@ const plugin = {
                 state.saveDebounceTimer = null;
             }, 1000);
         };
-        textarea.addEventListener('input', onInput);
         CleanupRegistry.registerEventListener(textarea, 'input', onInput);
 
         // Interval check: also saves every 1 s when no debounce is pending
@@ -82,9 +82,7 @@ const plugin = {
         state.saveIntervalId = setInterval(() => {
             if (!state.saveDebounceTimer) this.maybeSave(state);
         }, 1000);
-        CleanupRegistry.registerCallback(() => {
-            if (state.saveIntervalId) clearInterval(state.saveIntervalId);
-        });
+        CleanupRegistry.registerInterval(state.saveIntervalId);
 
         // Restore button (shown once on page load)
         this.maybeShowRestoreButton(state, textarea);

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -1,0 +1,273 @@
+// ============= prompt-cache.js =============
+// Auto-saves the prompt textarea content to local storage every 1 s (or 1 s after
+// the user finishes typing, whichever fires later).  When the page reloads with the
+// same instance_id a "Restore previous prompt?" button is shown above the textarea.
+// A live save-status indicator (spinner → checkmark) is injected next to the label.
+
+const plugin = {
+    id: 'promptCache',
+    name: 'Prompt Cache',
+    description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    storageKeys: {
+        promptText: 'comp-use-prompt-cache-text',
+        instanceId:  'comp-use-prompt-cache-instance-id'
+    },
+
+    initialState: {
+        textarea:             null,
+        lastSavedValue:       null,
+        saveDebounceTimer:    null,
+        saveIntervalId:       null,
+        statusEl:             null,
+        restoreInjected:      false,
+        stylesInjected:       false,
+        missingLogged:        false
+    },
+
+    // ─── lifecycle ────────────────────────────────────────────────────────────
+
+    onMutation(state, context) {
+        if (!state.stylesInjected) {
+            this.injectStyles();
+            state.stylesInjected = true;
+        }
+
+        const textarea = document.getElementById('prompt-editor');
+        if (!textarea) {
+            if (!state.missingLogged) {
+                Logger.debug('Prompt Cache: prompt editor not found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        // Re-setup whenever the textarea element reference changes
+        if (state.textarea !== textarea) {
+            this.teardown(state);
+            state.textarea = textarea;
+            this.setup(state, textarea);
+        }
+
+        this.ensureStatusIndicator(state, textarea);
+    },
+
+    teardown(state) {
+        if (state.saveIntervalId)   { clearInterval(state.saveIntervalId);   state.saveIntervalId = null; }
+        if (state.saveDebounceTimer){ clearTimeout(state.saveDebounceTimer);  state.saveDebounceTimer = null; }
+        state.textarea        = null;
+        state.statusEl        = null;
+        state.restoreInjected = false;
+    },
+
+    setup(state, textarea) {
+        // 1 s debounce on every keystroke
+        const onInput = () => {
+            this.setStatus(state, 'pending');
+            if (state.saveDebounceTimer) clearTimeout(state.saveDebounceTimer);
+            state.saveDebounceTimer = setTimeout(() => {
+                this.save(state);
+                state.saveDebounceTimer = null;
+            }, 1000);
+        };
+        textarea.addEventListener('input', onInput);
+        CleanupRegistry.registerEventListener(textarea, 'input', onInput);
+
+        // Interval check: also saves every 1 s when no debounce is pending
+        // (catches React-driven value changes that bypass 'input' events)
+        state.saveIntervalId = setInterval(() => {
+            if (!state.saveDebounceTimer) this.maybeSave(state);
+        }, 1000);
+        CleanupRegistry.registerCallback(() => {
+            if (state.saveIntervalId) clearInterval(state.saveIntervalId);
+        });
+
+        // Restore button (shown once on page load)
+        this.maybeShowRestoreButton(state, textarea);
+
+        Logger.log('Prompt Cache: initialized');
+    },
+
+    // ─── save logic ───────────────────────────────────────────────────────────
+
+    maybeSave(state) {
+        if (!state.textarea) return;
+        if (state.textarea.value !== state.lastSavedValue) this.save(state);
+    },
+
+    save(state) {
+        if (!state.textarea) return;
+        const val        = state.textarea.value;
+        const instanceId = this.getCurrentInstanceId();
+        Storage.set(this.storageKeys.promptText, val);
+        Storage.set(this.storageKeys.instanceId,  instanceId);
+        state.lastSavedValue = val;
+        this.setStatus(state, 'saved');
+        Logger.debug(`Prompt Cache: saved ${val.length} chars (instance: ${instanceId})`);
+    },
+
+    getCurrentInstanceId() {
+        return new URLSearchParams(window.location.search).get('instance_id') || '';
+    },
+
+    // ─── restore button ───────────────────────────────────────────────────────
+
+    maybeShowRestoreButton(state, textarea) {
+        if (state.restoreInjected) return;
+
+        const savedText       = Storage.get(this.storageKeys.promptText, '');
+        const savedInstanceId = Storage.get(this.storageKeys.instanceId,  '');
+        const currentId       = this.getCurrentInstanceId();
+
+        if (!savedText || !savedInstanceId || !currentId) {
+            Logger.debug('Prompt Cache: no saved data or missing instance_id, skipping restore');
+            return;
+        }
+        if (savedInstanceId !== currentId) {
+            Logger.debug(`Prompt Cache: saved instance (${savedInstanceId}) ≠ current (${currentId}), skipping restore`);
+            return;
+        }
+        if (savedText === textarea.value) {
+            Logger.debug('Prompt Cache: saved text already matches textarea, skipping restore');
+            return;
+        }
+
+        // DOM path: textarea → rounded-md container → div.relative wrapper → section
+        const container = textarea.closest('.flex.flex-col.relative.rounded-md') || textarea.parentElement;
+        const wrapper   = container ? container.parentElement : null;
+        const section   = wrapper   ? wrapper.parentElement   : null;
+
+        if (!section) {
+            Logger.warn('Prompt Cache: could not locate section for restore button');
+            return;
+        }
+
+        const btn = document.createElement('button');
+        btn.type  = 'button';
+        btn.setAttribute('data-fleet-prompt-cache-restore', 'true');
+        btn.className   = 'fleet-prompt-cache-restore-btn';
+        btn.textContent = 'Restore previous prompt?';
+
+        btn.addEventListener('click', () => {
+            this.setTextareaValueReactFriendly(textarea, savedText);
+            btn.remove();
+            state.restoreInjected = false;
+            Logger.log('Prompt Cache: restored saved prompt');
+        });
+
+        section.insertBefore(btn, wrapper);
+        state.restoreInjected = true;
+        Logger.info('Prompt Cache: restore button shown for instance ' + currentId);
+    },
+
+    // ─── status indicator ─────────────────────────────────────────────────────
+
+    ensureStatusIndicator(state, textarea) {
+        // Re-use if still in DOM
+        if (state.statusEl && document.contains(state.statusEl)) return;
+
+        const container = textarea.closest('.flex.flex-col.relative.rounded-md') || textarea.parentElement;
+        const wrapper   = container ? container.parentElement : null;
+        const section   = wrapper   ? wrapper.parentElement   : null;
+        if (!section) return;
+
+        const labelRow = section.querySelector('.flex.items-center.justify-between');
+        if (!labelRow) return;
+
+        const labelDiv = labelRow.querySelector('.text-sm.text-muted-foreground.font-medium');
+        if (!labelDiv) return;
+
+        if (labelDiv.querySelector('[data-fleet-prompt-cache-status]')) return;
+
+        const el = document.createElement('span');
+        el.setAttribute('data-fleet-prompt-cache-status', 'true');
+        el.style.cssText = 'display:inline-flex;align-items:center;margin-left:6px;vertical-align:middle;';
+        labelDiv.appendChild(el);
+        state.statusEl = el;
+
+        // Show initial status
+        const isSaved = state.lastSavedValue !== null && textarea.value === state.lastSavedValue;
+        this.setStatus(state, isSaved ? 'saved' : 'pending');
+    },
+
+    setStatus(state, status) {
+        if (!state.statusEl) return;
+        if (status === 'saved') {
+            state.statusEl.title = 'Prompt saved';
+            state.statusEl.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="rgb(34,197,94)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+        } else {
+            state.statusEl.title = 'Saving prompt…';
+            state.statusEl.innerHTML = `<svg class="fleet-prompt-cache-spinner" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>`;
+        }
+    },
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    injectStyles() {
+        if (document.getElementById('fleet-prompt-cache-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'fleet-prompt-cache-styles';
+        style.textContent = `
+            @keyframes fleet-prompt-cache-spin {
+                from { transform: rotate(0deg); }
+                to   { transform: rotate(360deg); }
+            }
+            .fleet-prompt-cache-spinner {
+                animation: fleet-prompt-cache-spin 1s linear infinite;
+                display: block;
+            }
+            @keyframes fleet-prompt-cache-flash-yellow {
+                0%, 100% {
+                    border-color: rgba(234, 179, 8, 0.9);
+                    box-shadow: 0 0 0 0 rgba(234, 179, 8, 0.4);
+                }
+                50% {
+                    border-color: rgba(234, 179, 8, 0.25);
+                    box-shadow: 0 0 0 4px rgba(234, 179, 8, 0.15);
+                }
+            }
+            .fleet-prompt-cache-restore-btn {
+                display: block;
+                width: 100%;
+                text-align: center;
+                padding: 6px 12px;
+                margin-bottom: 6px;
+                font-size: 0.75rem;
+                font-weight: 500;
+                border-radius: 4px;
+                cursor: pointer;
+                background-color: transparent;
+                color: inherit;
+                border: 2px solid rgba(234, 179, 8, 0.9);
+                animation: fleet-prompt-cache-flash-yellow 1.2s ease-in-out infinite;
+                transition: background-color 0.15s;
+            }
+            .fleet-prompt-cache-restore-btn:hover {
+                background-color: rgba(234, 179, 8, 0.08);
+            }
+        `;
+        document.head.appendChild(style);
+        Logger.debug('Prompt Cache: styles injected');
+    },
+
+    setTextareaValueReactFriendly(textarea, value) {
+        textarea.focus();
+        const previousValue = textarea.value;
+        const proto      = Object.getPrototypeOf(textarea);
+        const descriptor = Object.getOwnPropertyDescriptor(proto, 'value');
+        if (descriptor && descriptor.set) {
+            descriptor.set.call(textarea, value);
+        } else {
+            textarea.value = value;
+        }
+        if (textarea._valueTracker && typeof textarea._valueTracker.setValue === 'function') {
+            try { textarea._valueTracker.setValue(previousValue); } catch (_) { /* ignore */ }
+        }
+        textarea.dispatchEvent(new Event('input',  { bubbles: true }));
+        textarea.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+};

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -8,7 +8,7 @@ const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -191,9 +191,11 @@ const plugin = {
                     this.removeRestoreButtons(state);
                     Logger.log('Prompt Cache: confirmed restore of last saved prompt');
                 } else {
+                    this.setTextareaValueReactFriendly(textarea, savedText);
                     state.selectedVersion = 'current';
                     this.setBtnConfirm(btn1);
                     this.setBtnDefault(btn2);
+                    Logger.debug('Prompt Cache: previewing last saved prompt');
                 }
             });
 
@@ -203,9 +205,11 @@ const plugin = {
                     this.removeRestoreButtons(state);
                     Logger.log('Prompt Cache: confirmed restore of previous prompt');
                 } else {
+                    this.setTextareaValueReactFriendly(textarea, prevText);
                     state.selectedVersion = 'previous';
                     this.setBtnConfirm(btn2);
                     this.setBtnDefault(btn1);
+                    Logger.debug('Prompt Cache: previewing previous prompt');
                 }
             });
 

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -8,7 +8,7 @@ const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '2.1',
+    _version: '2.2',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -27,8 +27,9 @@ const plugin = {
         statusCurrent:     null,   // 'pending' | 'saved' — only write DOM on transitions
         restoreInjected:   false,
         restoreWrapperEl:  null,
-        restoreInitialText: '',    // textarea value at the time buttons were injected
-        selectedVersion:   null,   // 'current' | 'previous' — which btn is in confirm state
+        restoreInitialText:   '',    // textarea value at the time buttons were injected
+        selectedVersion:      null,  // 'current' | 'previous' — which btn is in confirm state
+        suppressRestoreCheck: false, // true while plugin-driven paste fires its synthetic input
         stylesInjected:    false,
         missingLogged:     false
     },
@@ -175,7 +176,7 @@ const plugin = {
             // Single button: no confirm step — click directly restores and dismisses
             const btn = this.makeRestoreBtn('Restore last saved prompt?');
             btn.addEventListener('click', () => {
-                this.setTextareaValueReactFriendly(textarea, savedText);
+                this.pastePreview(state, textarea, savedText);
                 this.removeRestoreButtons(state);
                 Logger.log('Prompt Cache: restored last saved prompt (single version)');
             });
@@ -187,11 +188,10 @@ const plugin = {
 
             btn1.addEventListener('click', () => {
                 if (state.selectedVersion === 'current') {
-                    this.setTextareaValueReactFriendly(textarea, savedText);
                     this.removeRestoreButtons(state);
                     Logger.log('Prompt Cache: confirmed restore of last saved prompt');
                 } else {
-                    this.setTextareaValueReactFriendly(textarea, savedText);
+                    this.pastePreview(state, textarea, savedText);
                     state.selectedVersion = 'current';
                     this.setBtnConfirm(btn1);
                     this.setBtnDefault(btn2);
@@ -201,11 +201,10 @@ const plugin = {
 
             btn2.addEventListener('click', () => {
                 if (state.selectedVersion === 'previous') {
-                    this.setTextareaValueReactFriendly(textarea, prevText);
                     this.removeRestoreButtons(state);
                     Logger.log('Prompt Cache: confirmed restore of previous prompt');
                 } else {
-                    this.setTextareaValueReactFriendly(textarea, prevText);
+                    this.pastePreview(state, textarea, prevText);
                     state.selectedVersion = 'previous';
                     this.setBtnConfirm(btn2);
                     this.setBtnDefault(btn1);
@@ -223,6 +222,14 @@ const plugin = {
         state.restoreInitialText = textarea.value;
         state.selectedVersion    = null;
         Logger.info(`Prompt Cache: restore button(s) shown (hasPrev: ${hasPrevious}) for instance ${currentId}`);
+    },
+
+    pastePreview(state, textarea, text) {
+        // Suppress the synthetic input event so our own paste doesn't trip the
+        // "user typed something new → dismiss buttons" check.
+        state.suppressRestoreCheck = true;
+        this.setTextareaValueReactFriendly(textarea, text);
+        state.suppressRestoreCheck = false;
     },
 
     makeRestoreBtn(label) {
@@ -247,6 +254,8 @@ const plugin = {
 
     maybeRemoveRestoreButtonsAfterTyping(state) {
         if (!state.restoreInjected || !state.textarea) return;
+        // Ignore the synthetic input event fired by our own preview paste
+        if (state.suppressRestoreCheck) return;
         if (state.textarea.value === state.restoreInitialText) return;
         this.removeRestoreButtons(state);
         Logger.info('Prompt Cache: restore buttons removed after user changed prompt text');

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -8,7 +8,7 @@ const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '1.3',
+    _version: '1.4',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -101,18 +101,27 @@ const plugin = {
 
     maybeSave(state) {
         if (!state.textarea) return;
+        if (!this.hasSavableContent(state.textarea.value)) return;
         if (state.textarea.value !== state.lastSavedValue) this.save(state);
     },
 
     save(state) {
         if (!state.textarea) return;
         const val        = state.textarea.value;
+        if (!this.hasSavableContent(val)) {
+            Logger.debug('Prompt Cache: skipped save for empty prompt');
+            return;
+        }
         const instanceId = this.getCurrentInstanceId();
         Storage.set(this.storageKeys.promptText, val);
         Storage.set(this.storageKeys.instanceId,  instanceId);
         state.lastSavedValue = val;
         this.setStatus(state, 'saved');
         Logger.debug(`Prompt Cache: saved ${val.length} chars (instance: ${instanceId})`);
+    },
+
+    hasSavableContent(value) {
+        return typeof value === 'string' && value.trim().length > 0;
     },
 
     getCurrentInstanceId() {

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -8,7 +8,7 @@ const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '1.2',
+    _version: '1.3',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -23,6 +23,7 @@ const plugin = {
         saveDebounceTimer:    null,
         saveIntervalId:       null,
         statusEl:             null,
+        statusCurrent:        null, // 'pending' | 'saved' — only write DOM on transitions
         restoreInjected:      false,
         restoreButtonEl:      null,
         restoreSourceText:    '',
@@ -63,6 +64,7 @@ const plugin = {
         if (state.saveDebounceTimer){ clearTimeout(state.saveDebounceTimer);  state.saveDebounceTimer = null; }
         state.textarea        = null;
         state.statusEl        = null;
+        state.statusCurrent   = null;
         state.restoreInjected = false;
         state.restoreButtonEl = null;
         state.restoreSourceText = '';
@@ -209,12 +211,21 @@ const plugin = {
         labelDiv.appendChild(el);
         state.statusEl = el;
 
-        // Show initial status
+        // Force re-render into the fresh element (statusCurrent is still set from before
+        // if the element was simply evicted from the DOM, so we clear it first)
+        const prev = state.statusCurrent;
+        state.statusCurrent = null;
         const isSaved = state.lastSavedValue !== null && textarea.value === state.lastSavedValue;
-        this.setStatus(state, isSaved ? 'saved' : 'pending');
+        this.setStatus(state, prev !== null ? prev : (isSaved ? 'saved' : 'pending'));
     },
 
     setStatus(state, status) {
+        // Guard: only touch the DOM when the status actually changes.
+        // Re-writing innerHTML on every keystroke (a) resets the spinner animation and
+        // (b) generates DOM mutations that can cause React to re-render the surrounding
+        // form and snap the textarea back to a stale value.
+        if (status === state.statusCurrent) return;
+        state.statusCurrent = status;
         if (!state.statusEl) return;
         if (status === 'saved') {
             state.statusEl.title = 'Prompt saved';

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -1,34 +1,36 @@
 // ============= prompt-cache.js =============
 // Auto-saves the prompt textarea content to local storage every 1 s (or 1 s after
-// the user finishes typing, whichever fires later).  When the page reloads with the
-// same instance_id a "Restore previous prompt?" button is shown above the textarea.
+// the user finishes typing, whichever fires later).  Keeps the two most-recent
+// non-empty saves so the user can restore either on page reload.
 // A live save-status indicator (spinner → checkmark) is injected next to the label.
 
 const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '1.4',
+    _version: '2.0',
     enabledByDefault: true,
     phase: 'mutation',
 
     storageKeys: {
-        promptText: 'comp-use-prompt-cache-text',
-        instanceId:  'comp-use-prompt-cache-instance-id'
+        promptText:     'comp-use-prompt-cache-text',
+        promptPrevText: 'comp-use-prompt-cache-prev-text',
+        instanceId:     'comp-use-prompt-cache-instance-id'
     },
 
     initialState: {
-        textarea:             null,
-        lastSavedValue:       null,
-        saveDebounceTimer:    null,
-        saveIntervalId:       null,
-        statusEl:             null,
-        statusCurrent:        null, // 'pending' | 'saved' — only write DOM on transitions
-        restoreInjected:      false,
-        restoreButtonEl:      null,
-        restoreSourceText:    '',
-        stylesInjected:       false,
-        missingLogged:        false
+        textarea:          null,
+        lastSavedValue:    null,
+        saveDebounceTimer: null,
+        saveIntervalId:    null,
+        statusEl:          null,
+        statusCurrent:     null,   // 'pending' | 'saved' — only write DOM on transitions
+        restoreInjected:   false,
+        restoreWrapperEl:  null,
+        restoreInitialText: '',    // textarea value at the time buttons were injected
+        selectedVersion:   null,   // 'current' | 'previous' — which btn is in confirm state
+        stylesInjected:    false,
+        missingLogged:     false
     },
 
     // ─── lifecycle ────────────────────────────────────────────────────────────
@@ -49,7 +51,6 @@ const plugin = {
         }
         state.missingLogged = false;
 
-        // Re-setup whenever the textarea element reference changes
         if (state.textarea !== textarea) {
             this.teardown(state);
             state.textarea = textarea;
@@ -60,21 +61,20 @@ const plugin = {
     },
 
     teardown(state) {
-        if (state.saveIntervalId)   { clearInterval(state.saveIntervalId);   state.saveIntervalId = null; }
-        if (state.saveDebounceTimer){ clearTimeout(state.saveDebounceTimer);  state.saveDebounceTimer = null; }
-        state.textarea        = null;
-        state.statusEl        = null;
-        state.statusCurrent   = null;
-        state.restoreInjected = false;
-        state.restoreButtonEl = null;
-        state.restoreSourceText = '';
+        if (state.saveIntervalId)    { clearInterval(state.saveIntervalId);   state.saveIntervalId = null; }
+        if (state.saveDebounceTimer) { clearTimeout(state.saveDebounceTimer);  state.saveDebounceTimer = null; }
+        state.textarea          = null;
+        state.statusEl          = null;
+        state.statusCurrent     = null;
+        state.restoreInjected   = false;
+        state.restoreWrapperEl  = null;
+        state.restoreInitialText = '';
+        state.selectedVersion   = null;
     },
 
     setup(state, textarea) {
-        // 1 s debounce on every keystroke
-        // (CleanupRegistry.registerEventListener also calls addEventListener internally)
         const onInput = () => {
-            this.maybeRemoveRestoreButtonAfterTyping(state);
+            this.maybeRemoveRestoreButtonsAfterTyping(state);
             this.setStatus(state, 'pending');
             if (state.saveDebounceTimer) clearTimeout(state.saveDebounceTimer);
             state.saveDebounceTimer = setTimeout(() => {
@@ -82,17 +82,15 @@ const plugin = {
                 state.saveDebounceTimer = null;
             }, 1000);
         };
+        // registerEventListener also calls addEventListener internally
         CleanupRegistry.registerEventListener(textarea, 'input', onInput);
 
-        // Interval check: also saves every 1 s when no debounce is pending
-        // (catches React-driven value changes that bypass 'input' events)
         state.saveIntervalId = setInterval(() => {
             if (!state.saveDebounceTimer) this.maybeSave(state);
         }, 1000);
         CleanupRegistry.registerInterval(state.saveIntervalId);
 
-        // Restore button (shown once on page load)
-        this.maybeShowRestoreButton(state, textarea);
+        this.maybeShowRestoreButtons(state, textarea);
 
         Logger.log('Prompt Cache: initialized');
     },
@@ -107,12 +105,19 @@ const plugin = {
 
     save(state) {
         if (!state.textarea) return;
-        const val        = state.textarea.value;
+        const val = state.textarea.value;
         if (!this.hasSavableContent(val)) {
             Logger.debug('Prompt Cache: skipped save for empty prompt');
             return;
         }
-        const instanceId = this.getCurrentInstanceId();
+        const instanceId    = this.getCurrentInstanceId();
+        const currentStored = Storage.get(this.storageKeys.promptText, '');
+
+        // Rotate current → previous before overwriting (only when content actually differs)
+        if (this.hasSavableContent(currentStored) && currentStored !== val) {
+            Storage.set(this.storageKeys.promptPrevText, currentStored);
+        }
+
         Storage.set(this.storageKeys.promptText, val);
         Storage.set(this.storageKeys.instanceId,  instanceId);
         state.lastSavedValue = val;
@@ -128,13 +133,14 @@ const plugin = {
         return new URLSearchParams(window.location.search).get('instance_id') || '';
     },
 
-    // ─── restore button ───────────────────────────────────────────────────────
+    // ─── restore buttons ──────────────────────────────────────────────────────
 
-    maybeShowRestoreButton(state, textarea) {
+    maybeShowRestoreButtons(state, textarea) {
         if (state.restoreInjected) return;
 
-        const savedText       = Storage.get(this.storageKeys.promptText, '');
-        const savedInstanceId = Storage.get(this.storageKeys.instanceId,  '');
+        const savedText       = Storage.get(this.storageKeys.promptText,     '');
+        const prevText        = Storage.get(this.storageKeys.promptPrevText,  '');
+        const savedInstanceId = Storage.get(this.storageKeys.instanceId,      '');
         const currentId       = this.getCurrentInstanceId();
 
         if (!savedText || !savedInstanceId || !currentId) {
@@ -150,55 +156,111 @@ const plugin = {
             return;
         }
 
-        // DOM path: textarea → rounded-md container → div.relative wrapper → section
         const container = textarea.closest('.flex.flex-col.relative.rounded-md') || textarea.parentElement;
         const wrapper   = container ? container.parentElement : null;
         const section   = wrapper   ? wrapper.parentElement   : null;
 
         if (!section) {
-            Logger.warn('Prompt Cache: could not locate section for restore button');
+            Logger.warn('Prompt Cache: could not locate section for restore buttons');
             return;
         }
 
+        const hasPrevious = this.hasSavableContent(prevText) && prevText !== savedText;
+
+        const wrapperEl = document.createElement('div');
+        wrapperEl.setAttribute('data-fleet-prompt-cache-restore-wrapper', 'true');
+        wrapperEl.style.cssText = 'display:flex;flex-direction:column;gap:4px;margin-bottom:6px;';
+
+        if (!hasPrevious) {
+            // Single button: no confirm step — click directly restores and dismisses
+            const btn = this.makeRestoreBtn('Restore last saved prompt?');
+            btn.addEventListener('click', () => {
+                this.setTextareaValueReactFriendly(textarea, savedText);
+                this.removeRestoreButtons(state);
+                Logger.log('Prompt Cache: restored last saved prompt (single version)');
+            });
+            wrapperEl.appendChild(btn);
+        } else {
+            // Two buttons: toggle-select → confirm pattern
+            const btn1 = this.makeRestoreBtn('Restore last saved prompt?');
+            const btn2 = this.makeRestoreBtn('Restore previous to last saved prompt?');
+
+            btn1.addEventListener('click', () => {
+                if (state.selectedVersion === 'current') {
+                    this.setTextareaValueReactFriendly(textarea, savedText);
+                    this.removeRestoreButtons(state);
+                    Logger.log('Prompt Cache: confirmed restore of last saved prompt');
+                } else {
+                    state.selectedVersion = 'current';
+                    this.setBtnConfirm(btn1);
+                    this.setBtnDefault(btn2);
+                }
+            });
+
+            btn2.addEventListener('click', () => {
+                if (state.selectedVersion === 'previous') {
+                    this.setTextareaValueReactFriendly(textarea, prevText);
+                    this.removeRestoreButtons(state);
+                    Logger.log('Prompt Cache: confirmed restore of previous prompt');
+                } else {
+                    state.selectedVersion = 'previous';
+                    this.setBtnConfirm(btn2);
+                    this.setBtnDefault(btn1);
+                }
+            });
+
+            wrapperEl.appendChild(btn1);
+            wrapperEl.appendChild(btn2);
+        }
+
+        section.insertBefore(wrapperEl, wrapper);
+        state.restoreInjected    = true;
+        state.restoreWrapperEl   = wrapperEl;
+        state.restoreInitialText = textarea.value;
+        state.selectedVersion    = null;
+        Logger.info(`Prompt Cache: restore button(s) shown (hasPrev: ${hasPrevious}) for instance ${currentId}`);
+    },
+
+    makeRestoreBtn(label) {
         const btn = document.createElement('button');
         btn.type  = 'button';
         btn.setAttribute('data-fleet-prompt-cache-restore', 'true');
+        btn.setAttribute('data-fleet-restore-label', label);
         btn.className   = 'fleet-prompt-cache-restore-btn';
-        btn.textContent = 'Restore previous prompt?';
-
-        btn.addEventListener('click', () => {
-            this.setTextareaValueReactFriendly(textarea, savedText);
-            this.removeRestoreButton(state);
-            Logger.log('Prompt Cache: restored saved prompt');
-        });
-
-        section.insertBefore(btn, wrapper);
-        state.restoreInjected = true;
-        state.restoreButtonEl = btn;
-        state.restoreSourceText = savedText;
-        Logger.info('Prompt Cache: restore button shown for instance ' + currentId);
+        btn.textContent = label;
+        return btn;
     },
 
-    maybeRemoveRestoreButtonAfterTyping(state) {
-        if (!state.restoreInjected || !state.restoreButtonEl || !state.textarea) return;
-        if (state.textarea.value === state.restoreSourceText) return;
-        this.removeRestoreButton(state);
-        Logger.info('Prompt Cache: restore button removed after user changed prompt text');
+    setBtnConfirm(btn) {
+        btn.className   = 'fleet-prompt-cache-restore-btn fleet-prompt-cache-restore-btn--confirm';
+        btn.textContent = 'Confirm Version';
     },
 
-    removeRestoreButton(state) {
-        if (state.restoreButtonEl && document.contains(state.restoreButtonEl)) {
-            state.restoreButtonEl.remove();
+    setBtnDefault(btn) {
+        btn.className   = 'fleet-prompt-cache-restore-btn';
+        btn.textContent = btn.getAttribute('data-fleet-restore-label') || btn.textContent;
+    },
+
+    maybeRemoveRestoreButtonsAfterTyping(state) {
+        if (!state.restoreInjected || !state.textarea) return;
+        if (state.textarea.value === state.restoreInitialText) return;
+        this.removeRestoreButtons(state);
+        Logger.info('Prompt Cache: restore buttons removed after user changed prompt text');
+    },
+
+    removeRestoreButtons(state) {
+        if (state.restoreWrapperEl && document.contains(state.restoreWrapperEl)) {
+            state.restoreWrapperEl.remove();
         }
-        state.restoreInjected = false;
-        state.restoreButtonEl = null;
-        state.restoreSourceText = '';
+        state.restoreInjected    = false;
+        state.restoreWrapperEl   = null;
+        state.restoreInitialText = '';
+        state.selectedVersion    = null;
     },
 
     // ─── status indicator ─────────────────────────────────────────────────────
 
     ensureStatusIndicator(state, textarea) {
-        // Re-use if still in DOM
         if (state.statusEl && document.contains(state.statusEl)) return;
 
         const container = textarea.closest('.flex.flex-col.relative.rounded-md') || textarea.parentElement;
@@ -220,8 +282,7 @@ const plugin = {
         labelDiv.appendChild(el);
         state.statusEl = el;
 
-        // Force re-render into the fresh element (statusCurrent is still set from before
-        // if the element was simply evicted from the DOM, so we clear it first)
+        // Re-render into the fresh element; reset current so setStatus will actually write
         const prev = state.statusCurrent;
         state.statusCurrent = null;
         const isSaved = state.lastSavedValue !== null && textarea.value === state.lastSavedValue;
@@ -229,10 +290,9 @@ const plugin = {
     },
 
     setStatus(state, status) {
-        // Guard: only touch the DOM when the status actually changes.
-        // Re-writing innerHTML on every keystroke (a) resets the spinner animation and
-        // (b) generates DOM mutations that can cause React to re-render the surrounding
-        // form and snap the textarea back to a stale value.
+        // Only touch the DOM when status transitions — avoids restarting the spinner
+        // animation and prevents DOM mutations near the textarea that can trigger
+        // React to reconcile the form with a stale value.
         if (status === state.statusCurrent) return;
         state.statusCurrent = status;
         if (!state.statusEl) return;
@@ -275,7 +335,6 @@ const plugin = {
                 width: 100%;
                 text-align: center;
                 padding: 6px 12px;
-                margin-bottom: 6px;
                 font-size: 0.75rem;
                 font-weight: 500;
                 border-radius: 4px;
@@ -284,10 +343,18 @@ const plugin = {
                 color: inherit;
                 border: 2px solid rgba(234, 179, 8, 0.9);
                 animation: fleet-prompt-cache-flash-yellow 1.2s ease-in-out infinite;
-                transition: background-color 0.15s;
+                transition: background-color 0.15s, color 0.15s, border-color 0.15s;
             }
             .fleet-prompt-cache-restore-btn:hover {
                 background-color: rgba(234, 179, 8, 0.08);
+            }
+            .fleet-prompt-cache-restore-btn--confirm {
+                border-color: rgb(34, 197, 94);
+                color: rgb(34, 197, 94);
+                animation: none;
+            }
+            .fleet-prompt-cache-restore-btn--confirm:hover {
+                background-color: rgba(34, 197, 94, 0.08);
             }
         `;
         document.head.appendChild(style);

--- a/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
+++ b/plugins/archetypes/comp-use-task-creation/main/prompt-cache.js
@@ -8,7 +8,7 @@ const plugin = {
     id: 'promptCache',
     name: 'Prompt Cache',
     description: 'Auto-saves the prompt and offers to restore it when returning to the same task instance',
-    _version: '1.1',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -24,6 +24,8 @@ const plugin = {
         saveIntervalId:       null,
         statusEl:             null,
         restoreInjected:      false,
+        restoreButtonEl:      null,
+        restoreSourceText:    '',
         stylesInjected:       false,
         missingLogged:        false
     },
@@ -62,12 +64,15 @@ const plugin = {
         state.textarea        = null;
         state.statusEl        = null;
         state.restoreInjected = false;
+        state.restoreButtonEl = null;
+        state.restoreSourceText = '';
     },
 
     setup(state, textarea) {
         // 1 s debounce on every keystroke
         // (CleanupRegistry.registerEventListener also calls addEventListener internally)
         const onInput = () => {
+            this.maybeRemoveRestoreButtonAfterTyping(state);
             this.setStatus(state, 'pending');
             if (state.saveDebounceTimer) clearTimeout(state.saveDebounceTimer);
             state.saveDebounceTimer = setTimeout(() => {
@@ -152,14 +157,31 @@ const plugin = {
 
         btn.addEventListener('click', () => {
             this.setTextareaValueReactFriendly(textarea, savedText);
-            btn.remove();
-            state.restoreInjected = false;
+            this.removeRestoreButton(state);
             Logger.log('Prompt Cache: restored saved prompt');
         });
 
         section.insertBefore(btn, wrapper);
         state.restoreInjected = true;
+        state.restoreButtonEl = btn;
+        state.restoreSourceText = savedText;
         Logger.info('Prompt Cache: restore button shown for instance ' + currentId);
+    },
+
+    maybeRemoveRestoreButtonAfterTyping(state) {
+        if (!state.restoreInjected || !state.restoreButtonEl || !state.textarea) return;
+        if (state.textarea.value === state.restoreSourceText) return;
+        this.removeRestoreButton(state);
+        Logger.info('Prompt Cache: restore button removed after user changed prompt text');
+    },
+
+    removeRestoreButton(state) {
+        if (state.restoreButtonEl && document.contains(state.restoreButtonEl)) {
+            state.restoreButtonEl.remove();
+        }
+        state.restoreInjected = false;
+        state.restoreButtonEl = null;
+        state.restoreSourceText = '';
     },
 
     // ─── status indicator ─────────────────────────────────────────────────────

--- a/plugins/archetypes/qa-comp-use/main/embedded-urlbar-fit.js
+++ b/plugins/archetypes/qa-comp-use/main/embedded-urlbar-fit.js
@@ -1,0 +1,62 @@
+// ============= embedded-urlbar-fit.js =============
+const plugin = {
+    id: 'qaCompUseEmbeddedUrlbarFit',
+    name: 'QA Computer Use Embedded URL Bar Fit',
+    description:
+        'Keeps embedded instance toolbar right-side controls visible by forcing URL segment to shrink/truncate',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, appliedLogged: false },
+
+    onMutation(state) {
+        const rows = Context.dom.queryAll('div.flex.items-center.gap-1.p-1.border-b.h-10.bg-background', {
+            context: `${this.id}.toolbarRows`
+        });
+
+        if (rows.length === 0) {
+            if (!state.missingLogged) {
+                Logger.debug('Embedded URL bar fit: no embedded toolbar rows found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        let fixedThisPass = 0;
+
+        rows.forEach((row) => {
+            const rowText = row.textContent || '';
+            if (!rowText.includes('Remote Copy') || !rowText.includes('Remote Paste')) return;
+
+            const directGroups = Array.from(row.children).filter(
+                (el) => el.tagName === 'DIV' && el.classList.contains('flex') && el.classList.contains('items-center')
+            );
+            if (directGroups.length < 3) return;
+
+            const middleGroup = directGroups[1];
+            const rightGroup = directGroups[2];
+
+            middleGroup.classList.add('min-w-0');
+            middleGroup.classList.add('overflow-hidden');
+            rightGroup.classList.add('shrink-0');
+
+            const urlPill = middleGroup.querySelector(':scope > div.flex-1');
+            if (urlPill) {
+                urlPill.classList.add('min-w-0');
+            }
+
+            const urlButton = middleGroup.querySelector('button.w-full');
+            if (urlButton) {
+                urlButton.classList.add('min-w-0');
+            }
+
+            fixedThisPass++;
+        });
+
+        if (fixedThisPass > 0 && !state.appliedLogged) {
+            Logger.log(`Embedded URL bar fit: adjusted ${fixedThisPass} toolbar row(s) this pass`);
+            state.appliedLogged = true;
+        }
+    }
+};

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.10',
+    _version: '2.11',
     enabledByDefault: true,
     phase: 'core',
 
@@ -126,7 +126,9 @@ const plugin = {
         header.style.justifyContent = 'space-between';
 
         const headerTitle = document.createElement('span');
-        headerTitle.textContent = 'Fleet UX Logs';
+        const scriptVersion = context && context.version ? context.version : (typeof Context !== 'undefined' ? (Context.version || '?') : '?');
+        const archetypesVersion = (typeof Context !== 'undefined' && Context.archetypesVersion) ? Context.archetypesVersion : '?';
+        headerTitle.textContent = `Logs · v${scriptVersion} · a${archetypesVersion}`;
 
         const headerActions = document.createElement('div');
         headerActions.style.display = 'flex';

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.9',
+    _version: '2.10',
     enabledByDefault: true,
     phase: 'core',
 
@@ -635,26 +635,29 @@ const plugin = {
 
     _flashDevLoggerCopyFeedback(targetEl, success) {
         if (targetEl._fleetLoggerCopyT) clearTimeout(targetEl._fleetLoggerCopyT);
+        const prevBackgroundColor = targetEl.style.backgroundColor;
+        const prevColor = targetEl.style.color;
+        const prevTransition = targetEl.style.transition;
         if (success) {
             targetEl.style.transition = '';
             targetEl.style.backgroundColor = 'rgb(34, 197, 94)';
             targetEl.style.color = '#ffffff';
             targetEl._fleetLoggerCopyT = setTimeout(() => {
-                targetEl.style.backgroundColor = '';
-                targetEl.style.color = '';
+                targetEl.style.backgroundColor = prevBackgroundColor;
+                targetEl.style.color = prevColor;
+                targetEl.style.transition = prevTransition;
                 targetEl._fleetLoggerCopyT = null;
             }, 1000);
         } else {
-            const prevT = targetEl.style.transition;
             targetEl.style.transition = 'none';
             targetEl.style.backgroundColor = 'rgb(239, 68, 68)';
             targetEl.style.color = '#ffffff';
             void targetEl.offsetHeight;
             targetEl.style.transition = 'background-color 500ms ease-out, color 500ms ease-out';
-            targetEl.style.backgroundColor = '';
-            targetEl.style.color = '';
+            targetEl.style.backgroundColor = prevBackgroundColor;
+            targetEl.style.color = prevColor;
             targetEl._fleetLoggerCopyT = setTimeout(() => {
-                targetEl.style.transition = prevT || '';
+                targetEl.style.transition = prevTransition;
                 targetEl._fleetLoggerCopyT = null;
             }, 500);
         }


### PR DESCRIPTION
## Summary

Adds two new capability modules to the computer-use archetype family: a **prompt-cache** plugin that persists and restores the user's prompt text with a two-version history and toggle-confirm restore UI, and an **embedded-urlbar-fit** plugin that keeps embedded URL bar controls fully visible. Both are propagated consistently across the relevant computer-use archetypes.

## Changes

- **`prompt-cache` module** (`comp-use-task-creation`): Auto-saves the prompt on each edit and provides a restore UI with two-version history. Multiple follow-up commits refined the UX: preview-on-toggle of the selected version, suppression of synthetic input events triggered by preview paste, DOM write guarding to status transitions only, clearing the restore button once the user edits after a restore, and fixing interval registration to use `registerInterval`.

- **`embedded-urlbar-fit` module**: Added to `comp-use-revision`, `comp-use-task-creation`, and `qa-comp-use` so the embedded URL bar toolbar controls remain fully visible regardless of container width.

- **Logger panel** (`plugins/core/dev/logger-panel.js`): Updated header to use the settings-style version label; restored original log row color after a copy-success flash.

- **`archetypes.json`**: Wired both new modules into the affected archetypes with correct version entries.

## New plugins

| Plugin | Archetype(s) | Description |
|---|---|---|
| `embedded-urlbar-fit.js` | comp-use-revision, comp-use-task-creation, qa-comp-use | Keeps embedded URL bar controls fully visible |
| `prompt-cache.js` | comp-use-task-creation | Persists prompt text and restores from two-version history |

## Commit history

- `b218649` fix(prompt-cache): suppress synthetic input from preview paste dismissing restore buttons
- `3c8fda8` fix(prompt-cache): preview selected restore version on toggle
- `a2f555c` Propagate embedded URL bar fit module to all computer-use archetypes
- `e27399f` Add comp-use task-creation module to keep embedded URL bar controls visible
- `efd050f` feat(prompt-cache): add two-version history with toggle-confirm restore UI
- `e2cef7e` Update logger panel header to settings-style version label
- `061dd9a` fix(prompt-cache): skip saving empty prompt and only mark saved for real content
- `5fc591e` fix(prompt-cache): guard setStatus to only write DOM on status transitions
- `7432f2c` fix(prompt-cache): remove restore button once user edits prompt
- `8787121` fix(dev-logger-panel): restore original log row color after copy success flash
- `d34eafa` fix(prompt-cache): use registerInterval instead of registerCallback, remove duplicate addEventListener
- `8f6ffba` feat(comp-use-task-creation): add prompt-cache plugin

## Stats

6 files changed, 619 insertions(+), 11 deletions(-)

## Issues

Closes #94
Closes #95
