### PR TITLE
Disable Source Data on QA; rename to Explore GUI with acknowledgment modal

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "7.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "7.110",
+  "archetypesVersion": "7.111",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -82,8 +82,8 @@
         },
         {
           "name": "source-data-explorer.js",
-          "version": "4.3",
-          "hash": "sha256-13f154d6308dd412522103ba85f231464942e1ef1feedcb0b3e5ed49f1a703cf",
+          "version": "4.4",
+          "hash": "sha256-daeb3a7e511984477e5efa4cca155895a8fa699dacbcc37e0e70911f9fd175c8",
           "log": false
         },
         {
@@ -123,8 +123,8 @@
         },
         {
           "name": "json-editor-online.js",
-          "version": "2.1",
-          "hash": "sha256-d592dc27ec9a77d267d003eb6bf14817ad829c74510b61b96dc6737a4d93f180",
+          "version": "2.3",
+          "hash": "sha256-54e10e97c1d6544aaef0011b2ad49c113943cd4204415b727b89bcb809d0dfc6",
           "log": false
         },
         {
@@ -304,12 +304,6 @@
           "name": "request-revisions-screenshot-upload-improvement.js",
           "version": "1.0",
           "hash": "sha256-3076e0f0c1a0329b851bb54d9c746bd546d5b576911418bcb2c5b6db335a85b9",
-          "log": false
-        },
-        {
-          "name": "source-data-explorer.js",
-          "version": "1.5",
-          "hash": "sha256-a517bc26114f719be064336eaa5dddf748b375b278c53038cd75d16dde96cdf4",
           "log": false
         },
         {
@@ -551,8 +545,8 @@
         },
         {
           "name": "json-editor-online.js",
-          "version": "2.2",
-          "hash": "sha256-59028c229418c123e8dd2edf6f8103c7928d858ea7ea251359b4b3b846a84b48",
+          "version": "2.3",
+          "hash": "sha256-b55d5eda727fa9ecc0dce714234666f1455f6546f7d290783b978a7ab5f7d028",
           "log": false
         },
         {
@@ -575,8 +569,8 @@
         },
         {
           "name": "workflow-integrity-check.js",
-          "version": "2.0",
-          "hash": "sha256-73c0cfacead59b2325ac1d937bf27a2c8c07b82331ef9657c5e8003e4f4829f0",
+          "version": "2.1",
+          "hash": "sha256-c3f2993835bbd82e3af4daf56e996ba44da79e50988c91b70e8c48b2363457d3",
           "log": false
         }
       ]
@@ -659,6 +653,12 @@
           "name": "reorganize-request-revisions.js",
           "version": "1.2",
           "hash": "sha256-2836fbebd730b9fad29d7b6c76525bf246f6b9d71fbc9083a652713a977fe514",
+          "log": false
+        },
+        {
+          "name": "source-data-explorer.js",
+          "version": "1.6",
+          "hash": "sha256-31e86494667aa9cfe9eea1b113ab639579277963ac73c58eb62cea1ec8bdf1e2",
           "log": false
         },
         {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/disable-source-data-for-qa] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat/disable-source-data-for-qa/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat/disable-source-data-for-qa/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/disable-source-data-for-qa',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/disable-source-data-for-qa] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat/disable-source-data-for-qa/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/feat/disable-source-data-for-qa/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/disable-source-data-for-qa',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/qa-tool-use/dev/source-data-explorer.js
