### PR TITLE
Centralize Fleet user JWT in FleetSessionAuth

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "9.2.0",
+  "version": "9.3.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "9.81",
+  "archetypesVersion": "9.82",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -22,8 +22,8 @@
     },
     {
       "name": "ops-tab.js",
-      "version": "3.7",
-      "hash": "sha256-ce3ba56ff067139538a52deebb3cc579b6c967eaec5931d8f372b3d277cbd2b5",
+      "version": "3.8",
+      "hash": "sha256-96dfab418a6742012a51684f7bc4c1e107908467ed5d8b1cc7b5800449188815",
       "log": false
     },
     {
@@ -46,8 +46,8 @@
     },
     {
       "name": "dashboard.js",
-      "version": "3.28",
-      "hash": "sha256-f95d70c4efefd64376c32abd763603aa12e334239e786b74a4e3905471f15ca1",
+      "version": "3.29",
+      "hash": "sha256-b24f0e7cc525c4c8a046baa72c9be2dbc0790a0777c9d326d701f9636af46e80",
       "log": false
     }
   ],

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      9.2.0
+// @version      9.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -30,7 +30,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '9.2.0';
+    const VERSION = '9.3.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -1087,6 +1087,225 @@
         supabaseAccessToken: 'fleet-ux:supabase-access-token'
     };
 
