### PR TITLE
Add horizontal scroll for QA top nav clusters

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.109",
+  "archetypesVersion": "7.110",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -320,8 +320,8 @@
         },
         {
           "name": "top-nav-horizontal-scroll.js",
-          "version": "1.0",
-          "hash": "sha256-776ae5b7d8b96f15d653367551729855a315044d492562b4d67b5e00f722607b",
+          "version": "1.1",
+          "hash": "sha256-6d158742912ce5c8b246903c50db712a4013066dce5ee131caaeb374759bd9db",
           "log": false
         },
         {
@@ -359,8 +359,8 @@
         },
         {
           "name": "top-nav-horizontal-scroll.js",
-          "version": "1.0",
-          "hash": "sha256-92ec05565c2c268c9b122dcd9dbf3123adce3906527b5ae91c718080866ed679",
+          "version": "1.1",
+          "hash": "sha256-ffade6bbd99aa2c9922b1acfa7313719a5354f5dedb0662d2d46c557e99daade",
           "log": false
         }
       ]
@@ -410,8 +410,8 @@
         },
         {
           "name": "top-nav-horizontal-scroll.js",
-          "version": "1.0",
-          "hash": "sha256-8bbe8eeab14671db4767e936cc019045840a03168e51364009351f94ba4da642",
+          "version": "1.1",
+          "hash": "sha256-ab65e41862ffac8e2377de8d40bd242761eb168fa5e9b4faee2c5d427ce20b75",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.108",
+  "archetypesVersion": "7.109",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -319,6 +319,12 @@
           "log": false
         },
         {
+          "name": "top-nav-horizontal-scroll.js",
+          "version": "1.0",
+          "hash": "sha256-776ae5b7d8b96f15d653367551729855a315044d492562b4d67b5e00f722607b",
+          "log": false
+        },
+        {
           "name": "toggle-tool-parameters.js",
           "version": "2.2",
           "hash": "sha256-62263d3f80435f2ca56391e44925f726523430fae313d50316207d71e224ebc6",
@@ -349,6 +355,12 @@
           "name": "auto-expand-verifier-section.js",
           "version": "1.1",
           "hash": "sha256-dd81bb5282a535540267530d15df6e47699f91c538ed46ab25eed901b1259ece",
+          "log": false
+        },
+        {
+          "name": "top-nav-horizontal-scroll.js",
+          "version": "1.0",
+          "hash": "sha256-92ec05565c2c268c9b122dcd9dbf3123adce3906527b5ae91c718080866ed679",
           "log": false
         }
       ]
@@ -394,6 +406,12 @@
           "name": "hide-grading-autoclick.js",
           "version": "1.0",
           "hash": "sha256-aeda5bf0b0af514c12ddd6702d4f3381368ea0abae4fbc4715ed3bb1ab38ef37",
+          "log": false
+        },
+        {
+          "name": "top-nav-horizontal-scroll.js",
+          "version": "1.0",
+          "hash": "sha256-8bbe8eeab14671db4767e936cc019045840a03168e51364009351f94ba4da642",
           "log": false
         },
         {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix/top-nav-bar-scroll] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/top-nav-bar-scroll/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/top-nav-bar-scroll/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix/top-nav-bar-scroll',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix/top-nav-bar-scroll] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/top-nav-bar-scroll/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/top-nav-bar-scroll/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix/top-nav-bar-scroll',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/qa-comp-use/main/top-nav-horizontal-scroll.js
+++ b/plugins/archetypes/qa-comp-use/main/top-nav-horizontal-scroll.js
@@ -1,44 +1,47 @@
 // ============= top-nav-horizontal-scroll.js =============
-// Makes the main app header’s tab / action cluster horizontally scrollable when it overflows.
+// Makes the QA review header action row horizontally scrollable when it overflows.
 
