### PR TITLE
Add FOS embedded clipboard bridge for iframe env instances

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "9.6.1",
+  "version": "9.6.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.13",
+  "archetypesVersion": "11.14",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "9.5.4",
+  "version": "9.6.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.9",
+  "archetypesVersion": "11.11",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -78,6 +78,12 @@
       "name": "verifier-fetcher.js",
       "version": "2.0",
       "hash": "sha256-e718f83998625396d675b4fe140088f3cb96fd2a36dbab6ebc37f9c8adf9b3bd",
+      "log": false
+    },
+    {
+      "name": "fos-embedded-watcher.js",
+      "version": "1.0",
+      "hash": "sha256-78cb9fd0151190243b6412fc60a3202e3755f4784d196c9b6f40dbaf5360d812",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "9.6.1",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.12",
+  "archetypesVersion": "11.13",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -82,8 +82,8 @@
     },
     {
       "name": "fos-embedded-watcher.js",
-      "version": "1.0",
-      "hash": "sha256-78cb9fd0151190243b6412fc60a3202e3755f4784d196c9b6f40dbaf5360d812",
+      "version": "1.1",
+      "hash": "sha256-e4ea8afe3bf982acd2a5393e9bdfc0682e891e046dc205b7d3b2a9554dfa3aac",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "9.5.4",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.8",
+  "archetypesVersion": "11.9",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -601,8 +601,8 @@
       "plugins": [
         {
           "name": "vnc-helper.js",
-          "version": "1.6",
-          "hash": "sha256-5a0de18ed975c8875e0b6ea8f08cb26bc7e6e490ffe99e87da9496c93934ce50",
+          "version": "1.7",
+          "hash": "sha256-9369c3b7b2114234117469318bbe6e9754c9c10a50273d8a415f3c8df0965097",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "9.6.0",
+  "version": "9.6.1",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.11",
+  "archetypesVersion": "11.12",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/fos-embedded] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/fos-embedded';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/fos-embedded] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/fos-embedded';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/fos-embedded] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      9.6.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -16,8 +16,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -55,7 +55,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/fos-embedded',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/fos-embedded] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      9.5.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -16,8 +16,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fos-embedded/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -49,7 +49,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/fos-embedded',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/fos-embedded] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      9.6.1
+// @version      9.6.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -37,7 +37,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '9.6.1';
+    const VERSION = '9.6.2';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -312,6 +312,7 @@
 
         let fosAuthorized = false;
         let bridgeStarted = false;
+        let bridgeDismissed = false;
         let waitObserver = null;
         let clipQueue = Promise.resolve();
 
