### PR TITLE
Enable core-only mode until site changes verified

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
-  "coreOnlyMode": false,
-  "archetypesVersion": "7.83",
+  "coreOnlyMode": true,
+  "archetypesVersion": "7.84",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [chore/disable-ext] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'chore/disable-ext',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [chore/disable-ext] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'chore/disable-ext',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',


### PR DESCRIPTION
## Summary

Temporarily enables **core-only mode** in `archetypes.json` so the script stays conservative until site changes are verified. Bumps `archetypesVersion` by **0.1** to reflect the config change.

## Changes

- Set `coreOnlyMode` from `false` to `true` so non-core plugin bundles are not loaded until it is safe to re-enable them.
- Bump `archetypesVersion` from `7.83` to `7.84` in line with project versioning when archetype configuration changes.

## Commit history

- `89a46e4` Disable extention until site changes are verified
- `df35fc1` Sync fleet.user.js branch config to main
- `dcbc547` Sync fleet.user.js branch config to chore/disable-ext

## Stats

```
 archetypes.json | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```