-const ATTR = 'data-fleet-qa-top-nav-scroll';
+const ATTR_SCROLL = 'data-fleet-qa-top-nav-scroll';
+const ATTR_WRAP = 'data-fleet-qa-top-nav-scroll-wrap';
+const ATTR_INNER = 'data-fleet-qa-top-nav-scroll-inner';
 
 const plugin = {
     id: 'qaCompUseTopNavScroll',
     name: 'Top nav horizontal scroll',
     description:
-        'Allows horizontal scrolling in the main top bar when tabs and action buttons exceed the viewport width',
-    _version: '1.0',
+        'Allows horizontal scrolling on the QA header ([data-ui="qa-header"]) when action buttons exceed the viewport width',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
     initialState: {
         missingLogged: false,
         activationLogged: false,
-        hadRow: false,
+        hadHeader: false,
         styleInjected: false
     },
 
-    findAppTopBarRow() {
-        const main = document.querySelector('main');
-        if (!main) return null;
-        const rows = main.querySelectorAll('.flex.items-center.justify-between');
-        for (const row of rows) {
-            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
-                return row;
-            }
-        }
-        return null;
+    findQaHeader() {
+        return document.querySelector('[data-ui="qa-header"]');
     },
 
-    findTabClusterHost(row) {
-        const tablist = row.querySelector('[role="tablist"]');
-        if (!tablist) return null;
-        let el = tablist;
-        while (el.parentElement && el.parentElement !== row) {
-            el = el.parentElement;
+    findHeaderInnerRow(header) {
+        const direct = header.querySelector(':scope > .flex.items-center');
+        return direct || null;
+    },
+
+    findCenterCluster(innerRow) {
+        for (const child of innerRow.children) {
+            if (child.classList && child.classList.contains('flex-1')) {
+                return child;
+            }
         }
-        return el.parentElement === row ? el : null;
+        const byApprove = innerRow.querySelector('[data-ui="approve-task"]');
+        if (byApprove) {
+            let el = byApprove.closest('.flex.flex-1');
+            if (el && el.parentElement === innerRow) return el;
+        }
+        return null;
     },
 
     ensureScrollStyles(state) {
@@ -52,52 +55,76 @@ const plugin = {
         style.id = id;
         style.setAttribute('data-fleet-plugin', this.id);
         style.textContent = `
-[${ATTR}="true"] {
+[${ATTR_WRAP}="true"] {
+    min-width: 0;
+    max-width: 100%;
+}
+[${ATTR_INNER}="true"] {
+    min-width: 0;
+}
+[${ATTR_SCROLL}="true"] {
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
+    justify-content: flex-start !important;
 }
 `;
         document.head.appendChild(style);
         state.styleInjected = true;
     },
 
-    applyToHost(host, state) {
+    applyWrap(header, innerRow, center, state) {
         this.ensureScrollStyles(state);
-        host.setAttribute(ATTR, 'true');
-        host.setAttribute('data-fleet-plugin', this.id);
-        host.classList.add('min-w-0', 'flex-1', 'overflow-x-auto', 'overflow-y-hidden');
-        if (host.classList.contains('flex')) {
-            host.classList.add('flex-nowrap');
+        header.setAttribute(ATTR_WRAP, 'true');
+        innerRow.setAttribute(ATTR_INNER, 'true');
+        innerRow.classList.add('w-full', 'min-w-0');
+
+        center.setAttribute(ATTR_SCROLL, 'true');
+        center.setAttribute('data-fleet-plugin', this.id);
+        center.classList.add(
+            'min-w-0',
+            'flex-1',
+            'overflow-x-auto',
+            'overflow-y-hidden',
+            'justify-start'
+        );
+        if (center.classList.contains('flex')) {
+            center.classList.add('flex-nowrap');
         }
     },
 
     onMutation(state) {
-        const row = this.findAppTopBarRow();
-        if (!row) {
-            if (state.hadRow) {
-                Logger.debug(`${this.id}: main header row left DOM — scroll hint inactive`);
-                state.hadRow = false;
+        const header = this.findQaHeader();
+        if (!header) {
+            if (state.hadHeader) {
+                Logger.debug(`${this.id}: [data-ui="qa-header"] left DOM — scroll inactive`);
+                state.hadHeader = false;
                 state.activationLogged = false;
             }
             if (!state.missingLogged) {
-                Logger.debug(`${this.id}: main header row not found yet`);
+                Logger.debug(`${this.id}: QA header not found yet`);
                 state.missingLogged = true;
             }
             return;
         }
         state.missingLogged = false;
-        state.hadRow = true;
+        state.hadHeader = true;
 
-        const host = this.findTabClusterHost(row);
-        if (!host) {
-            Logger.warn(`${this.id}: header row found but tab cluster host could not be resolved`);
+        const innerRow = this.findHeaderInnerRow(header);
+        if (!innerRow) {
+            Logger.warn(`${this.id}: QA header found but inner flex row missing`);
             return;
         }
 
-        this.applyToHost(host, state);
+        const center = this.findCenterCluster(innerRow);
+        if (!center) {
+            Logger.warn(`${this.id}: QA header inner row has no flex-1 center cluster`);
+            return;
+        }
+
+        this.applyWrap(header, innerRow, center, state);
 
         if (!state.activationLogged) {
-            Logger.log(`${this.id}: horizontal scroll enabled on top tab cluster`);
+            Logger.log(`${this.id}: horizontal scroll enabled on QA header action cluster`);
             state.activationLogged = true;
         }
     }

--- a/plugins/archetypes/qa-comp-use/main/top-nav-horizontal-scroll.js
+++ b/plugins/archetypes/qa-comp-use/main/top-nav-horizontal-scroll.js
@@ -1,0 +1,104 @@
+// ============= top-nav-horizontal-scroll.js =============
+// Makes the main app header’s tab / action cluster horizontally scrollable when it overflows.
+
+const ATTR = 'data-fleet-qa-top-nav-scroll';
+
+const plugin = {
+    id: 'qaCompUseTopNavScroll',
+    name: 'Top nav horizontal scroll',
+    description:
+        'Allows horizontal scrolling in the main top bar when tabs and action buttons exceed the viewport width',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        missingLogged: false,
+        activationLogged: false,
+        hadRow: false,
+        styleInjected: false
+    },
+
+    findAppTopBarRow() {
+        const main = document.querySelector('main');
+        if (!main) return null;
+        const rows = main.querySelectorAll('.flex.items-center.justify-between');
+        for (const row of rows) {
+            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
+                return row;
+            }
+        }
+        return null;
+    },
+
+    findTabClusterHost(row) {
+        const tablist = row.querySelector('[role="tablist"]');
+        if (!tablist) return null;
+        let el = tablist;
+        while (el.parentElement && el.parentElement !== row) {
+            el = el.parentElement;
+        }
+        return el.parentElement === row ? el : null;
+    },
+
+    ensureScrollStyles(state) {
+        if (state.styleInjected) return;
+        const id = 'fleet-qa-top-nav-scroll-style';
+        if (document.getElementById(id)) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = id;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+[${ATTR}="true"] {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+    },
+
+    applyToHost(host, state) {
+        this.ensureScrollStyles(state);
+        host.setAttribute(ATTR, 'true');
+        host.setAttribute('data-fleet-plugin', this.id);
+        host.classList.add('min-w-0', 'flex-1', 'overflow-x-auto', 'overflow-y-hidden');
+        if (host.classList.contains('flex')) {
+            host.classList.add('flex-nowrap');
+        }
+    },
+
+    onMutation(state) {
+        const row = this.findAppTopBarRow();
+        if (!row) {
+            if (state.hadRow) {
+                Logger.debug(`${this.id}: main header row left DOM — scroll hint inactive`);
+                state.hadRow = false;
+                state.activationLogged = false;
+            }
+            if (!state.missingLogged) {
+                Logger.debug(`${this.id}: main header row not found yet`);
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+        state.hadRow = true;
+
+        const host = this.findTabClusterHost(row);
+        if (!host) {
+            Logger.warn(`${this.id}: header row found but tab cluster host could not be resolved`);
+            return;
+        }
+
+        this.applyToHost(host, state);
+
+        if (!state.activationLogged) {
+            Logger.log(`${this.id}: horizontal scroll enabled on top tab cluster`);
+            state.activationLogged = true;
+        }
+    }
+};

--- a/plugins/archetypes/qa-session/main/top-nav-horizontal-scroll.js
+++ b/plugins/archetypes/qa-session/main/top-nav-horizontal-scroll.js
@@ -1,0 +1,104 @@
+// ============= top-nav-horizontal-scroll.js =============
+// Makes the main app header’s tab / action cluster horizontally scrollable when it overflows.
+
+const ATTR = 'data-fleet-qa-top-nav-scroll';
+
+const plugin = {
+    id: 'qaSessionTopNavScroll',
+    name: 'Top nav horizontal scroll',
+    description:
+        'Allows horizontal scrolling in the main top bar when tabs and action buttons exceed the viewport width',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        missingLogged: false,
+        activationLogged: false,
+        hadRow: false,
+        styleInjected: false
+    },
+
+    findAppTopBarRow() {
+        const main = document.querySelector('main');
+        if (!main) return null;
+        const rows = main.querySelectorAll('.flex.items-center.justify-between');
+        for (const row of rows) {
+            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
+                return row;
+            }
+        }
+        return null;
+    },
+
+    findTabClusterHost(row) {
+        const tablist = row.querySelector('[role="tablist"]');
+        if (!tablist) return null;
+        let el = tablist;
+        while (el.parentElement && el.parentElement !== row) {
+            el = el.parentElement;
+        }
+        return el.parentElement === row ? el : null;
+    },
+
+    ensureScrollStyles(state) {
+        if (state.styleInjected) return;
+        const id = 'fleet-qa-top-nav-scroll-style';
+        if (document.getElementById(id)) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = id;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+[${ATTR}="true"] {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+    },
+
+    applyToHost(host, state) {
+        this.ensureScrollStyles(state);
+        host.setAttribute(ATTR, 'true');
+        host.setAttribute('data-fleet-plugin', this.id);
+        host.classList.add('min-w-0', 'flex-1', 'overflow-x-auto', 'overflow-y-hidden');
+        if (host.classList.contains('flex')) {
+            host.classList.add('flex-nowrap');
+        }
+    },
+
+    onMutation(state) {
+        const row = this.findAppTopBarRow();
+        if (!row) {
+            if (state.hadRow) {
+                Logger.debug(`${this.id}: main header row left DOM — scroll hint inactive`);
+                state.hadRow = false;
+                state.activationLogged = false;
+            }
+            if (!state.missingLogged) {
+                Logger.debug(`${this.id}: main header row not found yet`);
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+        state.hadRow = true;
+
+        const host = this.findTabClusterHost(row);
+        if (!host) {
+            Logger.warn(`${this.id}: header row found but tab cluster host could not be resolved`);
+            return;
+        }
+
+        this.applyToHost(host, state);
+
+        if (!state.activationLogged) {
+            Logger.log(`${this.id}: horizontal scroll enabled on top tab cluster`);
+            state.activationLogged = true;
+        }
+    }
+};

--- a/plugins/archetypes/qa-session/main/top-nav-horizontal-scroll.js
+++ b/plugins/archetypes/qa-session/main/top-nav-horizontal-scroll.js
@@ -1,44 +1,47 @@
 // ============= top-nav-horizontal-scroll.js =============
-// Makes the main app header’s tab / action cluster horizontally scrollable when it overflows.
+// Makes the QA review header action row horizontally scrollable when it overflows.
 
-const ATTR = 'data-fleet-qa-top-nav-scroll';
+const ATTR_SCROLL = 'data-fleet-qa-top-nav-scroll';
+const ATTR_WRAP = 'data-fleet-qa-top-nav-scroll-wrap';
+const ATTR_INNER = 'data-fleet-qa-top-nav-scroll-inner';
 
 const plugin = {
     id: 'qaSessionTopNavScroll',
     name: 'Top nav horizontal scroll',
     description:
-        'Allows horizontal scrolling in the main top bar when tabs and action buttons exceed the viewport width',
-    _version: '1.0',
+        'Allows horizontal scrolling on the QA header ([data-ui="qa-header"]) when action buttons exceed the viewport width',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
     initialState: {
         missingLogged: false,
         activationLogged: false,
-        hadRow: false,
+        hadHeader: false,
         styleInjected: false
     },
 
-    findAppTopBarRow() {
-        const main = document.querySelector('main');
-        if (!main) return null;
-        const rows = main.querySelectorAll('.flex.items-center.justify-between');
-        for (const row of rows) {
-            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
-                return row;
-            }
-        }
-        return null;
+    findQaHeader() {
+        return document.querySelector('[data-ui="qa-header"]');
     },
 
-    findTabClusterHost(row) {
-        const tablist = row.querySelector('[role="tablist"]');
-        if (!tablist) return null;
-        let el = tablist;
-        while (el.parentElement && el.parentElement !== row) {
-            el = el.parentElement;
+    findHeaderInnerRow(header) {
+        const direct = header.querySelector(':scope > .flex.items-center');
+        return direct || null;
+    },
+
+    findCenterCluster(innerRow) {
+        for (const child of innerRow.children) {
+            if (child.classList && child.classList.contains('flex-1')) {
+                return child;
+            }
         }
-        return el.parentElement === row ? el : null;
+        const byApprove = innerRow.querySelector('[data-ui="approve-task"]');
+        if (byApprove) {
+            let el = byApprove.closest('.flex.flex-1');
+            if (el && el.parentElement === innerRow) return el;
+        }
+        return null;
     },
 
     ensureScrollStyles(state) {
@@ -52,52 +55,76 @@ const plugin = {
         style.id = id;
         style.setAttribute('data-fleet-plugin', this.id);
         style.textContent = `
-[${ATTR}="true"] {
+[${ATTR_WRAP}="true"] {
+    min-width: 0;
+    max-width: 100%;
+}
+[${ATTR_INNER}="true"] {
+    min-width: 0;
+}
+[${ATTR_SCROLL}="true"] {
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
+    justify-content: flex-start !important;
 }
 `;
         document.head.appendChild(style);
         state.styleInjected = true;
     },
 
-    applyToHost(host, state) {
+    applyWrap(header, innerRow, center, state) {
         this.ensureScrollStyles(state);
-        host.setAttribute(ATTR, 'true');
-        host.setAttribute('data-fleet-plugin', this.id);
-        host.classList.add('min-w-0', 'flex-1', 'overflow-x-auto', 'overflow-y-hidden');
-        if (host.classList.contains('flex')) {
-            host.classList.add('flex-nowrap');
+        header.setAttribute(ATTR_WRAP, 'true');
+        innerRow.setAttribute(ATTR_INNER, 'true');
+        innerRow.classList.add('w-full', 'min-w-0');
+
+        center.setAttribute(ATTR_SCROLL, 'true');
+        center.setAttribute('data-fleet-plugin', this.id);
+        center.classList.add(
+            'min-w-0',
+            'flex-1',
+            'overflow-x-auto',
+            'overflow-y-hidden',
+            'justify-start'
+        );
+        if (center.classList.contains('flex')) {
+            center.classList.add('flex-nowrap');
         }
     },
 
     onMutation(state) {
-        const row = this.findAppTopBarRow();
-        if (!row) {
-            if (state.hadRow) {
-                Logger.debug(`${this.id}: main header row left DOM — scroll hint inactive`);
-                state.hadRow = false;
+        const header = this.findQaHeader();
+        if (!header) {
+            if (state.hadHeader) {
+                Logger.debug(`${this.id}: [data-ui="qa-header"] left DOM — scroll inactive`);
+                state.hadHeader = false;
                 state.activationLogged = false;
             }
             if (!state.missingLogged) {
-                Logger.debug(`${this.id}: main header row not found yet`);
+                Logger.debug(`${this.id}: QA header not found yet`);
                 state.missingLogged = true;
             }
             return;
         }
         state.missingLogged = false;
-        state.hadRow = true;
+        state.hadHeader = true;
 
-        const host = this.findTabClusterHost(row);
-        if (!host) {
-            Logger.warn(`${this.id}: header row found but tab cluster host could not be resolved`);
+        const innerRow = this.findHeaderInnerRow(header);
+        if (!innerRow) {
+            Logger.warn(`${this.id}: QA header found but inner flex row missing`);
             return;
         }
 
-        this.applyToHost(host, state);
+        const center = this.findCenterCluster(innerRow);
+        if (!center) {
+            Logger.warn(`${this.id}: QA header inner row has no flex-1 center cluster`);
+            return;
+        }
+
+        this.applyWrap(header, innerRow, center, state);
 
         if (!state.activationLogged) {
-            Logger.log(`${this.id}: horizontal scroll enabled on top tab cluster`);
+            Logger.log(`${this.id}: horizontal scroll enabled on QA header action cluster`);
             state.activationLogged = true;
         }
     }

--- a/plugins/archetypes/qa-tool-use/main/top-nav-horizontal-scroll.js
+++ b/plugins/archetypes/qa-tool-use/main/top-nav-horizontal-scroll.js
@@ -1,45 +1,49 @@
 // ============= top-nav-horizontal-scroll.js =============
-// Makes the main app header’s tab / action cluster horizontally scrollable when it overflows.
+// Makes the QA review header action row horizontally scrollable when it overflows.
 
-const ATTR = 'data-fleet-qa-top-nav-scroll';
+const ATTR_SCROLL = 'data-fleet-qa-top-nav-scroll';
+const ATTR_WRAP = 'data-fleet-qa-top-nav-scroll-wrap';
+const ATTR_INNER = 'data-fleet-qa-top-nav-scroll-inner';
 
 const plugin = {
     id: 'qaToolUseTopNavScroll',
     name: 'Top nav horizontal scroll',
     description:
-        'Allows horizontal scrolling in the main top bar when tabs and action buttons exceed the viewport width',
-    _version: '1.0',
+        'Allows horizontal scrolling on the QA header ([data-ui="qa-header"]) when action buttons exceed the viewport width',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
 
     initialState: {
         missingLogged: false,
         activationLogged: false,
-        hadRow: false,
+        hadHeader: false,
         styleInjected: false
     },
 
-    findAppTopBarRow() {
-        const main = document.querySelector('main');
-        if (!main) return null;
-        const rows = main.querySelectorAll('.flex.items-center.justify-between');
-        for (const row of rows) {
-            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
-                return row;
-            }
-        }
-        return null;
+    findQaHeader() {
+        return document.querySelector('[data-ui="qa-header"]');
     },
 
-    /** Direct child of the header row whose subtree contains the tablist (center cluster). */
-    findTabClusterHost(row) {
-        const tablist = row.querySelector('[role="tablist"]');
-        if (!tablist) return null;
-        let el = tablist;
-        while (el.parentElement && el.parentElement !== row) {
-            el = el.parentElement;
+    /** Direct child row: flex strip with left / center (flex-1) / right clusters. */
+    findHeaderInnerRow(header) {
+        const direct = header.querySelector(':scope > .flex.items-center');
+        return direct || null;
+    },
+
+    /** Center column that holds Approve / Request Revisions / plugin buttons, etc. */
+    findCenterCluster(innerRow) {
+        for (const child of innerRow.children) {
+            if (child.classList && child.classList.contains('flex-1')) {
+                return child;
+            }
         }
-        return el.parentElement === row ? el : null;
+        const byApprove = innerRow.querySelector('[data-ui="approve-task"]');
+        if (byApprove) {
+            let el = byApprove.closest('.flex.flex-1');
+            if (el && el.parentElement === innerRow) return el;
+        }
+        return null;
     },
 
     ensureScrollStyles(state) {
@@ -53,52 +57,76 @@ const plugin = {
         style.id = id;
         style.setAttribute('data-fleet-plugin', this.id);
         style.textContent = `
-[${ATTR}="true"] {
+[${ATTR_WRAP}="true"] {
+    min-width: 0;
+    max-width: 100%;
+}
+[${ATTR_INNER}="true"] {
+    min-width: 0;
+}
+[${ATTR_SCROLL}="true"] {
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
+    justify-content: flex-start !important;
 }
 `;
         document.head.appendChild(style);
         state.styleInjected = true;
     },
 
-    applyToHost(host, state) {
+    applyWrap(header, innerRow, center, state) {
         this.ensureScrollStyles(state);
-        host.setAttribute(ATTR, 'true');
-        host.setAttribute('data-fleet-plugin', this.id);
-        host.classList.add('min-w-0', 'flex-1', 'overflow-x-auto', 'overflow-y-hidden');
-        if (host.classList.contains('flex')) {
-            host.classList.add('flex-nowrap');
+        header.setAttribute(ATTR_WRAP, 'true');
+        innerRow.setAttribute(ATTR_INNER, 'true');
+        innerRow.classList.add('w-full', 'min-w-0');
+
+        center.setAttribute(ATTR_SCROLL, 'true');
+        center.setAttribute('data-fleet-plugin', this.id);
+        center.classList.add(
+            'min-w-0',
+            'flex-1',
+            'overflow-x-auto',
+            'overflow-y-hidden',
+            'justify-start'
+        );
+        if (center.classList.contains('flex')) {
+            center.classList.add('flex-nowrap');
         }
     },
 
     onMutation(state) {
-        const row = this.findAppTopBarRow();
-        if (!row) {
-            if (state.hadRow) {
-                Logger.debug(`${this.id}: main header row left DOM — scroll hint inactive`);
-                state.hadRow = false;
+        const header = this.findQaHeader();
+        if (!header) {
+            if (state.hadHeader) {
+                Logger.debug(`${this.id}: [data-ui="qa-header"] left DOM — scroll inactive`);
+                state.hadHeader = false;
                 state.activationLogged = false;
             }
             if (!state.missingLogged) {
-                Logger.debug(`${this.id}: main header row not found yet`);
+                Logger.debug(`${this.id}: QA header not found yet`);
                 state.missingLogged = true;
             }
             return;
         }
         state.missingLogged = false;
-        state.hadRow = true;
+        state.hadHeader = true;
 
-        const host = this.findTabClusterHost(row);
-        if (!host) {
-            Logger.warn(`${this.id}: header row found but tab cluster host could not be resolved`);
+        const innerRow = this.findHeaderInnerRow(header);
+        if (!innerRow) {
+            Logger.warn(`${this.id}: QA header found but inner flex row missing`);
             return;
         }
 
-        this.applyToHost(host, state);
+        const center = this.findCenterCluster(innerRow);
+        if (!center) {
+            Logger.warn(`${this.id}: QA header inner row has no flex-1 center cluster`);
+            return;
+        }
+
+        this.applyWrap(header, innerRow, center, state);
 
         if (!state.activationLogged) {
-            Logger.log(`${this.id}: horizontal scroll enabled on top tab cluster`);
+            Logger.log(`${this.id}: horizontal scroll enabled on QA header action cluster`);
             state.activationLogged = true;
         }
     }

--- a/plugins/archetypes/qa-tool-use/main/top-nav-horizontal-scroll.js
+++ b/plugins/archetypes/qa-tool-use/main/top-nav-horizontal-scroll.js
@@ -1,0 +1,105 @@
+// ============= top-nav-horizontal-scroll.js =============
+// Makes the main app header’s tab / action cluster horizontally scrollable when it overflows.
+
+const ATTR = 'data-fleet-qa-top-nav-scroll';
+
+const plugin = {
+    id: 'qaToolUseTopNavScroll',
+    name: 'Top nav horizontal scroll',
+    description:
+        'Allows horizontal scrolling in the main top bar when tabs and action buttons exceed the viewport width',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+
+    initialState: {
+        missingLogged: false,
+        activationLogged: false,
+        hadRow: false,
+        styleInjected: false
+    },
+
+    findAppTopBarRow() {
+        const main = document.querySelector('main');
+        if (!main) return null;
+        const rows = main.querySelectorAll('.flex.items-center.justify-between');
+        for (const row of rows) {
+            if (row.querySelector('[role="tablist"]') && row.querySelector('a[href="/"]')) {
+                return row;
+            }
+        }
+        return null;
+    },
+
+    /** Direct child of the header row whose subtree contains the tablist (center cluster). */
+    findTabClusterHost(row) {
+        const tablist = row.querySelector('[role="tablist"]');
+        if (!tablist) return null;
+        let el = tablist;
+        while (el.parentElement && el.parentElement !== row) {
+            el = el.parentElement;
+        }
+        return el.parentElement === row ? el : null;
+    },
+
+    ensureScrollStyles(state) {
+        if (state.styleInjected) return;
+        const id = 'fleet-qa-top-nav-scroll-style';
+        if (document.getElementById(id)) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = id;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = `
+[${ATTR}="true"] {
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+}
+`;
+        document.head.appendChild(style);
+        state.styleInjected = true;
+    },
+
+    applyToHost(host, state) {
+        this.ensureScrollStyles(state);
+        host.setAttribute(ATTR, 'true');
+        host.setAttribute('data-fleet-plugin', this.id);
+        host.classList.add('min-w-0', 'flex-1', 'overflow-x-auto', 'overflow-y-hidden');
+        if (host.classList.contains('flex')) {
+            host.classList.add('flex-nowrap');
+        }
+    },
+
+    onMutation(state) {
+        const row = this.findAppTopBarRow();
+        if (!row) {
+            if (state.hadRow) {
+                Logger.debug(`${this.id}: main header row left DOM — scroll hint inactive`);
+                state.hadRow = false;
+                state.activationLogged = false;
+            }
+            if (!state.missingLogged) {
+                Logger.debug(`${this.id}: main header row not found yet`);
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+        state.hadRow = true;
+
+        const host = this.findTabClusterHost(row);
+        if (!host) {
+            Logger.warn(`${this.id}: header row found but tab cluster host could not be resolved`);
+            return;
+        }
+
+        this.applyToHost(host, state);
+
+        if (!state.activationLogged) {
+            Logger.log(`${this.id}: horizontal scroll enabled on top tab cluster`);
+            state.activationLogged = true;
+        }
+    }
+};


### PR DESCRIPTION
## Summary
Add horizontal scrolling support for QA top navigation header clusters so controls no longer overflow off-screen in narrow layouts.

## Changes
- Added and aligned the `top-nav-horizontal-scroll` plugin behavior across the QA archetypes that use this header pattern (`qa-comp-use`, `qa-session`, and `qa-tool-use`).
- Updated the scroll targeting to use the QA header center cluster (`data-ui="qa-header"`) so scrolling is applied to the correct container.
- Synced plugin metadata in `archetypes.json` to reflect the updated module wiring and versions/hashes.

## Commit history
- `020ffb6` fix(qa): scroll QA header via data-ui=qa-header center cluster
- `f180fa8` feat(qa): add horizontal scroll on top nav tab clusters

## Stats
- 4 files changed, 414 insertions(+), 1 deletion(-)

## Issues

Closes #116
