### PR TITLE
Add dispute-detail embedded URL bar fit plugin

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.82",
+  "archetypesVersion": "7.83",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -531,6 +531,12 @@
           "name": "dispute-screenshot-upload-improvement.js",
           "version": "1.2",
           "hash": "sha256-a1bc305b24991917ce9e630cc23b1eb0d89cf4382fec4c9cab00f526c5ac25a3",
+          "log": false
+        },
+        {
+          "name": "embedded-urlbar-fit.js",
+          "version": "1.0",
+          "hash": "sha256-e76d414ff42a25ea58764646b3912e05280a78d06c0d540bbf350dccf4087ad5",
           "log": false
         },
         {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dispute-res-menu-bar] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dispute-res-menu-bar',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dispute-res-menu-bar] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dispute-res-menu-bar',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/embedded-urlbar-fit.js
+++ b/plugins/archetypes/dispute-detail/main/embedded-urlbar-fit.js
@@ -1,0 +1,62 @@
+// ============= embedded-urlbar-fit.js =============
+const plugin = {
+    id: 'disputeDetailEmbeddedUrlbarFit',
+    name: 'Dispute Detail Embedded URL Bar Fit',
+    description:
+        'Keeps embedded instance toolbar right-side controls visible by forcing URL segment to shrink/truncate',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: { missingLogged: false, appliedLogged: false },
+
+    onMutation(state) {
+        const rows = Context.dom.queryAll('div.flex.items-center.gap-1.p-1.border-b.h-10.bg-background', {
+            context: `${this.id}.toolbarRows`
+        });
+
+        if (rows.length === 0) {
+            if (!state.missingLogged) {
+                Logger.debug('Dispute Detail embedded URL bar fit: no embedded toolbar rows found');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        let fixedThisPass = 0;
+
+        rows.forEach((row) => {
+            const rowText = row.textContent || '';
+            if (!rowText.includes('Remote Copy') || !rowText.includes('Remote Paste')) return;
+
+            const directGroups = Array.from(row.children).filter(
+                (el) => el.tagName === 'DIV' && el.classList.contains('flex') && el.classList.contains('items-center')
+            );
+            if (directGroups.length < 3) return;
+
+            const middleGroup = directGroups[1];
+            const rightGroup = directGroups[2];
+
+            middleGroup.classList.add('min-w-0');
+            middleGroup.classList.add('overflow-hidden');
+            rightGroup.classList.add('shrink-0');
+
+            const urlPill = middleGroup.querySelector(':scope > div.flex-1');
+            if (urlPill) {
+                urlPill.classList.add('min-w-0');
+            }
+
+            const urlButton = middleGroup.querySelector('button.w-full');
+            if (urlButton) {
+                urlButton.classList.add('min-w-0');
+            }
+
+            fixedThisPass++;
+        });
+
+        if (fixedThisPass > 0 && !state.appliedLogged) {
+            Logger.log(`Dispute Detail embedded URL bar fit: adjusted ${fixedThisPass} toolbar row(s) this pass`);
+            state.appliedLogged = true;
+        }
+    }
+};


### PR DESCRIPTION
## Summary

Adds the **embedded URL bar fit** plugin to the **dispute-detail** archetype so embedded instance toolbars keep right-side controls (for example Remote Copy / Remote Paste) visible when the URL segment is long or the layout is tight. The change mirrors the same module used on other archetypes and registers it in `archetypes.json` (including version/hash metadata).

## Changes

- New `embedded-urlbar-fit.js` under `dispute-detail/main`: mutation-phase observer that finds embedded toolbar rows, applies flex shrink / truncation styling to the middle URL group, and logs setup and failures via `Logger`.
- `archetypes.json`: enable the module for dispute-detail and bump catalog metadata as required by the repo’s versioning rules.

Intermediate commits on the branch sync `fleet.user.js` branch metadata with `main`; the **net diff against `main` does not include `fleet.user.js`** (only `archetypes.json` and the new plugin file).

## New plugins

| Archetype       | Plugin                    | Role |
|----------------|---------------------------|------|
| dispute-detail | `embedded-urlbar-fit.js` | Shrinks/truncates embedded URL bar so right toolbar controls stay visible |

## Commit history

- `619cee5` — feat(dispute-detail): add embedded URL bar fit plugin

*(Omitted from this list: `Sync fleet.user.js branch config …` commits — branch housekeeping; no net change vs `main` for `fleet.user.js`.)*

## Stats

```
 archetypes.json                                    |  8 ++-
 .../dispute-detail/main/embedded-urlbar-fit.js     | 62 ++++++++++++++++++++++
 2 files changed, 69 insertions(+), 1 deletion(-)
```