@@ -448,6 +449,9 @@
         }
 
         function injectPanel() {
+            if (bridgeDismissed) {
+                return;
+            }
             const old = document.getElementById(ROOT_ID);
             if (old) {
                 old.remove();
@@ -464,10 +468,32 @@
                 'box-shadow:0 8px 32px rgba(0,0,0,0.45);user-select:none;';
 
             const clipHeader = document.createElement('div');
-            clipHeader.textContent = 'VM Clipboard';
             clipHeader.style.cssText =
-                'padding:8px 12px 4px 12px;font-size:11px;font-weight:600;color:#b0b0b8;' +
-                'letter-spacing:0.03em;text-transform:uppercase;cursor:grab;';
+                'display:flex;align-items:center;justify-content:space-between;' +
+                'padding:6px 8px 4px 12px;cursor:grab;';
+
+            const clipTitle = document.createElement('div');
+            clipTitle.textContent = 'VM Clipboard';
+            clipTitle.style.cssText =
+                'font-size:11px;font-weight:600;color:#b0b0b8;' +
+                'letter-spacing:0.03em;text-transform:uppercase;flex:1;min-width:0;';
+
+            const closeBtn = document.createElement('button');
+            closeBtn.type = 'button';
+            closeBtn.setAttribute('aria-label', 'Close VM Clipboard');
+            closeBtn.textContent = '\u00d7';
+            closeBtn.style.cssText =
+                'flex-shrink:0;margin:0;padding:0 4px;border:none;background:transparent;' +
+                'color:#a5a5ad;font:inherit;font-size:16px;line-height:1;cursor:pointer;border-radius:4px;';
+            closeBtn.onmouseenter = () => {
+                closeBtn.style.color = '#f2f2f2';
+            };
+            closeBtn.onmouseleave = () => {
+                closeBtn.style.color = '#a5a5ad';
+            };
+
+            clipHeader.appendChild(clipTitle);
+            clipHeader.appendChild(closeBtn);
 
             const clipBody = document.createElement('div');
             clipBody.style.cssText = 'padding:0 12px 10px 12px;';
@@ -534,8 +560,29 @@
                 document.removeEventListener('mouseup', onDragUp, true);
             }
 
+            function dismissBridge() {
+                bridgeDismissed = true;
+                bridgeStarted = true;
+                onDragUp();
+                if (waitObserver) {
+                    try {
+                        waitObserver.disconnect();
+                    } catch (_e) { /* ignore */ }
+                    waitObserver = null;
+                }
+                if (root.parentNode) {
+                    root.parentNode.removeChild(root);
+                }
+                console.log(EMBED_LOG + ': clipboard panel dismissed');
+            }
+
+            closeBtn.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                dismissBridge();
+            });
+
             clipHeader.addEventListener('mousedown', (ev) => {
-                if (ev.button !== 0) {
+                if (ev.button !== 0 || ev.target === closeBtn) {
                     return;
                 }
                 ev.preventDefault();
@@ -555,7 +602,7 @@
         }
 
         function startBridge() {
-            if (bridgeStarted) {
+            if (bridgeStarted || bridgeDismissed) {
                 return;
             }
             if (waitObserver) {
@@ -580,11 +627,11 @@
         }
 
         function installWaitObserver() {
-            if (bridgeStarted || waitObserver) {
+            if (bridgeStarted || bridgeDismissed || waitObserver) {
                 return;
             }
             const check = () => {
-                if (!fosAuthorized || bridgeStarted) {
+                if (!fosAuthorized || bridgeStarted || bridgeDismissed) {
                     return;
                 }
                 if (document.getElementById(NOVNC_CLIPBOARD_ID)) {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/fos-embedded] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      9.6.0
+// @version      9.6.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -37,7 +37,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '9.6.0';
+    const VERSION = '9.6.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -467,7 +467,7 @@
             clipHeader.textContent = 'VM Clipboard';
             clipHeader.style.cssText =
                 'padding:8px 12px 4px 12px;font-size:11px;font-weight:600;color:#b0b0b8;' +
-                'letter-spacing:0.03em;text-transform:uppercase;';
+                'letter-spacing:0.03em;text-transform:uppercase;cursor:grab;';
 
             const clipBody = document.createElement('div');
             clipBody.style.cssText = 'padding:0 12px 10px 12px;';
@@ -511,6 +511,46 @@
             root.appendChild(clipHeader);
             root.appendChild(clipBody);
             document.body.appendChild(root);
+
+            let dragging = false;
+            let dragOx = 0;
+            let dragOy = 0;
+
+            function onDragMove(ev) {
+                if (!dragging) {
+                    return;
+                }
+                root.style.left = Math.max(0, ev.clientX - dragOx) + 'px';
+                root.style.top = Math.max(0, ev.clientY - dragOy) + 'px';
+            }
+
+            function onDragUp() {
+                if (!dragging) {
+                    return;
+                }
+                dragging = false;
+                clipHeader.style.cursor = 'grab';
+                document.removeEventListener('mousemove', onDragMove, true);
+                document.removeEventListener('mouseup', onDragUp, true);
+            }
+
+            clipHeader.addEventListener('mousedown', (ev) => {
+                if (ev.button !== 0) {
+                    return;
+                }
+                ev.preventDefault();
+                const r = root.getBoundingClientRect();
+                root.style.bottom = 'auto';
+                root.style.left = r.left + 'px';
+                root.style.top = r.top + 'px';
+                dragging = true;
+                dragOx = ev.clientX - r.left;
+                dragOy = ev.clientY - r.top;
+                clipHeader.style.cursor = 'grabbing';
+                document.addEventListener('mousemove', onDragMove, true);
+                document.addEventListener('mouseup', onDragUp, true);
+            });
+
             console.log(EMBED_LOG + ': clipboard panel injected');
         }
 

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/fos-embedded] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      9.5.4
+// @version      9.6.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -23,14 +23,21 @@
 (function() {
     'use strict';
 
-    // Exit immediately if inside an iframe.
+    // noVNC / embedded env instances live on *.env.*.fleetai.com (also used before full bootstrap in iframes).
+    const NOVNC_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
+
+    // Exit immediately if inside a non-env iframe; env-subdomain iframes run minimal FOS clipboard bootstrap only.
     if (window.top != window.self) {
-        console.warn("[Fleet UX Enhancer] - iframe detected. Terminating duplicate script instance. This is normal.");
+        if (!NOVNC_HOST_PATTERN.test(window.location.hostname)) {
+            console.warn("[Fleet UX Enhancer] - iframe detected. Terminating duplicate script instance. This is normal.");
+            return;
+        }
+        initFosEmbeddedMode();
         return;
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '9.5.4';
+    const VERSION = '9.6.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -42,7 +49,6 @@
 
     // noVNC instances run on a separate subdomain origin; return a synthetic path so
     // the archetype detection pipeline can still match them via urlPattern.
-    const NOVNC_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
     const NOVNC_SYNTHETIC_PATH = '_novnc';
     
     // GitHub repository configuration
@@ -290,6 +296,300 @@
 
     if (DEV_SCRIPTS_ENABLED) {
         writeDevActiveBranchMarker();
+    }
+
+    /**
+     * Minimal bootstrap for FOS env iframes embedded on www.fleetai.com.
+     * Parent fos-embedded-watcher authorizes via postMessage; this injects a neutered clipboard panel only.
+     */
+    function initFosEmbeddedMode() {
+        const EMBED_LOG = '[Fleet UX Enhancer] fos-embedded';
+        const ROOT_ID = 'fleet-fos-embedded-clipboard';
+        const NOVNC_CLIPBOARD_ID = 'noVNC_clipboard_text';
+        const COPY_SUCCESS_MS = 1000;
+        const COPY_FAIL_MS = 500;
+        const FLEET_PARENT_HOSTS = new Set(['www.fleetai.com', 'fleetai.com']);
+
+        let fosAuthorized = false;
+        let bridgeStarted = false;
+        let waitObserver = null;
+        let clipQueue = Promise.resolve();
+
+        function isFleetParentOrigin(origin) {
+            try {
+                return FLEET_PARENT_HOSTS.has(new URL(origin).hostname);
+            } catch (_e) {
+                return false;
+            }
+        }
+
+        function flashSuccess(btn) {
+            if (btn._fosClipResetTimeout) {
+                clearTimeout(btn._fosClipResetTimeout);
+            }
+            btn.style.transition = '';
+            btn.style.backgroundColor = 'rgb(34, 197, 94)';
+            btn.style.color = '#ffffff';
+            btn._fosClipResetTimeout = setTimeout(() => {
+                btn._fosClipResetTimeout = null;
+                btn.style.backgroundColor = 'rgba(255,255,255,0.08)';
+                btn.style.color = '#f2f2f2';
+            }, COPY_SUCCESS_MS);
+        }
+
+        function flashFailure(btn) {
+            if (btn._fosClipResetTimeout) {
+                clearTimeout(btn._fosClipResetTimeout);
+            }
+            const prevT = btn.style.transition;
+            btn.style.transition = 'none';
+            btn.style.backgroundColor = 'rgb(239, 68, 68)';
+            btn.style.color = '#ffffff';
+            void btn.offsetHeight;
+            btn.style.transition = 'background-color ' + COPY_FAIL_MS + 'ms ease-out, color ' + COPY_FAIL_MS + 'ms ease-out';
+            btn.style.backgroundColor = 'rgba(255,255,255,0.08)';
+            btn.style.color = '#f2f2f2';
+            btn._fosClipResetTimeout = setTimeout(() => {
+                btn.style.transition = prevT || '';
+                btn._fosClipResetTimeout = null;
+            }, COPY_FAIL_MS);
+        }
+
+        function clipEl() {
+            return document.getElementById(NOVNC_CLIPBOARD_ID);
+        }
+
+        function getRfb() {
+            return (
+                window.rfb ||
+                window._rfb ||
+                (window.UI && window.UI.rfb) ||
+                (window.APP && window.APP.rfb) ||
+                (window.noVNC && window.noVNC.rfb) ||
+                null
+            );
+        }
+
+        function sleep(ms) {
+            return new Promise((resolve) => {
+                setTimeout(resolve, ms);
+            });
+        }
+
+        async function pushOsTextToVmClipboard(text) {
+            const el = clipEl();
+            if (!el) {
+                console.warn(EMBED_LOG + ': overwrite failed — noVNC clipboard field missing');
+                return false;
+            }
+            const merged = text;
+            const rfb = getRfb();
+            el.value = merged;
+            if (rfb && typeof rfb.clipboardPasteFrom === 'function') {
+                rfb.clipboardPasteFrom('');
+                await sleep(12);
+                rfb.clipboardPasteFrom(merged);
+            } else {
+                el.value = '';
+                el.dispatchEvent(new Event('change', { bubbles: true }));
+                el.dispatchEvent(new Event('input', { bubbles: true }));
+                await sleep(12);
+                el.value = merged;
+                el.dispatchEvent(new Event('change', { bubbles: true }));
+                el.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            return true;
+        }
+
+        async function extractVmTextToOs() {
+            const el = clipEl();
+            if (!el) {
+                console.warn(EMBED_LOG + ': extract failed — noVNC clipboard field missing');
+                return false;
+            }
+            const v = el.value || '';
+            if (!v) {
+                console.warn(EMBED_LOG + ': extract skipped — VM clipboard empty');
+                return false;
+            }
+            try {
+                await navigator.clipboard.writeText(v);
+                return true;
+            } catch (e) {
+                console.warn(EMBED_LOG + ': extract failed — could not write system clipboard', e);
+                return false;
+            }
+        }
+
+        async function runOverwrite(btn) {
+            try {
+                const t = await navigator.clipboard.readText();
+                const ok = await pushOsTextToVmClipboard(typeof t === 'string' ? t : '');
+                if (ok) {
+                    flashSuccess(btn);
+                    console.log(EMBED_LOG + ': overwrite ok');
+                } else {
+                    flashFailure(btn);
+                }
+            } catch (e) {
+                flashFailure(btn);
+                console.warn(EMBED_LOG + ': overwrite failed — could not read system clipboard', e);
+            }
+        }
+
+        async function runExtract(btn) {
+            const ok = await extractVmTextToOs();
+            if (ok) {
+                flashSuccess(btn);
+                console.log(EMBED_LOG + ': extract ok');
+            } else {
+                flashFailure(btn);
+            }
+        }
+
+        function injectPanel() {
+            const old = document.getElementById(ROOT_ID);
+            if (old) {
+                old.remove();
+            }
+
+            const root = document.createElement('div');
+            root.id = ROOT_ID;
+            root.style.cssText =
+                'position:fixed;left:16px;bottom:16px;z-index:2147483646;' +
+                'min-width:220px;max-width:280px;padding:0;' +
+                'border-radius:10px;border:1px solid rgba(255,255,255,0.14);' +
+                'background:rgba(28,28,32,0.96);color:#f2f2f2;' +
+                'font:500 12px/1.4 system-ui,-apple-system,sans-serif;' +
+                'box-shadow:0 8px 32px rgba(0,0,0,0.45);user-select:none;';
+
+            const clipHeader = document.createElement('div');
+            clipHeader.textContent = 'VM Clipboard';
+            clipHeader.style.cssText =
+                'padding:8px 12px 4px 12px;font-size:11px;font-weight:600;color:#b0b0b8;' +
+                'letter-spacing:0.03em;text-transform:uppercase;';
+
+            const clipBody = document.createElement('div');
+            clipBody.style.cssText = 'padding:0 12px 10px 12px;';
+
+            const btnRow = document.createElement('div');
+            btnRow.style.cssText = 'display:flex;gap:8px;';
+
+            function makeBtn(label) {
+                const b = document.createElement('button');
+                b.type = 'button';
+                b.textContent = label;
+                b.style.cssText =
+                    'flex:1;margin:0;padding:6px 8px;border-radius:6px;' +
+                    'border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);' +
+                    'color:#f2f2f2;font:inherit;font-size:11px;font-weight:500;cursor:pointer;';
+                b.onmouseenter = () => {
+                    if (!b._fosClipResetTimeout) {
+                        b.style.background = 'rgba(255,255,255,0.14)';
+                    }
+                };
+                b.onmouseleave = () => {
+                    if (!b._fosClipResetTimeout) {
+                        b.style.background = 'rgba(255,255,255,0.08)';
+                    }
+                };
+                return b;
+            }
+
+            const bExtract = makeBtn('Extract');
+            const bOverwrite = makeBtn('Overwrite');
+            bExtract.addEventListener('click', () => {
+                clipQueue = clipQueue.then(() => runExtract(bExtract)).catch(() => {});
+            });
+            bOverwrite.addEventListener('click', () => {
+                clipQueue = clipQueue.then(() => runOverwrite(bOverwrite)).catch(() => {});
+            });
+
+            btnRow.appendChild(bExtract);
+            btnRow.appendChild(bOverwrite);
+            clipBody.appendChild(btnRow);
+            root.appendChild(clipHeader);
+            root.appendChild(clipBody);
+            document.body.appendChild(root);
+            console.log(EMBED_LOG + ': clipboard panel injected');
+        }
+
+        function startBridge() {
+            if (bridgeStarted) {
+                return;
+            }
+            if (waitObserver) {
+                try {
+                    waitObserver.disconnect();
+                } catch (_e) { /* ignore */ }
+                waitObserver = null;
+            }
+            bridgeStarted = true;
+
+            const attach = () => {
+                if (!document.body) {
+                    return;
+                }
+                injectPanel();
+            };
+            if (document.body) {
+                attach();
+            } else {
+                document.addEventListener('DOMContentLoaded', attach, { once: true });
+            }
+        }
+
+        function installWaitObserver() {
+            if (bridgeStarted || waitObserver) {
+                return;
+            }
+            const check = () => {
+                if (!fosAuthorized || bridgeStarted) {
+                    return;
+                }
+                if (document.getElementById(NOVNC_CLIPBOARD_ID)) {
+                    startBridge();
+                }
+            };
+            check();
+            if (bridgeStarted) {
+                return;
+            }
+            waitObserver = new MutationObserver(check);
+            const root = document.documentElement || document.body;
+            if (root) {
+                waitObserver.observe(root, { childList: true, subtree: true });
+            }
+        }
+
+        window.addEventListener('message', (event) => {
+            if (!event.data || event.data.type !== 'fleet-fos-embedded-ready') {
+                return;
+            }
+            if (!isFleetParentOrigin(event.origin)) {
+                return;
+            }
+            const envKey = String(event.data.envKey || '');
+            if (!envKey.includes('fos')) {
+                return;
+            }
+            if (fosAuthorized) {
+                return;
+            }
+            fosAuthorized = true;
+            console.log(EMBED_LOG + ': authorized for env ' + envKey);
+            installWaitObserver();
+        });
+
+        try {
+            window.parent.postMessage(
+                { type: 'fleet-fos-child-ready', hostname: window.location.hostname },
+                '*'
+            );
+            console.log(EMBED_LOG + ': child-ready sent');
+        } catch (e) {
+            console.warn(EMBED_LOG + ': child-ready postMessage failed', e);
+        }
     }
 
     function showNonDevRedirectModal() {

--- a/plugins/archetypes/no-vnc/main/vnc-helper.js
+++ b/plugins/archetypes/no-vnc/main/vnc-helper.js
@@ -38,7 +38,7 @@ const plugin = {
     name: 'VNC Helper',
     description:
         'VNC Helper modal with prompt cache, scratchpad, and clipboard bridge for noVNC sessions',
-    _version: '1.6',
+    _version: '1.7',
     enabledByDefault: true,
     phase: 'mutation',
     subOptions: [SHOW_PANEL_SUBOPTION],
@@ -397,13 +397,16 @@ const plugin = {
             this.applyPromptTextareaSizing(promptTextarea, cachedPrompt);
             promptBody.appendChild(promptTextarea);
 
-            const resetPromptBtn = this.makeSmallHeaderButton('Reset', 'Reset prompt to page-load state');
-            resetPromptBtn.addEventListener('click', (ev) => {
-                ev.stopPropagation();
-                promptTextarea.value = initialPromptText;
-                this.applyPromptTextareaSizing(promptTextarea, initialPromptText);
-                Logger.log('vncHelper: prompt reset to page-load state');
-            });
+            let resetPromptBtn = null;
+            if (cachedPrompt) {
+                resetPromptBtn = this.makeSmallHeaderButton('Reset', 'Reset prompt to page-load state');
+                resetPromptBtn.addEventListener('click', (ev) => {
+                    ev.stopPropagation();
+                    promptTextarea.value = initialPromptText;
+                    this.applyPromptTextareaSizing(promptTextarea, initialPromptText);
+                    Logger.log('vncHelper: prompt reset to page-load state');
+                });
+            }
 
             const promptSection = this.makeSectionHeader('Prompt', (collapsed) => {
                 promptBody.style.display = collapsed ? 'none' : '';

--- a/plugins/core/main/fos-embedded-watcher.js
+++ b/plugins/core/main/fos-embedded-watcher.js
@@ -1,0 +1,209 @@
+// fos-embedded-watcher.js
+// Parent-page watcher: detects FOS env instances via orchestrator + latch, authorizes embedded iframe clipboard bridge.
+
+const FOS_ENV_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
+const FOS_ORCHESTRATOR_INSTANCES_URL = 'https://orchestrator.fleetai.com/v1/env/instances';
+const FOS_LATCH_TIMESTAMP_PATH = '/latch/api/v1/env/timestamp';
+const FOS_CHILD_READY_TYPE = 'fleet-fos-child-ready';
+const FOS_EMBEDDED_READY_TYPE = 'fleet-fos-embedded-ready';
+
+function fosInstanceIdFromHostname(hostname) {
+    return String(hostname || '').split('.')[0] || '';
+}
+
+function fosIsFosEnvKey(envKey) {
+    return String(envKey || '').includes('fos');
+}
+
+const plugin = {
+    id: 'fosEmbeddedWatcher',
+    name: 'FOS Embedded Watcher',
+    description:
+        'Detects embedded FOS env instances on the parent page and signals the iframe child when latch is ready',
+    _version: '1.0',
+    phase: 'core',
+    enabledByDefault: true,
+    initialState: {
+        fosInstances: null,
+        pendingChildren: null,
+        messageListenerInstalled: false,
+        activationLogged: false
+    },
+
+    init(state, _context) {
+        if (!state.fosInstances) {
+            state.fosInstances = new Map();
+        }
+        if (!state.pendingChildren) {
+            state.pendingChildren = new Map();
+        }
+        this._subscribeOrchestrator(state);
+        this._subscribeLatch(state);
+        this._listenChildReady(state);
+        Logger.debug('fosEmbeddedWatcher: parent watchers registered');
+    },
+
+    _ensureInstance(state, instanceId) {
+        if (!state.fosInstances.has(instanceId)) {
+            state.fosInstances.set(instanceId, { envKey: null, latchReady: false });
+        }
+        return state.fosInstances.get(instanceId);
+    },
+
+    _tryNotifyChild(state, instanceId, child) {
+        const rec = state.fosInstances.get(instanceId);
+        if (!rec || !rec.latchReady || !rec.envKey || !fosIsFosEnvKey(rec.envKey)) {
+            return false;
+        }
+        if (!child || !child.source || typeof child.source.postMessage !== 'function') {
+            return false;
+        }
+        try {
+            child.source.postMessage(
+                { type: FOS_EMBEDDED_READY_TYPE, envKey: rec.envKey },
+                child.origin || '*'
+            );
+            if (!state.activationLogged) {
+                state.activationLogged = true;
+                Logger.log(
+                    'fosEmbeddedWatcher: signaled embedded FOS iframe for instance ' +
+                        instanceId +
+                        ' (' +
+                        rec.envKey +
+                        ')'
+                );
+            } else {
+                Logger.debug('fosEmbeddedWatcher: signaled instance ' + instanceId);
+            }
+            return true;
+        } catch (e) {
+            Logger.warn('fosEmbeddedWatcher: postMessage to child failed for ' + instanceId, e);
+            return false;
+        }
+    },
+
+    _flushPendingChild(state, instanceId) {
+        const pending = state.pendingChildren.get(instanceId);
+        if (!pending) {
+            return;
+        }
+        if (this._tryNotifyChild(state, instanceId, pending)) {
+            state.pendingChildren.delete(instanceId);
+        }
+    },
+
+    _onInstanceProgress(state, instanceId) {
+        this._flushPendingChild(state, instanceId);
+    },
+
+    _subscribeOrchestrator(state) {
+        if (!Context.networkObserver || typeof Context.networkObserver.subscribe !== 'function') {
+            Logger.warn('fosEmbeddedWatcher: NetworkObserver unavailable; orchestrator capture skipped');
+            return;
+        }
+        const self = this;
+        Context.networkObserver.subscribe({
+            id: 'fos-embedded-watcher-orchestrator',
+            matches(meta) {
+                return (
+                    meta.method === 'POST' &&
+                    !!meta.urlObj &&
+                    meta.urlObj.href.startsWith(FOS_ORCHESTRATOR_INSTANCES_URL)
+                );
+            },
+            onResponse(meta, response) {
+                if (!response.ok) {
+                    return;
+                }
+                response
+                    .json()
+                    .then((body) => {
+                        if (!body || !body.instance_id || !fosIsFosEnvKey(body.env_key)) {
+                            return;
+                        }
+                        const instanceId = String(body.instance_id);
+                        const rec = self._ensureInstance(state, instanceId);
+                        rec.envKey = String(body.env_key);
+                        Logger.log(
+                            'fosEmbeddedWatcher: FOS instance registered ' +
+                                instanceId +
+                                ' env=' +
+                                rec.envKey
+                        );
+                        self._onInstanceProgress(state, instanceId);
+                    })
+                    .catch(() => { /* ignore non-JSON */ });
+            }
+        });
+    },
+
+    _subscribeLatch(state) {
+        if (!Context.networkObserver || typeof Context.networkObserver.subscribe !== 'function') {
+            Logger.warn('fosEmbeddedWatcher: NetworkObserver unavailable; latch capture skipped');
+            return;
+        }
+        const self = this;
+        Context.networkObserver.subscribe({
+            id: 'fos-embedded-watcher-latch',
+            matches(meta) {
+                return (
+                    meta.method === 'GET' &&
+                    !!meta.urlObj &&
+                    meta.urlObj.pathname === FOS_LATCH_TIMESTAMP_PATH &&
+                    FOS_ENV_HOST_PATTERN.test(meta.urlObj.hostname)
+                );
+            },
+            onResponse(meta, response) {
+                if (response.status !== 200) {
+                    return;
+                }
+                const instanceId = fosInstanceIdFromHostname(meta.urlObj.hostname);
+                if (!instanceId) {
+                    return;
+                }
+                const rec = self._ensureInstance(state, instanceId);
+                if (!rec.latchReady) {
+                    rec.latchReady = true;
+                    Logger.log('fosEmbeddedWatcher: latch ready for instance ' + instanceId);
+                }
+                self._onInstanceProgress(state, instanceId);
+            }
+        });
+    },
+
+    _listenChildReady(state) {
+        if (state.messageListenerInstalled) {
+            return;
+        }
+        state.messageListenerInstalled = true;
+        const self = this;
+        window.addEventListener('message', (event) => {
+            if (!event.data || event.data.type !== FOS_CHILD_READY_TYPE) {
+                return;
+            }
+            let originHostname = '';
+            try {
+                originHostname = new URL(event.origin).hostname;
+            } catch (_e) {
+                return;
+            }
+            if (!FOS_ENV_HOST_PATTERN.test(originHostname)) {
+                return;
+            }
+            const hostname = String(event.data.hostname || originHostname);
+            if (!FOS_ENV_HOST_PATTERN.test(hostname)) {
+                return;
+            }
+            const instanceId = fosInstanceIdFromHostname(hostname);
+            if (!instanceId) {
+                return;
+            }
+            const child = { source: event.source, origin: event.origin };
+            Logger.debug('fosEmbeddedWatcher: child-ready from ' + instanceId);
+            if (!self._tryNotifyChild(state, instanceId, child)) {
+                state.pendingChildren.set(instanceId, child);
+                Logger.debug('fosEmbeddedWatcher: child queued pending latch for ' + instanceId);
+            }
+        });
+    }
+};

--- a/plugins/core/main/fos-embedded-watcher.js
+++ b/plugins/core/main/fos-embedded-watcher.js
@@ -3,7 +3,6 @@
 
 const FOS_ENV_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
 const FOS_ORCHESTRATOR_INSTANCES_URL = 'https://orchestrator.fleetai.com/v1/env/instances';
-const FOS_LATCH_TIMESTAMP_PATH = '/latch/api/v1/env/timestamp';
 const FOS_CHILD_READY_TYPE = 'fleet-fos-child-ready';
 const FOS_EMBEDDED_READY_TYPE = 'fleet-fos-embedded-ready';
 
@@ -15,12 +14,22 @@ function fosIsFosEnvKey(envKey) {
     return String(envKey || '').includes('fos');
 }
 
+/** Any env-subdomain GET whose path includes "timestamp" (readiness probe path varies by FOS env). */
+function fosIsEnvTimestampProbe(meta) {
+    return (
+        meta.method === 'GET' &&
+        !!meta.urlObj &&
+        FOS_ENV_HOST_PATTERN.test(meta.urlObj.hostname) &&
+        meta.urlObj.pathname.includes('timestamp')
+    );
+}
+
 const plugin = {
     id: 'fosEmbeddedWatcher',
     name: 'FOS Embedded Watcher',
     description:
-        'Detects embedded FOS env instances on the parent page and signals the iframe child when latch is ready',
-    _version: '1.0',
+        'Detects embedded FOS env instances on the parent page and signals the iframe child when the env timestamp probe succeeds',
+    _version: '1.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: {
@@ -146,12 +155,7 @@ const plugin = {
         Context.networkObserver.subscribe({
             id: 'fos-embedded-watcher-latch',
             matches(meta) {
-                return (
-                    meta.method === 'GET' &&
-                    !!meta.urlObj &&
-                    meta.urlObj.pathname === FOS_LATCH_TIMESTAMP_PATH &&
-                    FOS_ENV_HOST_PATTERN.test(meta.urlObj.hostname)
-                );
+                return fosIsEnvTimestampProbe(meta);
             },
             onResponse(meta, response) {
                 if (response.status !== 200) {
@@ -164,7 +168,13 @@ const plugin = {
                 const rec = self._ensureInstance(state, instanceId);
                 if (!rec.latchReady) {
                     rec.latchReady = true;
-                    Logger.log('fosEmbeddedWatcher: latch ready for instance ' + instanceId);
+                    Logger.log(
+                        'fosEmbeddedWatcher: env ready for instance ' +
+                            instanceId +
+                            ' (' +
+                            meta.urlObj.pathname +
+                            ')'
+                    );
                 }
                 self._onInstanceProgress(state, instanceId);
             }


### PR DESCRIPTION
## Summary

Adds a lightweight clipboard bridge for FOS env instances embedded in `www.fleetai.com` iframes, coordinated between a new parent-page watcher and a minimal iframe bootstrap in the host userscript. Also tightens VNC Helper so the prompt Reset control only appears when a cached prompt was loaded on page open.

## Changes

**FOS embedded clipboard flow**

- New core plugin `fos-embedded-watcher` on the parent page watches orchestrator env-instance metadata and env-subdomain GET requests whose path includes `timestamp` (readiness probe paths vary by FOS env). When a FOS instance is latch-ready, it `postMessage`s `fleet-fos-embedded-ready` to the embedded iframe.
- `fleet.user.js` early-exits in env-subdomain iframes into `initFosEmbeddedMode()`: the child announces `fleet-fos-child-ready`, waits for parent authorization, then injects a **neutered** VM Clipboard panel (Extract / Overwrite only — no full VNC Helper modal).
- Panel UX: draggable via header (position not persisted across reinjection), permanent dismiss (×) that tears down the panel and blocks re-injection until reload, color-only copy feedback per project convention.

**VNC Helper**

- Prompt **Reset** button is shown only when `readCachedPrompt()` returned text on initial load, so operators without a cached prompt are not offered a no-op reset.

## New plugins

| Plugin | Archetype | Description |
|--------|-----------|-------------|
| `fos-embedded-watcher.js` | core | Detects embedded FOS env instances on the parent page and signals the iframe child when the env timestamp probe succeeds |