+    /** Reject user JWTs this many seconds before exp (clock skew). */
+    const FLEET_SESSION_JWT_EXPIRY_SKEW_SEC = 60;
+
+    /**
+     * Monolithic Fleet user JWT: parse sb-* storage, merge by exp, passive capture.
+     * All consumers use NetworkObserver.getFleetUserJwt() / refreshFromPage().
+     */
+    const FleetSessionAuth = {
+        _decodeJwtPayload(jwt) {
+            if (!jwt || typeof jwt !== 'string') return null;
+            const parts = jwt.split('.');
+            if (parts.length !== 3) return null;
+            try {
+                const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+                const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
+                return JSON.parse(atob(padded));
+            } catch (_e) {
+                return null;
+            }
+        },
+
+        _jwtExpSeconds(jwt) {
+            const payload = this._decodeJwtPayload(jwt);
+            return payload && Number.isFinite(payload.exp) ? payload.exp : null;
+        },
+
+        _isAnonJwt(jwt, projectRef) {
+            const payload = this._decodeJwtPayload(jwt);
+            if (!payload || payload.role !== 'anon') return false;
+            if (!projectRef) return true;
+            return payload.ref === projectRef;
+        },
+
+        _isJwtExpired(jwt, projectRef, skewSec) {
+            if (!jwt) return true;
+            if (this._isAnonJwt(jwt, projectRef)) return true;
+            const exp = this._jwtExpSeconds(jwt);
+            if (exp == null) return false;
+            const skew = Number.isFinite(skewSec) ? skewSec : FLEET_SESSION_JWT_EXPIRY_SKEW_SEC;
+            return Date.now() >= (exp * 1000) - skew * 1000;
+        },
+
+        _isValidUserJwt(jwt, projectRef) {
+            return !!(jwt && !this._isAnonJwt(jwt, projectRef) && !this._isJwtExpired(jwt, projectRef));
+        },
+
+        _extractAccessTokenFromValue(value) {
+            if (!value || typeof value !== 'string') return '';
+            try {
+                let candidate = value;
+                if (candidate.startsWith('base64-')) {
+                    candidate = atob(candidate.slice('base64-'.length));
+                }
+                const parsed = JSON.parse(candidate);
+                const direct =
+                    (parsed && parsed.access_token) ||
+                    (parsed && parsed.currentSession && parsed.currentSession.access_token) ||
+                    (parsed && parsed.session && parsed.session.access_token) ||
+                    (Array.isArray(parsed) && (
+                        (parsed[0] && parsed[0].access_token) ||
+                        (parsed[1] && parsed[1].access_token) ||
+                        (parsed[0] && parsed[0].currentSession && parsed[0].currentSession.access_token) ||
+                        (parsed[1] && parsed[1].currentSession && parsed[1].currentSession.access_token) ||
+                        (parsed[0] && parsed[0].session && parsed[0].session.access_token) ||
+                        (parsed[1] && parsed[1].session && parsed[1].session.access_token)
+                    ));
+                if (typeof direct === 'string' && direct.length > 0) return direct;
+            } catch (_e) {
+                /* fall through */
+            }
+            const match = value.match(/"access_token"\s*:\s*"([^"]+)"/);
+            return match ? match[1] : '';
+        },
+
+        _shouldInspectAuthStorageKey(key, raw) {
+            return (
+                (key && key.startsWith('sb-')) ||
+                (key && key.toLowerCase().includes('supabase')) ||
+                (raw && raw.includes('"access_token"'))
+            );
+        },
+
+        _collectFromStorage(storage) {
+            const tokens = [];
+            if (!storage) return tokens;
+            for (let i = 0; i < storage.length; i++) {
+                const key = storage.key(i);
+                if (!key) continue;
+                const raw = storage.getItem(key);
+                if (!raw || !this._shouldInspectAuthStorageKey(key, raw)) continue;
+                const token = this._extractAccessTokenFromValue(raw);
+                if (token) tokens.push(token);
+            }
+            return tokens;
+        },
+
+        _collectFromAuthCookies(pageWindow) {
+            const tokens = [];
+            try {
+                const cookie = (pageWindow && pageWindow.document && pageWindow.document.cookie) || '';
+                if (!cookie) return tokens;
+                const parts = cookie.split(/;\s*/);
+                const authParts = parts
+                    .map((part) => {
+                        const eq = part.indexOf('=');
+                        return eq >= 0 ? [part.slice(0, eq), part.slice(eq + 1)] : [part, ''];
+                    })
+                    .filter(([key]) => key.startsWith('sb-') && key.includes('auth-token'));
+                const grouped = new Map();
+                authParts.forEach(([key, value]) => {
+                    const base = key.replace(/\.\d+$/, '');
+                    const indexMatch = key.match(/\.(\d+)$/);
+                    const index = indexMatch ? Number(indexMatch[1]) : 0;
+                    if (!grouped.has(base)) grouped.set(base, []);
+                    grouped.get(base).push({ index, value });
+                });
+                for (const group of grouped.values()) {
+                    const decoded = group
+                        .sort((a, b) => a.index - b.index)
+                        .map(({ value }) => decodeURIComponent(value || ''))
+                        .join('');
+                    const token = this._extractAccessTokenFromValue(decoded);
+                    if (token) tokens.push(token);
+                }
+                for (const [, value] of authParts) {
+                    const decoded = decodeURIComponent(value || '');
+                    const token = this._extractAccessTokenFromValue(decoded);
+                    if (token) tokens.push(token);
+                }
+            } catch (e) {
+                Logger.debug('FleetSessionAuth: cookie token read failed', e);
+            }
+            return tokens;
+        },
+
+        _collectJwtCandidates(pageWindow, runtimeAccess) {
+            const candidates = [];
+            const push = (token) => {
+                if (token && !candidates.includes(token)) candidates.push(token);
+            };
+            if (runtimeAccess && runtimeAccess.supabaseAccessToken) {
+                push(runtimeAccess.supabaseAccessToken);
+            }
+            try {
+                const storage = pageWindow && pageWindow.localStorage;
+                if (storage) {
+                    const cached = storage.getItem(RUNTIME_ACCESS_STORAGE_KEYS.supabaseAccessToken);
+                    push(cached);
+                }
+            } catch (_e) { /* ignore */ }
+            if (pageWindow) {
+                this._collectFromStorage(pageWindow.localStorage).forEach(push);
+                this._collectFromStorage(pageWindow.sessionStorage).forEach(push);
+                this._collectFromAuthCookies(pageWindow).forEach(push);
+            }
+            return candidates;
+        },
+
+        _pickBestUserJwt(candidates, projectRef) {
+            let best = '';
+            let bestExp = -1;
+            for (const token of candidates) {
+                if (!this._isValidUserJwt(token, projectRef)) continue;
+                const exp = this._jwtExpSeconds(token);
+                const expScore = exp != null ? exp : Number.MAX_SAFE_INTEGER;
+                if (expScore > bestExp) {
+                    bestExp = expScore;
+                    best = token;
+                }
+            }
+            return best;
+        },
+
+        _shouldReplaceToken(newToken, currentToken, projectRef) {
+            if (!newToken || !this._isValidUserJwt(newToken, projectRef)) return false;
+            if (!currentToken || !this._isValidUserJwt(currentToken, projectRef)) return true;
+            const newExp = this._jwtExpSeconds(newToken);
+            const curExp = this._jwtExpSeconds(currentToken);
+            if (newExp == null) return false;
+            if (curExp == null) return true;
+            return newExp >= curExp;
+        },
+
+        mergeAccessToken(observer, pageWindow, token) {
+            if (!token || !observer) return;
+            const ref = observer._runtimeAccess.supabaseProjectRef;
+            if (this._isAnonJwt(token, ref)) return;
+            const current = observer._runtimeAccess.supabaseAccessToken;
+            if (!this._shouldReplaceToken(token, current, ref)) return;
+            observer._setRuntimeAccessToken(pageWindow, token);
+        },
+
+        refreshFromPage(observer, pageWindow) {
+            if (!observer || !pageWindow) return;
+            observer._loadRuntimeAccessFromStorage(pageWindow);
+            const ref = observer._runtimeAccess.supabaseProjectRef;
+            const candidates = this._collectJwtCandidates(pageWindow, observer._runtimeAccess);
+            const best = this._pickBestUserJwt(candidates, ref);
+            if (best) {
+                observer._setRuntimeAccessToken(pageWindow, best);
+            } else if (observer._runtimeAccess.supabaseAccessToken) {
+                observer._clearRuntimeAccessToken(pageWindow);
+            }
+            const exp = best ? this._jwtExpSeconds(best) : null;
+            Logger.debug('FleetSessionAuth: refreshFromPage', {
+                hasAccessToken: !!best,
+                exp: exp != null ? exp : '(none)'
+            });
+        },
+
+        getFleetUserJwt(observer, pageWindow) {
+            const win = pageWindow || (observer && Context.getPageWindow()) || window;
+            if (observer) this.refreshFromPage(observer, win);
+            const token = observer && observer._runtimeAccess.supabaseAccessToken;
+            const ref = observer && observer._runtimeAccess.supabaseProjectRef;
+            return token && this._isValidUserJwt(token, ref) ? token : '';
+        }
+    };
+
     /**
      * Central page-fetch interception. Owned by the main userscript so dynamic API endpoint
      * discovery happens exactly once and is shared across modules through `Context.networkObserver`.
@@ -1130,12 +1349,7 @@
                 onResponse(meta, response) {
                     response.json().then((body) => {
                         if (!body || !body.access_token) return;
-                        if (observer._jwtIsAnonForRef(body.access_token, observer._runtimeAccess.supabaseProjectRef)) {
-                            return;
-                        }
-                        observer._persistRuntimeAccess(meta.pageWindow, {
-                            supabaseAccessToken: body.access_token
-                        });
+                        FleetSessionAuth.mergeAccessToken(observer, meta.pageWindow, body.access_token);
                         Logger.debug('NetworkObserver: captured access_token from auth/v1/token response');
                     }).catch(() => { /* ignore non-JSON */ });
                 }
