### PR TITLE
Fix main fleet.user.js config and keep main URLs on checkout

### DIFF
--- a/.github/workflows/verify-main-branch-config-main.yml
+++ b/.github/workflows/verify-main-branch-config-main.yml
@@ -1,0 +1,30 @@
+name: Sync main branch config (main)
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-branch-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Sync fleet.user.js for main
+        run: |
+          ./dev/utils/sync-branch-config.sh -m
+
+          if git diff --quiet fleet.user.js; then
+            echo "fleet.user.js is already configured for main."
+            exit 0
+          fi
+
+          echo "fleet.user.js was not configured for main. Committing fix."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add fleet.user.js
+          git commit -m "CI: sync branch config for main"
+          git push

--- a/.github/workflows/verify-main-branch-config-pr.yml
+++ b/.github/workflows/verify-main-branch-config-pr.yml
@@ -25,7 +25,10 @@ jobs:
         run: |
           ./dev/utils/sync-branch-config.sh -m
 
-          if git diff --quiet fleet.user.js dev/fleet-dev-id.user.js; then
+          config_files=(fleet.user.js)
+          [[ -f dev/fleet-dev-id.user.js ]] && config_files+=(dev/fleet-dev-id.user.js)
+
+          if git diff --quiet "${config_files[@]}"; then
             echo "Branch config files are already configured for main."
             exit 0
           fi
@@ -33,6 +36,6 @@ jobs:
           echo "Branch config was not synced for main. Committing fix."
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add fleet.user.js dev/fleet-dev-id.user.js
+          git add "${config_files[@]}"
           git commit -m "CI: sync branch config for main"
           git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/dev/utils/checkout.sh
+++ b/dev/utils/checkout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# checkout.sh — Create a feature branch and sync fleet.user.js for branch-specific installs
+# checkout.sh — Create a feature branch; fleet.user.js stays on main (production) config
 #
 # Usage:
 #   ./utils/checkout.sh [--dry-run] <branch>
@@ -13,22 +13,18 @@
 #
 # Effects:
 #   1. Checks out main and creates a new branch with the given name.
-#   2. Updates fleet.user.js so it targets this branch (via sync-branch-config.sh):
-#      - @name: prefixed with "[<branch>] " (e.g. "[my-feature] Fleet").
-#      - @downloadURL / @updateURL: branch segment set to <branch> so Tampermonkey
-#        installs/updates from the branch-specific raw URL.
-#      - GITHUB_CONFIG.branch: set to <branch> for in-script behaviour.
-#      - VERSION: kept in sync with the header @version.
+#   2. Ensures fleet.user.js uses main config (via sync-branch-config.sh -m):
+#      - @name: no branch prefix
+#      - @downloadURL / @updateURL: main segment in the raw GitHub URL
+#      - GITHUB_CONFIG.branch: main
+#      - VERSION: kept in sync with the header @version
 #   3. Runs toggle-core-only-mode.sh -f so archetypes.json has coreOnlyMode false for
 #      feature work (bumps archetypesVersion only when that value changes).
-#   4. Commits these changes with the message from sync-branch-config.sh (--print-commit-message)
-#      and pushes the new
-#      branch to origin.
-#   5. Prints the GitHub tree URL for the branch so you can install the branch-specific
-#      userscript for development and testing.
+#   4. Commits these changes and pushes the new branch to origin.
+#   5. Prints the main raw install URL for Tampermonkey.
 #
-# Use this when starting work on a feature: install the script from the printed URL
-# and develop against that branch; publish.sh merges the branch into main when done.
+# Use this when starting work on a feature. fleet.user.js always targets main for
+# installs/updates; develop on your feature branch in git without branch-scoped userscript URLs.
 #
 # Prerequisites: run from anywhere inside the repo; main must exist; branch name
 # must not exist locally or on origin.
@@ -66,12 +62,12 @@ fi
 
 if [[ "$dry_run" == true ]]; then
   echo "[info] Dry run - would create branch: $BRANCH (no git or file changes)"
-  "$sync_script" --dry-run --branch "$BRANCH"
-  _commit_msg="$("$sync_script" --print-commit-message --branch "$BRANCH")"
+  "$sync_script" --dry-run -m
+  _commit_msg="$("$sync_script" --print-commit-message -m)"
   echo "[dry-run] Would run: \"$toggle_core_script\" -f"
   echo "[dry-run] Would run: git checkout main"
   echo "[dry-run] Would run: git checkout -b $BRANCH"
-  echo "[dry-run] Would run: $sync_script"
+  echo "[dry-run] Would run: $sync_script -m"
   echo "[dry-run] Would run: git add ."
   echo "[dry-run] Would run: git commit -m \"$_commit_msg\""
   echo "[dry-run] Would run: git push -u origin $BRANCH"
@@ -82,22 +78,22 @@ git -C "$root" checkout main
 git -C "$root" checkout -b "$BRANCH"
 echo "[info] Current branch: $(git -C "$root" rev-parse --abbrev-ref HEAD)"
 
-commit_msg="$("$sync_script" --print-commit-message)"
-"$sync_script"
+commit_msg="$("$sync_script" --print-commit-message -m)"
+"$sync_script" -m
 "$toggle_core_script" -f
 
 git -C "$root" add .
 git -C "$root" commit -m "$commit_msg"
 git -C "$root" push -u origin "$BRANCH"
 