+++ b/plugins/archetypes/qa-tool-use/dev/source-data-explorer.js
@@ -3,9 +3,9 @@
 
 const plugin = {
     id: 'sourceDataExplorer',
-    name: 'Source Data Explorer',
-    description: 'Add button that opens the underlying environment in a new tab. This is meant to be used as an additional way to explore the underlying data so you can build amazing prompts without having to parse the data in JSON format. This links to the actual instance that your tool calls are modifying. BE AWARE: if you make changes inside the instance, they will be reflected in your tool calls. Only use the tools to perform write actions, or you may run into unexpected problems when your submission is graded.',
-    _version: '1.5',
+    name: 'Explore GUI',
+    description: 'Adds an Explore GUI button that opens the underlying environment in a new tab so you can inspect data without parsing JSON. This links to the actual instance that your tool calls are modifying. BE AWARE: if you make changes inside the instance, they will be reflected in your tool calls. Only use the tools to perform write actions, or you may run into unexpected problems when your submission is graded.',
+    _version: '1.6',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, interceptionInstalled: false },
@@ -27,7 +27,7 @@ const plugin = {
 
         if (!center) {
             if (!state.missingLogged) {
-                Logger.debug('Action bar center not found for Source Data Explorer button');
+                Logger.debug('Action bar center not found for Explore GUI button');
                 state.missingLogged = true;
             }
             return;
@@ -160,14 +160,14 @@ const plugin = {
 
         const label = document.createElement('span');
         label.className = 'whitespace-nowrap text-md font-medium';
-        label.textContent = 'Source Data';
+        label.textContent = 'Explore GUI';
         button.appendChild(label);
 
         button.addEventListener('click', () => {
             if (context.source) {
                 const sourceUrl = this.sourceHrefToOpenUrl(context.source, context);
                 window.open(sourceUrl, '_blank');
-                Logger.log('sourceDataExplorer: Opening source data:', sourceUrl);
+                Logger.log('sourceDataExplorer: Opening Explore GUI (instance root):', sourceUrl);
             } else {
                 Logger.warn('sourceDataExplorer: Source URL not available (no MCP POST observed yet)');
             }
@@ -191,7 +191,7 @@ const plugin = {
             centerContainer.appendChild(button);
         }
 
-        Logger.log('✓ Source Data Explorer button added (action bar)');
+        Logger.log('sourceDataExplorer: ✓ Explore GUI button added (action bar)');
         return button;
     },
 

--- a/plugins/archetypes/tool-use-task-creation-openclaw/main/json-editor-online.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/main/json-editor-online.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'jsonEditorOnline',
     name: 'JSON Editor Online',
     description: 'Add button that opens JSON Editor Online in a new tab. Optionally show button on each tool result to copy output and open editor.',
-    _version: '2.1',
+    _version: '2.3',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -76,10 +76,10 @@ const plugin = {
             }
         }
         
-        // Strategy 4: Look for Source Data button and use its container
+        // Strategy 4: Look for Explore GUI button and use its container
         if (!buttonContainer) {
-            const sourceDataBtn = Array.from(document.querySelectorAll('button')).find(btn => 
-                btn.textContent.includes('Source Data')
+            const sourceDataBtn = Array.from(document.querySelectorAll('button')).find(btn =>
+                btn.textContent.includes('Explore GUI')
             );
             if (sourceDataBtn) {
                 buttonContainer = sourceDataBtn.parentElement;
@@ -114,9 +114,9 @@ const plugin = {
             Logger.log('Opening JSON Editor Online');
         };
         
-        // Insert after Source Data button if it exists, otherwise as first child
-        const sourceDataBtn = Array.from(buttonContainer.querySelectorAll('button')).find(btn => 
-            btn.textContent.includes('Source Data')
+        // Insert after Explore GUI button if it exists, otherwise as first child
+        const sourceDataBtn = Array.from(buttonContainer.querySelectorAll('button')).find(btn =>
+            btn.textContent.includes('Explore GUI')
         );
         if (sourceDataBtn) {
             sourceDataBtn.insertAdjacentElement('afterend', button);

--- a/plugins/archetypes/tool-use-task-creation/dev/json-editor-online.js
+++ b/plugins/archetypes/tool-use-task-creation/dev/json-editor-online.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'jsonEditorOnline',
     name: 'JSON Editor Online',
     description: 'Add button that opens JSON Editor Online in a new tab. Optionally show button on each tool result to copy output and open editor.',
-    _version: '2.2',
+    _version: '2.3',
     enabledByDefault: false,
     phase: 'mutation',
     
@@ -76,10 +76,10 @@ const plugin = {
             }
         }
         
-        // Strategy 4: Look for Source Data button and use its container
+        // Strategy 4: Look for Explore GUI button and use its container
         if (!buttonContainer) {
-            const sourceDataBtn = Array.from(document.querySelectorAll('button')).find(btn => 
-                btn.textContent.includes('Source Data')
+            const sourceDataBtn = Array.from(document.querySelectorAll('button')).find(btn =>
+                btn.textContent.includes('Explore GUI')
             );
             if (sourceDataBtn) {
                 buttonContainer = sourceDataBtn.parentElement;
@@ -114,9 +114,9 @@ const plugin = {
             Logger.log('Opening JSON Editor Online');
         };
         
-        // Insert after Source Data button if it exists, otherwise as first child
-        const sourceDataBtn = Array.from(buttonContainer.querySelectorAll('button')).find(btn => 
-            btn.textContent.includes('Source Data')
+        // Insert after Explore GUI button if it exists, otherwise as first child
+        const sourceDataBtn = Array.from(buttonContainer.querySelectorAll('button')).find(btn =>
+            btn.textContent.includes('Explore GUI')
         );
         if (sourceDataBtn) {
             sourceDataBtn.insertAdjacentElement('afterend', button);

--- a/plugins/archetypes/tool-use-task-creation/dev/workflow-integrity-check.js
+++ b/plugins/archetypes/tool-use-task-creation/dev/workflow-integrity-check.js
@@ -3,7 +3,7 @@ const plugin = {
     id: 'workflowIntegrityCheck',
     name: 'Workflow Integrity Check',
     description: 'Adds button to check workflow integrity by verifying tool inputs exist in prompt or previous outputs',
-    _version: '2.0',
+    _version: '2.1',
     enabledByDefault: false,
     phase: 'mutation',
 
@@ -70,10 +70,10 @@ const plugin = {
             }
         }
         
-        // Strategy 4: Look for Source Data button and use its container
+        // Strategy 4: Look for Explore GUI button and use its container
         if (!buttonContainer) {
-            const sourceDataBtn = Array.from(document.querySelectorAll('button')).find(btn => 
-                btn.textContent.includes('Source Data')
+            const sourceDataBtn = Array.from(document.querySelectorAll('button')).find(btn =>
+                btn.textContent.includes('Explore GUI')
             );
             if (sourceDataBtn) {
                 buttonContainer = sourceDataBtn.parentElement;

--- a/plugins/archetypes/tool-use-task-creation/main/source-data-explorer.js
+++ b/plugins/archetypes/tool-use-task-creation/main/source-data-explorer.js
@@ -3,9 +3,9 @@
 
 const plugin = {
     id: 'sourceDataExplorer',
-    name: 'Source Data Explorer',
-    description: 'Add button that opens the underlying environment in a new tab. This is meant to be used as an additional way to explore the underlying data so you can build amazing prompts without having to parse the data in JSON format. This links to the actual instance that your tool calls are modifying. BE AWARE: if you make changes inside the instance, they will be reflected in your tool calls. Only use the tools to perform write actions, or you may run into unexpected problems when your submission is graded.',
-    _version: '4.3',
+    name: 'Explore GUI',
+    description: 'Adds an Explore GUI control that opens the underlying environment in a new tab so you can inspect data without parsing JSON. This links to the actual instance that your tool calls are modifying. BE AWARE: if you make changes inside the instance, they will be reflected in your tool calls. Only use the tools to perform write actions, or you may run into unexpected problems when your submission is graded.',
+    _version: '4.4',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: { missingLogged: false, interceptionInstalled: false },
@@ -55,7 +55,7 @@ const plugin = {
         
         if (!buttonContainer) {
             if (!state.missingLogged) {
-                Logger.debug('sourceDataExplorer: Button container not found for Source Data Explorer button');
+                Logger.debug('sourceDataExplorer: Button container not found for Explore GUI button');
                 state.missingLogged = true;
             }
             return;
@@ -178,6 +178,127 @@ const plugin = {
         Logger.log('sourceDataExplorer: ✓ Network interception installed (fetch + XHR)');
     },
 
+    /** @param {Window} pageWindow */
+    showExploreGuiAckModal(pageWindow, context) {
+        const OVERLAY_ID = 'fleet-explore-gui-ack-overlay';
+        if (document.getElementById(OVERLAY_ID)) {
+            return;
+        }
+
+        const openInstance = () => {
+            if (!context.source) {
+                Logger.warn('sourceDataExplorer: Source URL not available (no MCP POST observed yet)');
+                return;
+            }
+            const sourceUrl = this.sourceHrefToOpenUrl(context.source, context);
+            pageWindow.open(sourceUrl, '_blank');
+            Logger.log('sourceDataExplorer: Opening Explore GUI after acknowledgment:', sourceUrl);
+        };
+
+        const overlay = document.createElement('div');
+        overlay.id = OVERLAY_ID;
+        overlay.setAttribute('data-fleet-plugin', this.id);
+        overlay.setAttribute('data-slot', 'explore-gui-ack-modal');
+        overlay.style.cssText = `
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 10000;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 16px;
+        `;
+
+        const modal = document.createElement('div');
+        modal.style.cssText = `
+            position: relative;
+            background: var(--background, white);
+            border: 1px solid var(--border, #e5e5e5);
+            border-radius: 12px;
+            padding: 24px;
+            width: 100%;
+            max-width: 520px;
+            max-height: 90vh;
+            overflow-y: auto;
+            box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+        `;
+
+        modal.innerHTML = `
+            <p style="margin: 0 0 16px; font-size: 14px; line-height: 1.5; color: var(--foreground, #333);">
+                Please check each box to acknowledge that you understand the following information:
+            </p>
+            <div style="display: flex; flex-direction: column; gap: 12px; margin-bottom: 20px;">
+                <label style="display: flex; align-items: flex-start; gap: 10px; font-size: 14px; line-height: 1.45; cursor: pointer; color: var(--foreground, #333);">
+                    <input id="fleet-explore-gui-ack-cb1" type="checkbox" style="margin-top: 3px; flex-shrink: 0;" />
+                    <span>The GUI interface is meant to be used as a tool to enable more efficient exploration of the data.</span>
+                </label>
+                <label style="display: flex; align-items: flex-start; gap: 10px; font-size: 14px; line-height: 1.45; cursor: pointer; color: var(--foreground, #333);">
+                    <input id="fleet-explore-gui-ack-cb2" type="checkbox" style="margin-top: 3px; flex-shrink: 0;" />
+                    <span>The tool calls are the source of truth. If you can't find specific GUI data with tool calls, it does not exist and cannot be referenced in the prompt.</span>
+                </label>
+                <label style="display: flex; align-items: flex-start; gap: 10px; font-size: 14px; line-height: 1.45; cursor: pointer; color: var(--foreground, #333);">
+                    <input id="fleet-explore-gui-ack-cb3" type="checkbox" style="margin-top: 3px; flex-shrink: 0;" />
+                    <span>Your tool use workflow must contain all of the search tool calls necessary to find any information you find in the GUI.</span>
+                </label>
+            </div>
+            <div style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end;">
+                <button type="button" id="fleet-explore-gui-ack-cancel"
+                    style="padding: 8px 16px; border-radius: 6px; border: 1px solid var(--border, #e5e5e5); background: var(--background, white); color: var(--foreground, #333); font-size: 13px; font-weight: 500; cursor: pointer;">
+                    Cancel
+                </button>
+                <button type="button" id="fleet-explore-gui-ack-continue" disabled
+                    style="padding: 8px 16px; border-radius: 6px; border: none; background: #171717; color: #fafafa; font-size: 13px; font-weight: 500; cursor: not-allowed; opacity: 0.5;">
+                    Acknowledge and continue
+                </button>
+            </div>
+        `;
+
+        overlay.appendChild(modal);
+        document.body.appendChild(overlay);
+
+        const cb1 = modal.querySelector('#fleet-explore-gui-ack-cb1');
+        const cb2 = modal.querySelector('#fleet-explore-gui-ack-cb2');
+        const cb3 = modal.querySelector('#fleet-explore-gui-ack-cb3');
+        const continueBtn = modal.querySelector('#fleet-explore-gui-ack-continue');
+        const cancelBtn = modal.querySelector('#fleet-explore-gui-ack-cancel');
+
+        const syncContinue = () => {
+            const allChecked = Boolean(cb1.checked && cb2.checked && cb3.checked);
+            continueBtn.disabled = !allChecked;
+            continueBtn.style.cursor = allChecked ? 'pointer' : 'not-allowed';
+            continueBtn.style.opacity = allChecked ? '1' : '0.5';
+        };
+
+        const closeModal = (reason) => {
+            overlay.remove();
+            if (reason) {
+                Logger.log(`sourceDataExplorer: Explore GUI acknowledgment modal closed (${reason})`);
+            }
+        };
+
+        [cb1, cb2, cb3].forEach((cb) => cb.addEventListener('change', syncContinue));
+
+        continueBtn.addEventListener('click', () => {
+            if (continueBtn.disabled) return;
+            closeModal(null);
+            openInstance();
+        });
+
+        cancelBtn.addEventListener('click', () => closeModal('cancel'));
+
+        overlay.addEventListener('click', (e) => {
+            if (e.target === overlay) {
+                closeModal('backdrop');
+            }
+        });
+
+        Logger.log('sourceDataExplorer: Explore GUI acknowledgment modal shown');
+    },
+
     ensureSourceButton(buttonContainer, context) {
         const existing = buttonContainer.querySelector(
             '[data-fleet-plugin="sourceDataExplorer"][data-slot="source-data-button"]'
@@ -193,20 +314,18 @@ const plugin = {
         button.className =
             'inline-flex items-center justify-center whitespace-nowrap font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border bg-background transition-colors hover:bg-accent hover:text-accent-foreground h-8 rounded-sm pl-3 pr-3 gap-2 text-xs relative border-amber-300 dark:border-amber-700';
         button.type = 'button';
-        button.textContent = '📊 Source Data';
+        button.textContent = 'Explore GUI';
 
         button.addEventListener('click', () => {
             if (!context.source) {
                 Logger.warn('sourceDataExplorer: Source URL not available (no MCP POST observed yet)');
                 return;
             }
-            const sourceUrl = this.sourceHrefToOpenUrl(context.source, context);
-            pageWindow.open(sourceUrl, '_blank');
-            Logger.log('sourceDataExplorer: Opening source data:', sourceUrl);
+            this.showExploreGuiAckModal(pageWindow, context);
         });
 
         buttonContainer.insertBefore(button, buttonContainer.firstChild);
-        Logger.log('sourceDataExplorer: ✓ Source Data Explorer button added');
+        Logger.log('sourceDataExplorer: ✓ Explore GUI button added');
         return button;
     },
 


### PR DESCRIPTION
## Summary

Disable the Source Data button by default on the QA tool-use archetype by moving the plugin from `main/` to `dev/`, and rebrand the same plugin on the task-creation side as **Explore GUI**, gated behind a 3-checkbox acknowledgment modal. References to the old "Source Data" label in sibling task-creation plugins are updated to find the renamed button instead.

## Changes

- **QA tool-use: opt-in rather than always-on.** `plugins/archetypes/qa-tool-use/main/source-data-explorer.js` is moved to `plugins/archetypes/qa-tool-use/dev/source-data-explorer.js` (version `1.5` → `1.6`) and `archetypes.json` is updated to register it under `dev` instead of `main` for `qa-tool-use`. The plugin name is also rebranded to **Explore GUI** to match task-creation. Net effect: QA users no longer get the GUI shortcut by default.
- **Task creation: rename + acknowledgment gate.** `plugins/archetypes/tool-use-task-creation/main/source-data-explorer.js` renames the plugin from "Source Data Explorer" to "Explore GUI" (button label `📊 Source Data` → `Explore GUI`), bumps version `4.3` → `4.4`, and routes the click through a new `showExploreGuiAckModal()` modal. The user must tick three checkboxes — (1) the GUI is for exploration only, (2) tool calls are the source of truth, (3) the workflow must include all search tool calls covering anything seen in the GUI — before the environment opens in a new tab. Cancel and backdrop-click both dismiss without opening.
- **Sibling button placement updated.** `tool-use-task-creation/dev/json-editor-online.js` (`2.2` → `2.3`), `tool-use-task-creation-openclaw/main/json-editor-online.js` (`2.1` → `2.3`), and `tool-use-task-creation/dev/workflow-integrity-check.js` (`2.0` → `2.1`) now look up the renamed `Explore GUI` button (instead of `Source Data`) when deciding where to inject themselves and where to insert their own buttons.
- **archetypes.json / version bookkeeping.** `archetypesVersion` bumps `7.110` → `7.111`; per-plugin versions and hashes refreshed for the moved/renamed/touched plugins.

## New plugins

| Archetype       | Path                                | Plugin       | Version | Notes                                                       |
|-----------------|-------------------------------------|--------------|---------|-------------------------------------------------------------|
| `qa-tool-use`   | `dev/source-data-explorer.js`       | Explore GUI  | `1.6`   | Moved from `main/`; opt-in for QA, rebranded to Explore GUI |

## Commit history

- `127e8f0` feat(qa): move Explore GUI to dev; task creation acknowledgment modal

## Stats

```
 archetypes.json                                                              |  30 ++---
 fleet.user.js                                                                |   8 +-
 plugins/archetypes/qa-tool-use/{main => dev}/source-data-explorer.js         |  14 +--
 plugins/archetypes/tool-use-task-creation-openclaw/main/json-editor-online.js |  14 +--
 plugins/archetypes/tool-use-task-creation/dev/json-editor-online.js          |  14 +--
 plugins/archetypes/tool-use-task-creation/dev/workflow-integrity-check.js    |   8 +-
 plugins/archetypes/tool-use-task-creation/main/source-data-explorer.js       | 137 +++++++++++++++++++--
 7 files changed, 172 insertions(+), 53 deletions(-)
```