@@ -1154,7 +1368,7 @@
                 const anonKeyValid = anonKey ? this._jwtIsAnonForRef(anonKey, projectRef) : false;
                 const baseUrlValid = baseUrl ? this._validRestBaseUrlForRef(baseUrl, projectRef) : false;
                 const accessTokenValid = accessToken
-                    ? !this._jwtIsAnonForRef(accessToken, projectRef)
+                    ? FleetSessionAuth._isValidUserJwt(accessToken, projectRef)
                     : false;
 
                 if (anonKey && !anonKeyValid) {
@@ -1265,10 +1479,38 @@
             const bearer = authHeader && authHeader.startsWith('Bearer ')
                 ? authHeader.slice(7).trim()
                 : null;
-            if (bearer && !this._jwtIsAnonForRef(bearer, ref)) {
-                update.supabaseAccessToken = bearer;
-            }
             this._persistRuntimeAccess(meta.pageWindow, update);
+            if (bearer) {
+                FleetSessionAuth.mergeAccessToken(this, meta.pageWindow, bearer);
+            }
+        },
+
+        _setRuntimeAccessToken(pageWindow, token) {
+            this._runtimeAccess.supabaseAccessToken = token;
+            try {
+                const storage = pageWindow && pageWindow.localStorage;
+                if (storage && token) {
+                    storage.setItem(RUNTIME_ACCESS_STORAGE_KEYS.supabaseAccessToken, token);
+                }
+            } catch (_e) { /* ignore */ }
+        },
+
+        _clearRuntimeAccessToken(pageWindow) {
+            this._runtimeAccess.supabaseAccessToken = null;
+            try {
+                const storage = pageWindow && pageWindow.localStorage;
+                if (storage) storage.removeItem(RUNTIME_ACCESS_STORAGE_KEYS.supabaseAccessToken);
+            } catch (_e) { /* ignore */ }
+        },
+
+        refreshFromPage(pageWindow) {
+            const win = pageWindow || Context.getPageWindow();
+            if (!win) return;
+            FleetSessionAuth.refreshFromPage(this, win);
+        },
+
+        getFleetUserJwt(pageWindow) {
+            return FleetSessionAuth.getFleetUserJwt(this, pageWindow);
         },
 
         _readHeader(headers, name) {
@@ -1296,23 +1538,11 @@
         },
 
         _decodeJwtPayload(jwt) {
-            if (!jwt || typeof jwt !== 'string') return null;
-            const parts = jwt.split('.');
-            if (parts.length !== 3) return null;
-            try {
-                const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-                const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
-                return JSON.parse(atob(padded));
-            } catch (_e) {
-                return null;
-            }
+            return FleetSessionAuth._decodeJwtPayload(jwt);
         },
 
         _jwtIsAnonForRef(jwt, expectedRef) {
-            const payload = this._decodeJwtPayload(jwt);
-            if (!payload || payload.role !== 'anon') return false;
-            if (!expectedRef) return true;
-            return payload.ref === expectedRef;
+            return FleetSessionAuth._isAnonJwt(jwt, expectedRef);
         },
 
         _validRestBaseUrlForRef(baseUrl, ref) {
@@ -1339,12 +1569,6 @@
                 }
                 changed = true;
             };