-url="$(cd "$root" && gh browse --no-browser "$BRANCH")"
+url="$(cd "$root" && gh browse --no-browser main)"
 ghuser=$(echo "$url" | perl -nE 'say $1 if m{github\.com/([^/]+)}')
 ghrepo=$(echo "$url" | perl -nE 'say $1 if m{'"$ghuser"'/([^/]+)(?:/|$)}')
-RAW_INSTALL_URL="https://raw.githubusercontent.com/$ghuser/$ghrepo/$BRANCH/fleet.user.js"
-BLOB_URL="https://github.com/$ghuser/$ghrepo/blob/$BRANCH/fleet.user.js"
+RAW_INSTALL_URL="https://raw.githubusercontent.com/$ghuser/$ghrepo/main/fleet.user.js"
+BLOB_URL="https://github.com/$ghuser/$ghrepo/blob/main/fleet.user.js"
 
-echo "You MUST test and develop using this $BRANCH specific userscript."
+echo "fleet.user.js is configured for main (production install/update URLs)."
 echo "View on GitHub:"
 echo "$BLOB_URL"
-echo "Install it at (raw):"
+echo "Install or update Tampermonkey from (raw):"
 echo "$RAW_INSTALL_URL"

--- a/dev/utils/sync-branch-config.sh
+++ b/dev/utils/sync-branch-config.sh
@@ -17,7 +17,9 @@
 #   - GITHUB_CONFIG.branch: set to current branch
 #   - const VERSION: set from header @version
 #
-# Used by checkout.sh and test.sh; may be run directly.
+# Used by checkout.sh (always -m) and test.sh (branch-scoped for update testing); may be run directly.
+# checkout.sh keeps main config on feature branches; use sync without -m only when you intentionally
+# want branch-scoped @downloadURL / @updateURL (e.g. test.sh).
 #
 
 set -euo pipefail
@@ -209,10 +211,20 @@ else
 fi
 
 if [[ "$commit_after" == true ]]; then
+  if git -C "$root" diff --name-only --diff-filter=U | grep -q .; then
+    echo "[error] Cannot commit: repository has unresolved merge conflicts. Resolve or abort the merge first." >&2
+    exit 1
+  fi
   if [[ "$changed_write" == true ]]; then
     git -C "$root" add -- "$file_path"
-    git -C "$root" commit -m "Sync fleet.user.js branch config to $branch"
-    echo "[info] Committed fleet.user.js for branch: $branch"
+    if git -C "$root" diff --cached --quiet -- "$file_path"; then
+      echo "[info] No commit (-c): fleet.user.js matches HEAD after sync"
+    elif git -C "$root" commit -m "Sync fleet.user.js branch config to $branch"; then
+      echo "[info] Committed fleet.user.js for branch: $branch"
+    else
+      echo "[error] git commit failed" >&2
+      exit 1
+    fi
   else
     echo "[info] No commit (-c): fleet.user.js was already in sync"
   fi

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix/sync-branch-config-CI] Fleet Workflow Builder UX Enhancer
+// @name         [fix/sync-branch-config-2] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-CI/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-CI/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-2/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-2/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix/sync-branch-config-CI',
+        branch: 'fix/sync-branch-config-2',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix/sync-branch-config-2] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      7.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -15,8 +15,8 @@
 // @grant        GM_xmlhttpRequest
 // @connect      raw.githubusercontent.com
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-2/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/fix/sync-branch-config-2/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/fleet-ai-operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -48,7 +48,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix/sync-branch-config-2',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',


### PR DESCRIPTION
## Summary

Fixes accidental branch-scoped `fleet.user.js` config on `main` (introduced when PR #131 merged) and changes the default feature-branch workflow so new branches keep **main** Tampermonkey install/update URLs instead of rewriting headers to the current git branch name.

## Changes

- **Restore `fleet.user.js` on `main`**: `@name` without branch prefix, `@downloadURL` / `@updateURL` and `GITHUB_CONFIG.branch` all point at `main` again (removes stale `fix/sync-branch-config-CI` references).
- **`checkout.sh`**: runs `sync-branch-config.sh -m` so creating a feature branch no longer stamps branch-scoped raw GitHub URLs into the userscript; prints the main install URL instead of a branch-specific one.
- **`sync-branch-config.sh`**: clearer `-c` behavior when merge conflicts block commit or when there is nothing to commit after sync; documents that checkout uses `-m` while `test.sh` still uses branch-scoped sync intentionally.
- **CI guardrails**: new workflow on **push to `main`** auto-runs `sync-branch-config.sh -m` and commits if `fleet.user.js` drifts; PR workflow only stages `dev/fleet-dev-id.user.js` when that file exists.

## Commit history

- `6ad5297` fix: restore main fleet.user.js config; checkout.sh keeps main URLs on new branches

## Stats

```
 .../workflows/verify-main-branch-config-main.yml   | 30 ++++++++++++++
 .github/workflows/verify-main-branch-config-pr.yml |  7 +++-
 dev/utils/checkout.sh                              | 46 ++++++++++------------
 dev/utils/sync-branch-config.sh                    | 18 +++++++--
 fleet.user.js                                      |  8 ++--
 5 files changed, 75 insertions(+), 34 deletions(-)
```
