### PR TITLE
Fix PR branch-config sync workflow (fetch origin/main)

### DIFF
--- a/.github/workflows/verify-main-branch-config-pr.yml
+++ b/.github/workflows/verify-main-branch-config-pr.yml
@@ -18,18 +18,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
+      - name: Fetch main for sync baseline
+        run: git fetch origin main
+
       - name: Sync fleet.user.js for main
         run: |
           ./dev/utils/sync-branch-config.sh -m
 
-          if git diff --quiet fleet.user.js; then
-            echo "fleet.user.js is already configured for main."
+          if git diff --quiet fleet.user.js dev/fleet-dev-id.user.js; then
+            echo "Branch config files are already configured for main."
             exit 0
           fi
 
-          echo "fleet.user.js was not synced for main. Committing fix."
+          echo "Branch config was not synced for main. Committing fix."
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add fleet.user.js
+          git add fleet.user.js dev/fleet-dev-id.user.js
           git commit -m "CI: sync branch config for main"
-          git push
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix/sync-branch-config-CI] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-CI/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-CI/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix/sync-branch-config-CI',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',


### PR DESCRIPTION
## Summary

Fixes the **Sync main branch config (PR)** workflow, which failed because `sync-branch-config.sh` reads `@name` baselines from `origin/main` while Actions only checked out the PR head branch—so `origin/main` was missing until fetched.

## Changes

- Add a **Fetch main for sync baseline** step (`git fetch origin main`) before running `sync-branch-config.sh -m`.
- Treat **both** branch-bound userscripts (`fleet.user.js` and `dev/fleet-dev-id.user.js`) when checking for drift, staging, and committing CI fixes.
- Push bot commits explicitly to the PR head ref: `git push origin HEAD:<branch>`.

## Commit history

- `754e636` CI: fetch origin/main before PR branch-config sync
- `66fe9c7` Sync fleet.user.js branch config to fix/sync-branch-config-CI

## Stats

```
 .github/workflows/verify-main-branch-config-pr.yml | 13 ++++++++-----
 fleet.user.js                                      |  8 ++++----
 2 files changed, 12 insertions(+), 9 deletions(-)
```