-            if (partial.supabaseAccessToken) {
-                const ref = partial.supabaseProjectRef || this._runtimeAccess.supabaseProjectRef;
-                if (!this._jwtIsAnonForRef(partial.supabaseAccessToken, ref)) {
-                    setKey('supabaseAccessToken', partial.supabaseAccessToken);
-                }
-            }
             setKey('supabaseProjectRef', partial.supabaseProjectRef);
             setKey('supabaseRestBaseUrl', partial.supabaseRestBaseUrl);
             setKey('supabaseAnonKey', partial.supabaseAnonKey);
@@ -1385,7 +1609,10 @@
     Context.networkObserver = {
         subscribe: (opts) => NetworkObserver.subscribe(opts),
         unsubscribe: (id) => NetworkObserver.unsubscribe(id),
-        getRuntimeAccess: () => NetworkObserver.getRuntimeAccess()
+        getRuntimeAccess: () => NetworkObserver.getRuntimeAccess(),
+        getFleetUserJwt: (pageWindow) => NetworkObserver.getFleetUserJwt(pageWindow),
+        refreshFromPage: (pageWindow) => NetworkObserver.refreshFromPage(pageWindow),
+        decodeJwtPayload: (jwt) => FleetSessionAuth._decodeJwtPayload(jwt)
     };
 
     // ============= ARCHETYPE MANAGER =============
@@ -2718,7 +2945,13 @@
     
     async function initializeForPage() {
         Logger.log('Initializing for current page...');
-        
+
+        try {
+            NetworkObserver.refreshFromPage(Context.getPageWindow());
+        } catch (e) {
+            Logger.debug('FleetSessionAuth: refreshFromPage on init failed', e);
+        }
+
         try {
             // Load archetype definitions (cached after first load)
             await ArchetypeManager.loadArchetypes();

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      9.3.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -16,8 +16,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -49,7 +49,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      9.2.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -16,8 +16,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -49,7 +49,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/dashboard.js
+++ b/plugins/core/main/dashboard.js
@@ -159,7 +159,7 @@ const plugin = {
     id: 'dashboard',
     name: 'Dashboard',
     description: 'Worker Output Search dashboard popup (task creations + QA reviews) opened from the Ops tab; all data via documented Fleet PostgREST endpoints',
-    _version: '3.28',
+    _version: '3.29',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -1273,6 +1273,13 @@ const plugin = {
     },
 
     open() {
+        try {
+            if (Context.networkObserver && typeof Context.networkObserver.refreshFromPage === 'function') {
+                Context.networkObserver.refreshFromPage(this._pageWindow());
+            }
+        } catch (e) {
+            Logger.debug('dashboard: refreshFromPage on open failed', e);
+        }
         this._ensureBuilt();
         this._overlay.style.display = 'flex';
         // Close the regular settings modal if it is open

--- a/plugins/core/main/ops-tab.js
+++ b/plugins/core/main/ops-tab.js
@@ -137,7 +137,7 @@ const plugin = {
     id: 'ops-tab',
     name: 'Ops Tab',
     description: 'Provides the Ops tab UI and verifier code fetcher in the settings modal',
-    _version: '3.7',
+    _version: '3.8',
     phase: 'core',
     enabledByDefault: true,
 
@@ -201,7 +201,8 @@ const plugin = {
             postgrestQuery: (queryKey, overrides) => this._opsPostgrestQuery(queryKey, overrides),
             // tableKey → resolved table name from decrypted ops bundle
             postgrestGet: (tableKey, params) => this._opsPostgrestGetByKey(tableKey, params),
-            isSessionRefreshRequiredError: (err) => this._isOpsSessionRefreshRequiredError(err)
+            isSessionRefreshRequiredError: (err) => this._isOpsSessionRefreshRequiredError(err),
+            getFleetUserJwt: (pageWindow) => this._getOpsFleetUserJwt(pageWindow)
         };
         Logger.log('Ops tab module registered (Context.opsTab)');
         this._loadOpsTeamSearchActionFromStorage();
@@ -526,50 +527,12 @@ const plugin = {
         return window;
     },
 
-    _decodeOpsJwtPayload(jwt) {
-        if (!jwt || typeof jwt !== 'string') return null;
-        const parts = jwt.split('.');
-        if (parts.length !== 3) return null;
-        try {
-            const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-            const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4);
-            return JSON.parse(atob(padded));
-        } catch (_e) {
-            return null;
+    _getOpsFleetUserJwt(pageWindow) {
+        const no = Context.networkObserver;
+        if (no && typeof no.getFleetUserJwt === 'function') {
+            return no.getFleetUserJwt(pageWindow);
         }
-    },
-
-    _isOpsSupabaseAnonKey(key) {
-        const payload = this._decodeOpsJwtPayload(key);
-        return payload && payload.role === 'anon';
-    },
-
-    _extractOpsAccessTokenFromValue(value) {
-        if (!value || typeof value !== 'string') return '';
-        try {
-            let candidate = value;
-            if (candidate.startsWith('base64-')) {
-                candidate = atob(candidate.slice('base64-'.length));
-            }
-            const parsed = JSON.parse(candidate);
-            const direct =
-                (parsed && parsed.access_token) ||
-                (parsed && parsed.currentSession && parsed.currentSession.access_token) ||
-                (parsed && parsed.session && parsed.session.access_token) ||
-                (Array.isArray(parsed) && (
-                    (parsed[0] && parsed[0].access_token) ||
-                    (parsed[1] && parsed[1].access_token) ||
-                    (parsed[0] && parsed[0].currentSession && parsed[0].currentSession.access_token) ||
-                    (parsed[1] && parsed[1].currentSession && parsed[1].currentSession.access_token) ||
-                    (parsed[0] && parsed[0].session && parsed[0].session.access_token) ||
-                    (parsed[1] && parsed[1].session && parsed[1].session.access_token)
-                ));
-            if (typeof direct === 'string' && direct.length > 0) return direct;
-        } catch (_e) {
-            /* fall through to regex extraction */
-        }
-        const match = value.match(/"access_token"\s*:\s*"([^"]+)"/);
-        return match ? match[1] : '';
+        return '';
     },
 
     _opsSessionRefreshRequiredError(message) {
@@ -586,80 +549,6 @@ const plugin = {
         if (!err || typeof err.message !== 'string') return false;
         if (!/\b401\b/.test(err.message)) return false;
         return /JWT expired|PGRST301/i.test(err.message);
-    },
-
-    _getOpsSupabaseAccessTokenFromStorage(storage) {
-        if (!storage) return '';
-        for (let i = 0; i < storage.length; i++) {
-            const key = storage.key(i);
-            if (!key) continue;
-            const raw = storage.getItem(key);
-            if (!raw) continue;
-            const shouldInspect =
-                key.startsWith('sb-') ||
-                key.toLowerCase().includes('supabase') ||
-                raw.includes('"access_token"');
-            if (!shouldInspect) continue;
-            const token = this._extractOpsAccessTokenFromValue(raw);
-            if (token) return token;
-        }
-        return '';
-    },
-
-    _getOpsSupabaseAccessTokenFromCookies(pageWindow) {
-        try {
-            const cookie = (pageWindow.document && pageWindow.document.cookie) || document.cookie || '';
-            if (!cookie) return '';
-            const parts = cookie.split(/;\s*/);
-            const authParts = parts
-                .map(part => {
-                    const eq = part.indexOf('=');
-                    return eq >= 0 ? [part.slice(0, eq), part.slice(eq + 1)] : [part, ''];
-                })
-                .filter(([key]) => key.startsWith('sb-') && key.includes('auth-token'));
-            const grouped = new Map();
-            authParts.forEach(([key, value]) => {
-                const base = key.replace(/\.\d+$/, '');
-                const indexMatch = key.match(/\.(\d+)$/);
-                const index = indexMatch ? Number(indexMatch[1]) : 0;
-                if (!grouped.has(base)) grouped.set(base, []);
-                grouped.get(base).push({ index, value });
-            });
-            for (const group of grouped.values()) {
-                const decoded = group
-                    .sort((a, b) => a.index - b.index)
-                    .map(({ value }) => decodeURIComponent(value || ''))
-                    .join('');
-                const token = this._extractOpsAccessTokenFromValue(decoded);
-                if (token) return token;
-            }
-            for (const [, value] of authParts) {
-                const decoded = decodeURIComponent(value || '');
-                const token = this._extractOpsAccessTokenFromValue(decoded);
-                if (token) return token;
-            }
-        } catch (e) {
-            Logger.debug('ops-tab: cookie token read failed', e);
-        }
-        return '';
-    },
-
-    _getOpsSupabaseAccessToken(pageWindow) {
-        const win = pageWindow || this._getOpsPageWindow();
-        try {
-            return (
-                this._getOpsSupabaseAccessTokenFromStorage(win.localStorage) ||
-                this._getOpsSupabaseAccessTokenFromStorage(win.sessionStorage) ||
-                this._getOpsSupabaseAccessTokenFromCookies(win)
-            );
-        } catch (e) {
-            Logger.debug('ops-tab: token read failed', e);
-        }
-        return '';
-    },
-
-    _extractOpsJwtToken(pageWindow) {
-        return this._getOpsSupabaseAccessToken(pageWindow);
     },
 
     _getOpsRuntimeAccess() {
@@ -682,18 +571,6 @@ const plugin = {
         return { baseUrl, anonKey, projectRef: access.supabaseProjectRef || null };
     },
 
-    _getOpsPostgrestAccessToken(pageWindow) {
-        const intercepted = this._getOpsRuntimeAccess().supabaseAccessToken;
-        if (intercepted && !this._isOpsSupabaseAnonKey(intercepted)) {
-            return intercepted;
-        }
-        const fallback = this._getOpsSupabaseAccessToken(pageWindow);
-        if (fallback && !this._isOpsSupabaseAnonKey(fallback)) {
-            return fallback;
-        }
-        return '';
-    },
-
     _getOpsPostgrestHeaders() {
         const pageWindow = this._getOpsPageWindow();
         const { anonKey } = this._ensureOpsRuntimeAccess();
@@ -703,7 +580,7 @@ const plugin = {
             apikey: anonKey,
             'x-client-info': 'fleet-ux-ops-tab/' + this._version
         };
-        const token = this._getOpsPostgrestAccessToken(pageWindow);
+        const token = this._getOpsFleetUserJwt(pageWindow);
         if (token) {
             headers.authorization = 'Bearer ' + token;
         }
@@ -968,9 +845,10 @@ const plugin = {
     },
 
     _extractOpsUserIdFromJwt(pageWindow) {
-        const jwt = this._extractOpsJwtToken(pageWindow);
+        const jwt = this._getOpsFleetUserJwt(pageWindow);
         if (!jwt) return '';
-        const payload = this._decodeOpsJwtPayload(jwt);
+        const decode = Context.networkObserver && Context.networkObserver.decodeJwtPayload;
+        const payload = decode ? decode(jwt) : null;
         const sub = payload && payload.sub;
         return typeof sub === 'string' && OPS_UUID_RE.test(sub) ? sub : '';
     },
@@ -2155,9 +2033,9 @@ const plugin = {
 
     async _fetchOpsVerifierCodeFromOrchestrator(resolved) {
         const pageWindow = this._getOpsPageWindow();
-        const jwt = this._extractOpsJwtToken(pageWindow);
+        const jwt = this._getOpsFleetUserJwt(pageWindow);
         if (!jwt) {
-            Logger.debug('ops-tab: orchestrator skipped — no JWT');
+            Logger.warn('ops-tab: orchestrator skipped — no Fleet user JWT (open Fleet on a data page)');
             return null;
         }
         if (!resolved.verifierId) {
@@ -2188,7 +2066,11 @@ const plugin = {
             });
             if (!res.ok) {
                 const text = await res.text().catch(() => '');
-                Logger.debug('ops-tab: orchestrator HTTP ' + res.status + ' for ' + resolved.verifierId, text.slice(0, 200));
+                Logger.warn('ops-tab: orchestrator HTTP ' + res.status, {
+                    verifierId: resolved.verifierId,
+                    teamId: teamId || '(none)',
+                    body: text.slice(0, 200)
+                });
                 return null;
             }
             const body = await res.json().catch(() => null);
@@ -2261,9 +2143,13 @@ const plugin = {
         const rows = await this._opsPostgrestQuery('verifier_versions.select_source', params);
         const row = Array.isArray(rows) ? rows[0] : rows;
         if (!row) {
+            const pageWindow = this._getOpsPageWindow();
+            if (!this._getOpsFleetUserJwt(pageWindow)) {
+                throw this._opsSessionRefreshRequiredError();
+            }
             const hint = resolved.teamId
-                ? 'No verifier version rows for team ' + resolved.teamId.slice(0, 8) + '…'
-                : 'Verifier versions may require a team context that could not be resolved automatically.';
+                ? 'PostgREST returned no rows (RLS or team scope). Team ' + resolved.teamId.slice(0, 8) + '…'
+                : 'PostgREST returned no rows — likely RLS or missing team context.';
             throw new Error('No verifier version found for ' + resolved.verifierId + '. ' + hint);
         }
         if (!row.display_src) {


### PR DESCRIPTION
## Summary

Centralizes Fleet user JWT discovery and validation in the userscript host (`FleetSessionAuth`) so Ops, Dashboard, and network interception share one code path. Ops tab drops duplicate storage/cookie scraping; Dashboard and init refresh the session before API calls.

## Changes

- **`fleet.user.js`**: Adds `FleetSessionAuth` to collect JWT candidates from runtime cache, `localStorage`/`sessionStorage` (`sb-*` keys), and chunked Supabase auth cookies; picks the best non-anon, non-expired token (60s skew); merges tokens from auth responses and REST `Authorization` headers via `mergeAccessToken`. Exposes `Context.networkObserver.getFleetUserJwt`, `refreshFromPage`, and `decodeJwtPayload`. Refreshes session on page init.
- **`ops-tab.js` (3.8)**: Removes local JWT decode/storage/cookie helpers; uses `getFleetUserJwt` for PostgREST and orchestrator calls. Improves logging when JWT or orchestrator calls fail; throws session-refresh error when PostgREST returns no rows without a valid JWT.
- **`dashboard.js` (3.29)**: Calls `refreshFromPage` when opening the dashboard overlay.
- **Versions**: Fleet/userscript `9.3.0`, `archetypesVersion` `9.82`.

## Commit history

- `ec455a5` Monolithic Fleet user JWT via FleetSessionAuth in host

## Stats

```
 archetypes.json                |  12 +-
 fleet.user.js                  | 301 ++++++++++++++++++++++++++++++++++++-----
 plugins/core/main/dashboard.js |   9 +-
 plugins/core/main/ops-tab.js   | 164 ++++------------------
 4 files changed, 306 insertions(+), 180 deletions(-)
```
