### PR TITLE
Defer ops dashboard load until unlock and polish dashboard UX

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "9.6.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.15",
+  "archetypesVersion": "11.16",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -34,8 +34,8 @@
     },
     {
       "name": "dashboard-lib.js",
-      "version": "3.1",
-      "hash": "sha256-50de0ba3c2c25c693ef956962e8001ad8efbb83ac4d95e4018fa172c8ef65348",
+      "version": "3.2",
+      "hash": "sha256-7e6137f9d966dc17c4c08c8a56c9cc9bac2c23c24ee4e8c40942a5669c6546e8",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "9.6.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.16",
+  "archetypesVersion": "11.17",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -58,8 +58,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "4.0",
-      "hash": "sha256-fba00087baa7c99d10c25c25d37ba7e60e8d37538f2796bb19bb924c7808e803",
+      "version": "4.1",
+      "hash": "sha256-22bc4ef1e93b27f78e5c04973c311795f4663f19fc011e3cc7eb331e462e435c",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "9.6.2",
+  "version": "10.0",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.17",
+  "archetypesVersion": "12.1",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -32,6 +32,14 @@
       "hash": "sha256-2371541f990f2da97d700ba580d6b10e941289063b9ad231418a4cb5cb6e83b2",
       "log": false
     },
+    {
+      "name": "fos-embedded-watcher.js",
+      "version": "1.1",
+      "hash": "sha256-e4ea8afe3bf982acd2a5393e9bdfc0682e891e046dc205b7d3b2a9554dfa3aac",
+      "log": false
+    }
+  ],
+  "opsDashboardPlugins": [
     {
       "name": "dashboard-lib.js",
       "version": "3.2",
@@ -78,12 +86,6 @@
       "name": "verifier-fetcher.js",
       "version": "2.0",
       "hash": "sha256-e718f83998625396d675b4fe140088f3cb96fd2a36dbab6ebc37f9c8adf9b3bd",
-      "log": false
-    },
-    {
-      "name": "fos-embedded-watcher.js",
-      "version": "1.1",
-      "hash": "sha256-e4ea8afe3bf982acd2a5393e9bdfc0682e891e046dc205b7d3b2a9554dfa3aac",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "10.1",
   "coreOnlyMode": false,
-  "archetypesVersion": "12.3",
+  "archetypesVersion": "12.4",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -22,8 +22,8 @@
     },
     {
       "name": "ops-tab.js",
-      "version": "8.2",
-      "hash": "sha256-bba869eda01dc5ea317b0726eaa02c399203307bf14464fd4b9bf288fbd9243c",
+      "version": "8.3",
+      "hash": "sha256-78b4430447ec0b263d0c6c099a8717cb7ad1a4ed53984e784bbd5eb1d7190749",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "10.0",
+  "version": "10.1",
   "coreOnlyMode": false,
-  "archetypesVersion": "12.1",
+  "archetypesVersion": "12.2",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -22,14 +22,14 @@
     },
     {
       "name": "ops-tab.js",
-      "version": "8.0",
-      "hash": "sha256-7774705edfb574d10736edc510e4ccad0a2b0d178c9927aa40d730c4cb4eb16b",
+      "version": "8.1",
+      "hash": "sha256-cc74c623864891c7bdcb0466fc61f5c6a45bb68ef4e16d59493e2e7d71aa5f6e",
       "log": false
     },
     {
       "name": "settings-ui.js",
-      "version": "10.0",
-      "hash": "sha256-2371541f990f2da97d700ba580d6b10e941289063b9ad231418a4cb5cb6e83b2",
+      "version": "10.1",
+      "hash": "sha256-496aebd0ccc5c70599f43ccfab1f4b28521b078d0cb8324546d054c46840e9d5",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "10.1",
   "coreOnlyMode": false,
-  "archetypesVersion": "12.2",
+  "archetypesVersion": "12.3",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -22,8 +22,8 @@
     },
     {
       "name": "ops-tab.js",
-      "version": "8.1",
-      "hash": "sha256-cc74c623864891c7bdcb0466fc61f5c6a45bb68ef4e16d59493e2e7d71aa5f6e",
+      "version": "8.2",
+      "hash": "sha256-bba869eda01dc5ea317b0726eaa02c399203307bf14464fd4b9bf288fbd9243c",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "9.6.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "11.14",
+  "archetypesVersion": "11.15",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -531,6 +531,12 @@
           "name": "verifier-expand-mismatch-rows.js",
           "version": "1.1",
           "hash": "sha256-4ae6e8d7080aa18a33423f710ef76856a64a0b91fc19119bb8a2d9a350eba6af",
+          "log": false
+        },
+        {
+          "name": "vnc-helper.js",
+          "version": "1.7",
+          "hash": "sha256-5a752f8810727b23a9c029d0f90d05c27a7f19113c99605cf61a6b206aab51e4",
           "log": false
         }
       ]

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      9.6.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -16,8 +16,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -55,7 +55,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      10.0
+// @version      10.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -37,7 +37,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '10.0';
+    const VERSION = '10.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -103,6 +103,8 @@
         opsAccess: null,
         /** From archetypes.json `opsSecrets` (encrypted secrets file path). */
         opsSecrets: null,
+        /** True after ops dashboard plugins are fetched and initialized this session. */
+        opsDashboardPluginsLoaded: false,
     };
 
     const RefreshGuard = {
@@ -3460,7 +3462,9 @@
                     .filter(p => !beforeIds.has(p.id))
                     .forEach(p => { p._isOps = true; });
                 PluginManager.runOpsDashboardPlugins();
+                Context.opsDashboardPluginsLoaded = true;
             } else {
+                Context.opsDashboardPluginsLoaded = false;
                 Logger.log('ops dashboard plugins deferred — reload page after granting ops access');
             }
         }

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      9.6.2
+// @version      10.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -37,7 +37,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '9.6.2';
+    const VERSION = '10.0';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -2063,6 +2063,7 @@
         archetypes: [],
         devArchetypes: [],
         corePlugins: [],
+        opsDashboardPlugins: [],
         devPlugins: [],
         currentArchetype: null,
         currentDevArchetype: null,
@@ -2106,6 +2107,7 @@
                                 this.archetypes = config.archetypes || [];
                                 this.devArchetypes = config.devArchetypes || [];
                                 this.corePlugins = config.corePlugins || [];
+                                this.opsDashboardPlugins = config.opsDashboardPlugins || [];
                                 this.devPlugins = config.devPlugins || [];
                                 this.settingsModalDocs = config.settingsModalDocs || [];
                                 
@@ -2168,6 +2170,10 @@
 
         getCorePlugins() {
             return this.corePlugins || [];
+        },
+
+        getOpsDashboardPlugins() {
+            return this.opsDashboardPlugins || [];
         },
 
         getDevPlugins() {
@@ -3279,6 +3285,10 @@
         getDevPlugins() {
             return this.getAll().filter(p => p._isDev === true);
         },
+
+        getOpsDashboardPlugins() {
+            return this.getAll().filter(p => p._isOps === true);
+        },
         
         isEnabled(id) {
             if (this._enabledCache.has(id)) return this._enabledCache.get(id);
@@ -3341,13 +3351,26 @@
         
         runCorePlugins() {
             this.getCorePlugins()
-                .filter(p => this.isEnabled(p.id))
+                .filter(p => p._isOps !== true && this.isEnabled(p.id))
                 .forEach(plugin => {
                     try {
                         if (plugin.init) plugin.init(plugin.state, Context);
                         Logger.log(`✓ Core plugin initialized: ${plugin.id}`);
                     } catch (e) {
                         Logger.error(`Error in core plugin ${plugin.id}:`, e);
+                    }
+                });
+        },
+
+        runOpsDashboardPlugins() {
+            this.getOpsDashboardPlugins()
+                .filter(p => this.isEnabled(p.id))
+                .forEach(plugin => {
+                    try {
+                        if (plugin.init) plugin.init(plugin.state, Context);
+                        Logger.log(`✓ Ops dashboard plugin initialized: ${plugin.id}`);
+                    } catch (e) {
+                        Logger.error(`Error in ops dashboard plugin ${plugin.id}:`, e);
                     }
                 });
         },
@@ -3423,9 +3446,24 @@
         const corePlugins = ArchetypeManager.getCorePlugins();
         await PluginLoader.loadPluginsFromConfig(corePlugins, 'core');
         corePluginsLoaded = true;
-        
+
         await waitForBody();
         PluginManager.runCorePlugins();
+
+        const opsDashboardPlugins = ArchetypeManager.getOpsDashboardPlugins();
+        if (opsDashboardPlugins.length > 0) {
+            if (Context.opsTab && Context.opsTab.isEnabled()) {
+                Logger.log('ops tab enabled: loading ops dashboard plugins...');
+                const beforeIds = new Set(PluginManager.getAll().map(p => p.id));
+                await PluginLoader.loadPluginsFromConfig(opsDashboardPlugins, 'core');
+                PluginManager.getAll()
+                    .filter(p => !beforeIds.has(p.id))
+                    .forEach(p => { p._isOps = true; });
+                PluginManager.runOpsDashboardPlugins();
+            } else {
+                Logger.log('ops dashboard plugins deferred — reload page after granting ops access');
+            }
+        }
     }
     
     async function initializeForPage() {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      10.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -16,8 +16,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -55,7 +55,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/dispute-detail/main/vnc-helper.js
+++ b/plugins/archetypes/dispute-detail/main/vnc-helper.js
@@ -1,0 +1,966 @@
+// ============= vnc-helper.js =============
+// Archetype: dispute-detail (embedded noVNC on dispute review pages).
+// VNC Helper modal: Prompt (from qa-comp-use cache), scratchpad, clipboard bridge buttons, and
+// ⌘C/⌘V + Ctrl+Shift+C/F shortcuts. Replaces novnc-clipboard-bridge.js.
+
+const ROOT_ID = 'fleet-vnc-helper';
+const TAB_ID = 'fleet-vnc-helper-tab';
+const Z_INDEX = '2147483646';
+const SHOW_PANEL_SUBOPTION_ID = 'show-panel';
+const NOVNC_CLIPBOARD_ID = 'noVNC_clipboard_text';
+const PROMPT_STORAGE_KEY = 'vnc-helper-prompt';
+const PROMPT_TS_STORAGE_KEY = 'vnc-helper-prompt-ts';
+const PROMPT_TTL_MS = 2 * 60 * 60 * 1000;
+const LINE_HEIGHT_PX = 20;
+const DEFAULT_LINES = 2;
+const PROMPT_DEFAULT_LINES = 5;
+const DEFAULT_MODAL_WIDTH = 320;
+const DEFAULT_MODAL_HEIGHT = 420;
+const MIN_MODAL_WIDTH = 260;
+const MIN_MODAL_HEIGHT = 180;
+
+const LAYOUT_STORAGE_KEYS = {
+    left: 'vnc-helper-layout-left',
+    top: 'vnc-helper-layout-top',
+    width: 'vnc-helper-layout-width',
+    height: 'vnc-helper-layout-height'
+};
+
+const SHOW_PANEL_SUBOPTION = {
+    id: SHOW_PANEL_SUBOPTION_ID,
+    name: 'Show panel',
+    description: 'When off, hides the VNC Helper modal; ⌘C/⌘V and Ctrl+Shift+C/F still work.',
+    enabledByDefault: true
+};
+
+const plugin = {
+    id: 'vncHelper',
+    name: 'VNC Helper',
+    description:
+        'VNC Helper modal with prompt cache, scratchpad, and clipboard bridge for noVNC sessions',
+    _version: '1.7',
+    enabledByDefault: true,
+    phase: 'mutation',
+    subOptions: [SHOW_PANEL_SUBOPTION],
+    initialState: {
+        bridgeStarted: false,
+        waitObserverAttached: false,
+        waitObserver: null,
+        minimized: false
+    },
+
+    isPanelEnabled() {
+        return Storage.getSubOptionEnabled(this.id, SHOW_PANEL_SUBOPTION_ID, true);
+    },
+
+    loadSavedLayout() {
+        return {
+            left: Storage.get(LAYOUT_STORAGE_KEYS.left, null),
+            top: Storage.get(LAYOUT_STORAGE_KEYS.top, null),
+            width: Storage.get(LAYOUT_STORAGE_KEYS.width, DEFAULT_MODAL_WIDTH),
+            height: Storage.get(LAYOUT_STORAGE_KEYS.height, DEFAULT_MODAL_HEIGHT)
+        };
+    },
+
+    saveLayout(root) {
+        if (!root) {
+            return;
+        }
+        const rect = root.getBoundingClientRect();
+        Storage.set(LAYOUT_STORAGE_KEYS.left, rect.left);
+        Storage.set(LAYOUT_STORAGE_KEYS.top, rect.top);
+        Storage.set(LAYOUT_STORAGE_KEYS.width, rect.width);
+        Storage.set(LAYOUT_STORAGE_KEYS.height, rect.height);
+    },
+
+    makeSmallHeaderButton(label, ariaLabel) {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = label;
+        btn.setAttribute('aria-label', ariaLabel);
+        btn.style.cssText =
+            'margin:0;padding:2px 8px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.08);color:#d0d0d8;font:inherit;font-size:10px;font-weight:500;cursor:pointer;';
+        btn.onmouseenter = () => {
+            btn.style.background = 'rgba(255,255,255,0.14)';
+        };
+        btn.onmouseleave = () => {
+            btn.style.background = 'rgba(255,255,255,0.08)';
+        };
+        return btn;
+    },
+
+    makeClipboardHelpDetails() {
+        const details = document.createElement('details');
+        details.style.cssText = 'margin:10px 0 0 0;padding-top:10px;border-top:1px solid rgba(255,255,255,0.08);';
+
+        const summaryEl = document.createElement('summary');
+        summaryEl.textContent = 'How this works';
+        summaryEl.style.cssText =
+            'cursor:pointer;font-size:12px;color:#b0b0b8;outline:none;user-select:none;';
+
+        const help = document.createElement('div');
+        help.style.cssText =
+            'margin-top:10px;font-size:11px;color:#a5a5ad;line-height:1.55;user-select:text;';
+
+        function pBlock(strongLabel, rest) {
+            const p = document.createElement('p');
+            p.style.margin = '0 0 8px 0';
+            const s = document.createElement('strong');
+            s.style.color = '#ddd';
+            s.textContent = strongLabel;
+            p.appendChild(s);
+            p.appendChild(document.createTextNode(` ${rest}`));
+            return p;
+        }
+
+        help.appendChild(
+            pBlock(
+                'Extract',
+                'copies the text noVNC currently holds for the virtual machine into this computer\u2019s system clipboard. Use the virtual machine\u2019s normal copy first so that buffer fills, then click Extract.'
+            )
+        );
+        help.appendChild(
+            pBlock(
+                'Overwrite',
+                'takes plain text from this computer\u2019s clipboard and pushes it into noVNC\u2019s virtual machine clipboard buffer. Then use the virtual machine\u2019s normal paste.'
+            )
+        );
+        help.appendChild(
+            pBlock(
+                'Keyboard',
+                '\u2318+C sends Ctrl+C to the virtual machine, then copies noVNC\u2019s buffer to this computer. \u2318+V pushes this computer\u2019s clipboard into the virtual machine and sends Ctrl+V. Ctrl+Shift+F is the same as Overwrite. Ctrl+Shift+C is the same as Extract.'
+            )
+        );
+        const p3 = document.createElement('p');
+        p3.style.margin = '0';
+        p3.textContent =
+            'Always combine these controls with the virtual machine\u2019s native copy/paste: copy in the virtual machine \u2192 Extract (or Ctrl+Shift+C) to the host; copy on the host \u2192 Overwrite (or Ctrl+Shift+F) \u2192 paste in the virtual machine (or \u2318+V).';
+        help.appendChild(p3);
+
+        details.appendChild(summaryEl);
+        details.appendChild(help);
+        return details;
+    },
+
+    installWaitObserver(state) {
+        if (state.waitObserverAttached) {
+            return;
+        }
+        state.waitObserverAttached = true;
+
+        const self = this;
+        const tryStart = () => {
+            if (state.bridgeStarted) {
+                return;
+            }
+            if (!document.getElementById(NOVNC_CLIPBOARD_ID)) {
+                return;
+            }
+            self.startBridge(state);
+        };
+
+        tryStart();
+        if (state.bridgeStarted) {
+            return;
+        }
+
+        const target = document.body || document.documentElement;
+        const observer = new MutationObserver(() => {
+            tryStart();
+        });
+        observer.observe(target, { childList: true, subtree: true });
+        CleanupRegistry.registerObserver(observer);
+        state.waitObserver = observer;
+        Logger.log('vncHelper: waiting for noVNC clipboard element (MutationObserver)');
+    },
+
+    readCachedPrompt() {
+        try {
+            const text = Storage.get(PROMPT_STORAGE_KEY, '');
+            const tsRaw = Storage.get(PROMPT_TS_STORAGE_KEY, '');
+            if (!text || !tsRaw) {
+                Logger.log('vncHelper: no cached prompt in storage');
+                return '';
+            }
+            const ts = parseInt(tsRaw, 10);
+            if (Number.isNaN(ts) || Date.now() - ts > PROMPT_TTL_MS) {
+                Storage.delete(PROMPT_STORAGE_KEY);
+                Storage.delete(PROMPT_TS_STORAGE_KEY);
+                Logger.log('vncHelper: cached prompt expired, cleared');
+                return '';
+            }
+            Logger.log(`vncHelper: loaded cached prompt (${text.length} chars)`);
+            return text;
+        } catch (e) {
+            Logger.warn('vncHelper: failed to read cached prompt', e);
+            return '';
+        }
+    },
+
+    textareaHeightForLines(lineCount) {
+        const lines = Math.max(DEFAULT_LINES, lineCount);
+        return `${lines * LINE_HEIGHT_PX + 16}px`;
+    },
+
+    applyPromptTextareaSizing(textarea, promptText) {
+        const initialLines = promptText ? PROMPT_DEFAULT_LINES : DEFAULT_LINES;
+        textarea.style.height = this.textareaHeightForLines(initialLines);
+        textarea.style.minHeight = this.textareaHeightForLines(DEFAULT_LINES);
+        textarea.style.overflowY = 'auto';
+        textarea.style.resize = 'vertical';
+        textarea.style.boxSizing = 'border-box';
+        textarea.style.width = '100%';
+        textarea.style.padding = '8px';
+        textarea.style.borderRadius = '6px';
+        textarea.style.border = '1px solid rgba(255,255,255,0.15)';
+        textarea.style.background = 'rgba(0,0,0,0.25)';
+        textarea.style.color = '#f2f2f2';
+        textarea.style.font = 'inherit';
+        textarea.style.lineHeight = `${LINE_HEIGHT_PX}px`;
+    },
+
+    applyScratchpadTextareaSizing(textarea) {
+        textarea.style.height = this.textareaHeightForLines(DEFAULT_LINES);
+        textarea.style.minHeight = this.textareaHeightForLines(DEFAULT_LINES);
+        textarea.style.overflowY = 'auto';
+        textarea.style.resize = 'vertical';
+        textarea.style.boxSizing = 'border-box';
+        textarea.style.width = '100%';
+        textarea.style.padding = '8px';
+        textarea.style.borderRadius = '6px';
+        textarea.style.border = '1px solid rgba(255,255,255,0.15)';
+        textarea.style.background = 'rgba(0,0,0,0.25)';
+        textarea.style.color = '#f2f2f2';
+        textarea.style.font = 'inherit';
+        textarea.style.lineHeight = `${LINE_HEIGHT_PX}px`;
+    },
+
+    makeSectionHeader(label, onToggle, trailingEl) {
+        const header = document.createElement('div');
+        header.style.cssText =
+            'display:flex;align-items:center;gap:6px;padding:8px 12px 4px 12px;font-size:11px;font-weight:600;color:#b0b0b8;letter-spacing:0.03em;text-transform:uppercase;user-select:none;';
+
+        const toggleBtn = document.createElement('button');
+        toggleBtn.type = 'button';
+        toggleBtn.textContent = '▼';
+        toggleBtn.setAttribute('aria-label', `Toggle ${label} section`);
+        toggleBtn.style.cssText =
+            'margin:0;padding:0 4px;border:none;background:transparent;color:#b0b0b8;font:inherit;font-size:11px;cursor:pointer;line-height:1;';
+
+        const title = document.createElement('span');
+        title.textContent = label;
+        title.style.flex = '1';
+
+        header.appendChild(toggleBtn);
+        header.appendChild(title);
+        if (trailingEl) {
+            header.appendChild(trailingEl);
+        }
+
+        let collapsed = false;
+        toggleBtn.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            collapsed = !collapsed;
+            toggleBtn.textContent = collapsed ? '▶' : '▼';
+            onToggle(collapsed);
+            Logger.log(`vncHelper: ${label} section ${collapsed ? 'hidden' : 'shown'}`);
+        });
+
+        return { header, setCollapsed: (next) => {
+            collapsed = next;
+            toggleBtn.textContent = collapsed ? '▶' : '▼';
+            onToggle(collapsed);
+        } };
+    },
+
+    startBridge(state) {
+        if (state.bridgeStarted) {
+            return;
+        }
+        if (state.waitObserver) {
+            try {
+                state.waitObserver.disconnect();
+            } catch (eDisc) {
+                Logger.warn('vncHelper: error disconnecting wait observer', eDisc);
+            }
+            state.waitObserver = null;
+        }
+
+        state.bridgeStarted = true;
+        Logger.log('vncHelper: noVNC clipboard element detected, initialising VNC Helper');
+
+        const oldRoot = document.getElementById(ROOT_ID);
+        const oldTab = document.getElementById(TAB_ID);
+        if (oldRoot || oldTab) {
+            if (window.__fleetVncHelperTeardown) {
+                try {
+                    window.__fleetVncHelperTeardown();
+                } catch (e4) {
+                    Logger.warn('vncHelper: prior teardown failed', e4);
+                }
+            }
+            if (oldRoot) {
+                oldRoot.remove();
+            }
+            if (oldTab) {
+                oldTab.remove();
+            }
+        }
+        if (window._vncHelperKeydown) {
+            document.removeEventListener('keydown', window._vncHelperKeydown, true);
+        }
+
+        /** Serialize paste, overwrite, and extract so clipboard I/O does not interleave. */
+        let clipQueue = Promise.resolve();
+
+        const showPanel = this.isPanelEnabled();
+        let root = null;
+        let restoreTab = null;
+        let onMove = () => {};
+        let onUp = () => {};
+        let onResizeMove = () => {};
+        let onResizeUp = () => {};
+
+        const minimizeModal = () => {
+            if (!root) {
+                return;
+            }
+            root.style.display = 'none';
+            state.minimized = true;
+            if (!restoreTab) {
+                restoreTab = document.createElement('button');
+                restoreTab.id = TAB_ID;
+                restoreTab.type = 'button';
+                restoreTab.textContent = 'VNC Helper';
+                restoreTab.setAttribute('aria-label', 'Restore VNC Helper');
+                restoreTab.style.cssText =
+                    'position:fixed;left:20px;bottom:124px;z-index:2147483646;padding:6px 10px;font-size:12px;border-radius:10px;border:1px solid rgba(0,0,0,0.2);background:#111827;color:#f9fafb;cursor:pointer;box-shadow:0 6px 18px rgba(0,0,0,0.35);';
+                restoreTab.addEventListener('click', () => {
+                    if (root) {
+                        root.style.display = '';
+                    }
+                    if (restoreTab && restoreTab.parentNode) {
+                        restoreTab.parentNode.removeChild(restoreTab);
+                    }
+                    restoreTab = null;
+                    state.minimized = false;
+                    Logger.log('vncHelper: modal restored from minimized tab');
+                });
+                document.body.appendChild(restoreTab);
+            }
+            Logger.log('vncHelper: modal minimized');
+        };
+
+        if (showPanel) {
+            const savedLayout = this.loadSavedLayout();
+            root = document.createElement('div');
+            root.id = ROOT_ID;
+            root.style.cssText = `position:fixed;left:${savedLayout.left ?? 16}px;top:${savedLayout.top ?? 120}px;width:${savedLayout.width}px;height:${savedLayout.height}px;min-width:${MIN_MODAL_WIDTH}px;min-height:${MIN_MODAL_HEIGHT}px;display:flex;flex-direction:column;z-index:${Z_INDEX};font:13px/1.45 system-ui,Segoe UI,sans-serif;color:#e8e8e8;background:linear-gradient(160deg,#1e1e24 0%,#121218 100%);border:1px solid rgba(255,255,255,0.12);border-radius:10px;box-shadow:0 12px 40px rgba(0,0,0,0.55);overflow:hidden;user-select:none;`;
+
+            const headerEl = document.createElement('div');
+            headerEl.style.cssText =
+                'display:flex;align-items:center;gap:8px;padding:8px 10px 8px 12px;font-weight:600;font-size:12px;letter-spacing:0.02em;color:#fff;background:rgba(255,255,255,0.06);border-bottom:1px solid rgba(255,255,255,0.08);flex-shrink:0;';
+            const headerTitle = document.createElement('div');
+            headerTitle.textContent = 'VNC Helper';
+            headerTitle.style.cssText =
+                'flex:1;min-width:0;cursor:grab;padding:2px 0;font-weight:600;font-size:12px;';
+            const minimizeBtn = document.createElement('button');
+            minimizeBtn.type = 'button';
+            minimizeBtn.textContent = 'Minimize';
+            minimizeBtn.setAttribute('aria-label', 'Minimize VNC Helper');
+            minimizeBtn.style.cssText =
+                'flex-shrink:0;margin:0;padding:5px 10px;border-radius:6px;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.1);color:#e8e8e8;font:inherit;font-size:11px;font-weight:500;cursor:pointer;';
+            minimizeBtn.onmouseenter = () => {
+                minimizeBtn.style.background = 'rgba(255,255,255,0.16)';
+            };
+            minimizeBtn.onmouseleave = () => {
+                minimizeBtn.style.background = 'rgba(255,255,255,0.1)';
+            };
+            headerEl.appendChild(headerTitle);
+            headerEl.appendChild(minimizeBtn);
+
+            const bodyEl = document.createElement('div');
+            bodyEl.style.cssText =
+                'flex:1;min-height:0;overflow-y:auto;padding:0 0 12px 0;user-select:text;';
+
+            // Prompt section
+            const promptBody = document.createElement('div');
+            promptBody.style.cssText = 'padding:0 12px 8px 12px;';
+            const promptTextarea = document.createElement('textarea');
+            promptTextarea.setAttribute('aria-label', 'Prompt');
+            promptTextarea.spellcheck = false;
+            const cachedPrompt = this.readCachedPrompt();
+            const initialPromptText = cachedPrompt;
+            if (cachedPrompt) {
+                promptTextarea.value = cachedPrompt;
+            }
+            this.applyPromptTextareaSizing(promptTextarea, cachedPrompt);
+            promptBody.appendChild(promptTextarea);
+
+            let resetPromptBtn = null;
+            if (cachedPrompt) {
+                resetPromptBtn = this.makeSmallHeaderButton('Reset', 'Reset prompt to page-load state');
+                resetPromptBtn.addEventListener('click', (ev) => {
+                    ev.stopPropagation();
+                    promptTextarea.value = initialPromptText;
+                    this.applyPromptTextareaSizing(promptTextarea, initialPromptText);
+                    Logger.log('vncHelper: prompt reset to page-load state');
+                });
+            }
+
+            const promptSection = this.makeSectionHeader('Prompt', (collapsed) => {
+                promptBody.style.display = collapsed ? 'none' : '';
+            }, resetPromptBtn);
+            bodyEl.appendChild(promptSection.header);
+            bodyEl.appendChild(promptBody);
+
+            // Scratchpad section
+            const scratchBody = document.createElement('div');
+            scratchBody.style.cssText = 'padding:0 12px 8px 12px;';
+            const scratchTextarea = document.createElement('textarea');
+            scratchTextarea.setAttribute('aria-label', 'Scratchpad');
+            scratchTextarea.placeholder = 'Scratchpad…';
+            scratchTextarea.spellcheck = false;
+            this.applyScratchpadTextareaSizing(scratchTextarea);
+            scratchBody.appendChild(scratchTextarea);
+
+            const scratchSection = this.makeSectionHeader('Scratchpad', (collapsed) => {
+                scratchBody.style.display = collapsed ? 'none' : '';
+            });
+            bodyEl.appendChild(scratchSection.header);
+            bodyEl.appendChild(scratchBody);
+
+            // VM Clipboard buttons section
+            const clipSection = document.createElement('div');
+            clipSection.style.cssText =
+                'padding:0 0 4px 0;border-top:1px solid rgba(255,255,255,0.08);user-select:text;';
+
+            const clipHeader = document.createElement('div');
+            clipHeader.textContent = 'VM Clipboard';
+            clipHeader.style.cssText =
+                'padding:8px 12px 4px 12px;font-size:11px;font-weight:600;color:#b0b0b8;letter-spacing:0.03em;text-transform:uppercase;user-select:none;';
+
+            const clipBody = document.createElement('div');
+            clipBody.style.cssText = 'padding:0 12px 8px 12px;';
+
+            const btnRow = document.createElement('div');
+            btnRow.style.cssText = 'display:flex;gap:8px;';
+
+            function makeBtn(label) {
+                const b = document.createElement('button');
+                b.type = 'button';
+                b.textContent = label;
+                b.style.cssText =
+                    'flex:1;margin:0;padding:6px 8px;border-radius:6px;border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);color:#f2f2f2;font:inherit;font-size:11px;font-weight:500;cursor:pointer;';
+                b.onmouseenter = () => {
+                    b.style.background = 'rgba(255,255,255,0.14)';
+                };
+                b.onmouseleave = () => {
+                    b.style.background = 'rgba(255,255,255,0.08)';
+                };
+                return b;
+            }
+
+            const bExtract = makeBtn('Extract');
+            const bOverwrite = makeBtn('Overwrite');
+            const shortcutHint = document.createElement('div');
+            shortcutHint.textContent = '⌘C/⌘V · Ctrl+Shift+C/F';
+            shortcutHint.style.cssText = 'font-size:11px;color:#a5a5ad;text-align:center;margin-top:8px;';
+
+            btnRow.appendChild(bExtract);
+            btnRow.appendChild(bOverwrite);
+            clipBody.appendChild(btnRow);
+            clipBody.appendChild(shortcutHint);
+            clipBody.appendChild(this.makeClipboardHelpDetails());
+            clipSection.appendChild(clipHeader);
+            clipSection.appendChild(clipBody);
+            bodyEl.appendChild(clipSection);
+
+            const resizeHandle = document.createElement('div');
+            resizeHandle.setAttribute('aria-label', 'Resize VNC Helper');
+            resizeHandle.style.cssText =
+                'position:absolute;right:2px;bottom:2px;width:14px;height:14px;cursor:se-resize;background:transparent;border-right:2px solid rgba(255,255,255,0.25);border-bottom:2px solid rgba(255,255,255,0.25);border-radius:0 0 8px 0;z-index:1;';
+
+            root.appendChild(headerEl);
+            root.appendChild(bodyEl);
+            root.appendChild(resizeHandle);
+            document.body.appendChild(root);
+
+            bExtract.addEventListener('click', () => {
+                clipQueue = clipQueue
+                    .then(() => extractVmTextToOs())
+                    .catch(() => {});
+            });
+            bOverwrite.addEventListener('click', () => {
+                clipQueue = clipQueue.then(runOverwriteFromShortcut).catch(() => {});
+            });
+
+            minimizeBtn.addEventListener('click', (ev) => {
+                ev.stopPropagation();
+                onUp();
+                minimizeModal();
+            });
+
+            let drag = false;
+            let resizing = false;
+            let ox = 0;
+            let oy = 0;
+            let resizeStartX = 0;
+            let resizeStartY = 0;
+            let resizeStartW = 0;
+            let resizeStartH = 0;
+
+            onMove = (ev) => {
+                if (!drag || !root) {
+                    return;
+                }
+                root.style.left = `${Math.max(0, ev.clientX - ox)}px`;
+                root.style.top = `${Math.max(0, ev.clientY - oy)}px`;
+            };
+            onResizeMove = (ev) => {
+                if (!resizing || !root) {
+                    return;
+                }
+                const nextW = Math.max(MIN_MODAL_WIDTH, resizeStartW + (ev.clientX - resizeStartX));
+                const nextH = Math.max(MIN_MODAL_HEIGHT, resizeStartH + (ev.clientY - resizeStartY));
+                root.style.width = `${nextW}px`;
+                root.style.height = `${nextH}px`;
+            };
+            onUp = () => {
+                if (!drag) {
+                    return;
+                }
+                drag = false;
+                headerTitle.style.cursor = 'grab';
+                document.removeEventListener('mousemove', onMove, true);
+                document.removeEventListener('mouseup', onUp, true);
+                if (root) {
+                    this.saveLayout(root);
+                    const rect = root.getBoundingClientRect();
+                    Logger.log(`vncHelper: modal moved to ${Math.round(rect.left)},${Math.round(rect.top)}`);
+                }
+            };
+            onResizeUp = () => {
+                if (!resizing) {
+                    return;
+                }
+                resizing = false;
+                document.body.style.userSelect = '';
+                document.removeEventListener('mousemove', onResizeMove, true);
+                document.removeEventListener('mouseup', onResizeUp, true);
+                if (root) {
+                    this.saveLayout(root);
+                    const rect = root.getBoundingClientRect();
+                    Logger.log(`vncHelper: modal resized to ${Math.round(rect.width)}×${Math.round(rect.height)}`);
+                }
+            };
+            headerTitle.addEventListener('mousedown', (ev) => {
+                if (ev.button !== 0) {
+                    return;
+                }
+                drag = true;
+                headerTitle.style.cursor = 'grabbing';
+                const r = root.getBoundingClientRect();
+                ox = ev.clientX - r.left;
+                oy = ev.clientY - r.top;
+                document.addEventListener('mousemove', onMove, true);
+                document.addEventListener('mouseup', onUp, true);
+                ev.preventDefault();
+            });
+            resizeHandle.addEventListener('mousedown', (ev) => {
+                if (ev.button !== 0) {
+                    return;
+                }
+                ev.preventDefault();
+                ev.stopPropagation();
+                resizing = true;
+                const r = root.getBoundingClientRect();
+                resizeStartX = ev.clientX;
+                resizeStartY = ev.clientY;
+                resizeStartW = r.width;
+                resizeStartH = r.height;
+                document.body.style.userSelect = 'none';
+                document.addEventListener('mousemove', onResizeMove, true);
+                document.addEventListener('mouseup', onResizeUp, true);
+            });
+        }
+
+        window._vncHelperKeydown = async (e) => {
+            const key = (e.key || '').toLowerCase();
+            if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === 'KeyF') {
+                if (e.repeat) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                clipQueue = clipQueue.then(runOverwriteFromShortcut).catch(() => {});
+                return;
+            }
+            if (e.ctrlKey && e.shiftKey && !e.metaKey && !e.altKey && e.code === 'KeyC') {
+                if (e.repeat) {
+                    return;
+                }
+                e.preventDefault();
+                e.stopPropagation();
+                clipQueue = clipQueue.then(() => extractVmTextToOs()).catch(() => {});
+                return;
+            }
+            if (e.metaKey && !e.ctrlKey && !e.altKey && key === 'c') {
+                e.preventDefault();
+                e.stopPropagation();
+                clipQueue = clipQueue.then(runCopyVmToHost).catch(() => {});
+                return;
+            }
+            if (e.metaKey && !e.ctrlKey && !e.altKey && key === 'v') {
+                e.preventDefault();
+                e.stopPropagation();
+                clipQueue = clipQueue.then(runPasteFromClipboard).catch(() => {});
+            }
+        };
+        document.addEventListener('keydown', window._vncHelperKeydown, true);
+
+        window.__fleetVncHelperTeardown = () => {
+            document.removeEventListener('mousemove', onMove, true);
+            document.removeEventListener('mouseup', onUp, true);
+            document.removeEventListener('mousemove', onResizeMove, true);
+            document.removeEventListener('mouseup', onResizeUp, true);
+            document.body.style.userSelect = '';
+            if (window._vncHelperKeydown) {
+                document.removeEventListener('keydown', window._vncHelperKeydown, true);
+                window._vncHelperKeydown = null;
+            }
+            if (root && root.parentNode) {
+                root.parentNode.removeChild(root);
+            }
+            if (restoreTab && restoreTab.parentNode) {
+                restoreTab.parentNode.removeChild(restoreTab);
+            }
+            root = null;
+            restoreTab = null;
+        };
+
+        if (showPanel) {
+            Logger.log('vncHelper: modal and keyboard shortcuts active');
+            toast('VNC Helper ready — drag title bar, resize corner. ⌘C/⌘V, Ctrl+Shift+C/F.');
+        } else {
+            Logger.log('vncHelper: keyboard shortcuts active (panel hidden via settings)');
+            toast('VNC Helper ready — ⌘C/⌘V, Ctrl+Shift+C/F. Panel is hidden in settings.');
+        }
+    },
+
+    onMutation(state) {
+        if (state.bridgeStarted) {
+            return;
+        }
+        this.installWaitObserver(state);
+    },
+
+    destroy(state) {
+        if (state.waitObserver) {
+            try {
+                state.waitObserver.disconnect();
+            } catch (e) {
+                Logger.warn('vncHelper: wait observer disconnect in destroy', e);
+            }
+            state.waitObserver = null;
+        }
+        if (typeof window.__fleetVncHelperTeardown === 'function') {
+            try {
+                window.__fleetVncHelperTeardown();
+            } catch (eTeardown) {
+                Logger.error('vncHelper: teardown failed', eTeardown);
+            }
+            window.__fleetVncHelperTeardown = undefined;
+        }
+        state.waitObserverAttached = false;
+        state.bridgeStarted = false;
+        state.minimized = false;
+        Logger.log('vncHelper: destroyed');
+    }
+};
+
+// ---- Clipboard / noVNC helpers (declarations hoisted; used by plugin methods above) ----
+
+function clipEl() {
+    return document.getElementById(NOVNC_CLIPBOARD_ID);
+}
+
+function getRfb() {
+    return (
+        window.rfb ||
+        window._rfb ||
+        (window.UI && window.UI.rfb) ||
+        (window.APP && window.APP.rfb) ||
+        (window.noVNC && window.noVNC.rfb) ||
+        null
+    );
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+function focusVncTarget() {
+    const rfb = getRfb();
+    if (rfb && typeof rfb.focus === 'function') {
+        try {
+            rfb.focus();
+            return;
+        } catch (e0) {
+            /* ignore */
+        }
+    }
+    const c = document.querySelector('canvas');
+    if (c && typeof c.focus === 'function') {
+        try {
+            c.focus();
+        } catch (e1) {
+            /* ignore */
+        }
+    }
+}
+
+/** Truncation for button toasts; empty becomes "(empty)". */
+function truncPreview(t) {
+    if (t == null || String(t).length === 0) {
+        return '(empty)';
+    }
+    t = String(t);
+    return t.length > 40 ? `${t.slice(0, 40)}\u2026` : t;
+}
+
+/** Truncation for Cmd+C / Cmd+V bridge toasts; empty stays blank. */
+function truncKey(t) {
+    t = t == null ? '' : String(t);
+    if (!t.length) {
+        return '';
+    }
+    return t.length > 40 ? `${t.slice(0, 40)}\u2026` : t;
+}
+
+function fireKey(target, type, opts) {
+    target.dispatchEvent(
+        new KeyboardEvent(type, Object.assign({ bubbles: true, cancelable: true, composed: true }, opts))
+    );
+}
+
+function sendCtrlDom(k) {
+    const t =
+        document.activeElement ||
+        document.querySelector('canvas') ||
+        document.body ||
+        document.documentElement;
+    fireKey(t, 'keydown', { key: 'Control', code: 'ControlLeft', ctrlKey: true });
+    fireKey(t, 'keydown', { key: k, code: `Key${k.toUpperCase()}`, ctrlKey: true });
+    fireKey(t, 'keyup', { key: k, code: `Key${k.toUpperCase()}`, ctrlKey: true });
+    fireKey(t, 'keyup', { key: 'Control', code: 'ControlLeft' });
+}
+
+function sendCtrlRfb(k) {
+    const rf = getRfb();
+    if (!rf || typeof rf.sendKey !== 'function') {
+        return false;
+    }
+    const ctrl = 0xffe3;
+    const ch = k.toLowerCase().charCodeAt(0);
+    rf.sendKey(ctrl, 'ControlLeft', true);
+    rf.sendKey(ch, `Key${k.toUpperCase()}`, true);
+    rf.sendKey(ch, `Key${k.toUpperCase()}`, false);
+    rf.sendKey(ctrl, 'ControlLeft', false);
+    return true;
+}
+
+function toast(message) {
+    const d = document.createElement('div');
+    d.textContent = message;
+    d.style.cssText = `position:fixed;top:12px;right:12px;z-index:${Z_INDEX};background:rgba(0,0,0,0.88);color:#fff;font:12px/1.4 system-ui,Segoe UI,sans-serif;padding:10px 12px;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,0.35);max-width:min(420px,92vw);word-break:break-word;white-space:pre-wrap;`;
+    document.body.appendChild(d);
+    setTimeout(() => {
+        d.remove();
+    }, 2200);
+}
+
+/** Prefer text/plain blob (tabs/line breaks); used for Cmd+V and Overwrite. */
+async function readClipboardText() {
+    try {
+        const items = await navigator.clipboard.read();
+        for (let i = 0; i < items.length; i++) {
+            const types = items[i].types || [];
+            for (let j = 0; j < types.length; j++) {
+                if (types[j] === 'text/plain') {
+                    const blob = await items[i].getType('text/plain');
+                    return await blob.text();
+                }
+            }
+        }
+    } catch (e2) {
+        /* fall through */
+    }
+    return await navigator.clipboard.readText();
+}
+
+async function syncRemoteClipboard(el, merged, caret, editingClipboard) {
+    if (editingClipboard) {
+        try {
+            el.focus();
+        } catch (eFocus) {
+            /* ignore */
+        }
+    }
+    const rf = getRfb();
+    if (rf && typeof rf.clipboardPasteFrom === 'function') {
+        el.value = merged;
+        if (editingClipboard && typeof el.setSelectionRange === 'function') {
+            try {
+                el.setSelectionRange(caret, caret);
+            } catch (eSel) {
+                /* ignore */
+            }
+        }
+        rf.clipboardPasteFrom('');
+        await sleep(12);
+        rf.clipboardPasteFrom(merged);
+        return;
+    }
+    el.value = '';
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    await sleep(12);
+    el.value = merged;
+    if (editingClipboard && typeof el.setSelectionRange === 'function') {
+        try {
+            el.setSelectionRange(caret, caret);
+        } catch (eSel2) {
+            /* ignore */
+        }
+    }
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+async function runPasteFromClipboard() {
+    const elSnap = clipEl();
+    const editingClipboard = !!(elSnap && document.activeElement === elSnap);
+    let text = '';
+    try {
+        text = await readClipboardText();
+    } catch (err) {
+        toast('PASTE fail (clipboard)');
+        focusVncTarget();
+        return;
+    }
+    const el = clipEl();
+    if (!el) {
+        toast('PASTE fail (noVNC el)');
+        focusVncTarget();
+        return;
+    }
+    const cur = el.value || '';
+    let merged;
+    let caret;
+    if (editingClipboard) {
+        let start = typeof el.selectionStart === 'number' ? el.selectionStart : cur.length;
+        let end = typeof el.selectionEnd === 'number' ? el.selectionEnd : cur.length;
+        if (start > end) {
+            const swap = start;
+            start = end;
+            end = swap;
+        }
+        merged = cur.slice(0, start) + text + cur.slice(end);
+        caret = start + text.length;
+    } else {
+        merged = text;
+        caret = text.length;
+    }
+    await syncRemoteClipboard(el, merged, caret, editingClipboard);
+    await sleep(75);
+    const ok = sendCtrlRfb('v');
+    if (!ok) {
+        sendCtrlDom('v');
+    }
+    toast(`${ok ? 'PASTE ' : 'PASTE? '}\u2192 ${truncKey(merged)}`);
+    focusVncTarget();
+}
+
+async function runOverwriteFromShortcut() {
+    try {
+        const t = await readClipboardText();
+        await pushOsTextToVmClipboard(typeof t === 'string' ? t : '');
+    } catch (eOw) {
+        toast('Overwrite failed: could not read system clipboard.');
+        focusVncTarget();
+    }
+}
+
+async function runCopyVmToHost() {
+    if (!sendCtrlRfb('c')) {
+        sendCtrlDom('c');
+    }
+    await sleep(150);
+    const el = clipEl();
+    const val = el ? el.value || '' : '';
+    if (val) {
+        try {
+            await navigator.clipboard.writeText(val);
+        } catch (eW) {
+            toast('COPY fail (could not write system clipboard)');
+            focusVncTarget();
+            return;
+        }
+    }
+    toast(`COPY \u2192 ${truncKey(val)}`);
+    focusVncTarget();
+}
+
+/** Push plain text to the virtual machine via noVNC (no Ctrl+V — updates remote clipboard only). */
+async function pushOsTextToVmClipboard(text) {
+    const el = clipEl();
+    if (!el) {
+        toast('Overwrite failed: noVNC clipboard field (#noVNC_clipboard_text) not found.');
+        focusVncTarget();
+        return;
+    }
+    const merged = text;
+    const rfb = getRfb();
+    el.value = merged;
+    if (rfb && typeof rfb.clipboardPasteFrom === 'function') {
+        rfb.clipboardPasteFrom('');
+        await sleep(12);
+        rfb.clipboardPasteFrom(merged);
+    } else {
+        el.value = '';
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        await sleep(12);
+        el.value = merged;
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    focusVncTarget();
+    toast(`Virtual machine clipboard updated from this computer.\n\u2192 ${truncPreview(merged)}`);
+}
+
+async function extractVmTextToOs() {
+    const el = clipEl();
+    if (!el) {
+        toast('Extract failed: noVNC clipboard field not found.');
+        focusVncTarget();
+        return;
+    }
+    const v = el.value || '';
+    if (!v) {
+        toast('Nothing to extract yet. Copy inside the virtual machine first, then try again.');
+        focusVncTarget();
+        return;
+    }
+    try {
+        await navigator.clipboard.writeText(v);
+        toast(`Copied virtual machine clipboard to this computer.\n\u2192 ${truncPreview(v)}`);
+        focusVncTarget();
+    } catch (e3) {
+        toast('Extract failed: could not write to system clipboard.');
+        focusVncTarget();
+    }
+}

--- a/plugins/core/main/dashboard-lib.js
+++ b/plugins/core/main/dashboard-lib.js
@@ -30,7 +30,7 @@ const DASH_LIB_PROMPT_HISTORY_LABELS = {
     qa_edited: 'QA Edited',
     disputed: 'Disputed',
     dispute_resolved: 'Dispute Resolved',
-    flagged: 'Flagged',
+    flagged: 'Flagged as bugged',
     senior_review_flagged: 'Flagged for Senior Review',
     escalated: 'Escalated',
     screenshots: 'Screenshots associated with task'
@@ -358,7 +358,7 @@ const plugin = {
     id: 'dashboard-lib',
     name: 'Dashboard Lib',
     description: 'Pure helpers for the Worker Output Search dashboard (filters, versions, highlighting)',
-    _version: '3.1',
+    _version: '3.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/ops-tab.js
+++ b/plugins/core/main/ops-tab.js
@@ -192,7 +192,7 @@ const plugin = {
     id: 'ops-tab',
     name: 'Ops Tab',
     description: 'Ops dashboard backend: password gate, PostgREST, team search, verifier fetch, task links',
-    _version: '8.0',
+    _version: '8.1',
     phase: 'core',
     enabledByDefault: true,
 
@@ -253,6 +253,7 @@ const plugin = {
             isEnabled: () => this._getOpsTabEnabled(),
             isWanted: () => this._getOpsTabWanted(),
             hasStoredPassword: () => this._hasOpsStoredPassword(),
+            needsOpsDashboardRefresh: () => this._needsOpsDashboardRefresh(),
             shouldOpenDashboardOnSettings: () => this._shouldOpenDashboardOnSettings(),
             getOpsDashboardOpenOnSettings: () => this._getOpsDashboardOpenOnSettings(),
             setOpsDashboardOpenOnSettings: (enabled) => this._setOpsDashboardOpenOnSettings(enabled),
@@ -662,6 +663,11 @@ const plugin = {
 
     _getOpsTabEnabled() {
         return this._getOpsTabWanted() && this._hasOpsStoredPassword() && this._isOpsAccessConfigured();
+    },
+
+    _needsOpsDashboardRefresh() {
+        if (!this._getOpsTabEnabled()) return false;
+        return Context.opsDashboardPluginsLoaded !== true;
     },
 
     async _verifyOpsPassword(password) {
@@ -4345,6 +4351,9 @@ const plugin = {
         void this._loadOpsSecrets(true);
         if (settingsPlugin && typeof settingsPlugin.rebuildSettingsTabRow === 'function') {
             settingsPlugin.rebuildSettingsTabRow(modal, null, { keepCurrentPane: true });
+        }
+        if (settingsPlugin && typeof settingsPlugin.syncOpsRefreshBanner === 'function') {
+            settingsPlugin.syncOpsRefreshBanner(modal);
         }
         return true;
     },

--- a/plugins/core/main/ops-tab.js
+++ b/plugins/core/main/ops-tab.js
@@ -192,7 +192,7 @@ const plugin = {
     id: 'ops-tab',
     name: 'Ops Tab',
     description: 'Ops dashboard backend: password gate, PostgREST, team search, verifier fetch, task links',
-    _version: '8.2',
+    _version: '8.3',
     phase: 'core',
     enabledByDefault: true,
 
@@ -4355,6 +4355,7 @@ const plugin = {
         if (settingsPlugin && typeof settingsPlugin.syncOpsRefreshBanner === 'function') {
             settingsPlugin.syncOpsRefreshBanner(modal);
         }
+        this._syncOpsSettingsSubmoduleVisibility(modal);
         return true;
     },
 
@@ -4375,16 +4376,16 @@ const plugin = {
     _renderOpsSettingsSection() {
         const opsWantsEnabled = this._getOpsTabWanted();
         const opsHasStoredPassword = this._hasOpsStoredPassword();
-        const opsNeedsPassword = opsWantsEnabled && !opsHasStoredPassword;
-        const opsUnlocked = opsWantsEnabled && opsHasStoredPassword;
         const switchHTML = this._renderOpsSwitchHTML('wf-ops-tab-enabled', opsWantsEnabled);
         const openOnSettings = this._getOpsDashboardOpenOnSettings();
         const submoduleSwitchHTML = this._renderOpsSubSwitchHTML('wf-ops-dashboard-open-on-settings', openOnSettings);
-        const passwordPanelDisplay = opsNeedsPassword ? 'block' : 'none';
-        const suboptionsDisplay = opsWantsEnabled ? 'block' : 'none';
-        const openDashboardBtnDisplay = opsUnlocked ? 'block' : 'none';
+        const enableCardDisplay = opsHasStoredPassword ? 'block' : 'none';
+        const passwordPanelDisplay = opsHasStoredPassword ? 'none' : 'block';
+        const suboptionsDisplay = opsHasStoredPassword && opsWantsEnabled ? 'block' : 'none';
+        const openDashboardBtnDisplay = opsHasStoredPassword && opsWantsEnabled ? 'block' : 'none';
         return `
             <div style="margin-bottom: 20px;">
+                <div id="wf-ops-enable-wrap" style="display: ${enableCardDisplay};">
                 <div style="padding: 12px 14px; border: 1px solid var(--border, #e5e5e5); border-radius: 8px; background: var(--card, #fafafa);">
                     <div style="display: flex; align-items: center; justify-content: space-between; gap: 10px;">
                         <div style="font-size: 14px; font-weight: 600; color: var(--foreground, #333);">Enable Ops Dashboard</div>
@@ -4403,6 +4404,7 @@ const plugin = {
                             box-sizing: border-box;
                         ">Open Dashboard</button>
                     </div>
+                </div>
                 </div>
                 <div id="wf-ops-password-panel" style="display: ${passwordPanelDisplay}; margin-top: 10px; padding: 12px 14px; border: 1px solid var(--border, #e5e5e5); border-radius: 8px; background: var(--card, #fafafa);">
                     <label for="wf-ops-password-input" style="display: block; font-size: 12px; font-weight: 500; color: var(--foreground, #333); margin-bottom: 6px;">Ops Dashboard</label>
@@ -4428,12 +4430,16 @@ const plugin = {
     },
 
     _syncOpsSettingsSubmoduleVisibility(modal) {
+        const enableWrap = this._opsQuery(modal, '#wf-ops-enable-wrap', 'opsEnableWrap');
+        const passwordPanel = this._opsQuery(modal, '#wf-ops-password-panel', 'opsPasswordPanelSync');
         const wrap = this._opsQuery(modal, '#wf-ops-dashboard-suboptions-wrap', 'opsSubmoduleWrap');
         const openBtn = this._opsQuery(modal, '#wf-ops-open-dashboard-btn', 'opsOpenDashboardBtn');
+        const hasPassword = this._hasOpsStoredPassword();
         const wanted = this._getOpsTabWanted();
-        const unlocked = wanted && this._hasOpsStoredPassword();
-        if (wrap) wrap.style.display = wanted ? 'block' : 'none';
-        if (openBtn) openBtn.style.display = unlocked ? 'block' : 'none';
+        if (enableWrap) enableWrap.style.display = hasPassword ? 'block' : 'none';
+        if (passwordPanel) passwordPanel.style.display = hasPassword ? 'none' : 'block';
+        if (wrap) wrap.style.display = hasPassword && wanted ? 'block' : 'none';
+        if (openBtn) openBtn.style.display = hasPassword && wanted ? 'block' : 'none';
     },
 
     _renderOpsSwitchHTML(id, isEnabled) {

--- a/plugins/core/main/ops-tab.js
+++ b/plugins/core/main/ops-tab.js
@@ -192,7 +192,7 @@ const plugin = {
     id: 'ops-tab',
     name: 'Ops Tab',
     description: 'Ops dashboard backend: password gate, PostgREST, team search, verifier fetch, task links',
-    _version: '8.1',
+    _version: '8.2',
     phase: 'core',
     enabledByDefault: true,
 
@@ -4405,9 +4405,9 @@ const plugin = {
                     </div>
                 </div>
                 <div id="wf-ops-password-panel" style="display: ${passwordPanelDisplay}; margin-top: 10px; padding: 12px 14px; border: 1px solid var(--border, #e5e5e5); border-radius: 8px; background: var(--card, #fafafa);">
-                    <label for="wf-ops-password-input" style="display: block; font-size: 12px; font-weight: 500; color: var(--foreground, #333); margin-bottom: 6px;">Ops password</label>
+                    <label for="wf-ops-password-input" style="display: block; font-size: 12px; font-weight: 500; color: var(--foreground, #333); margin-bottom: 6px;">Ops Dashboard</label>
                     <div style="display: flex; gap: 8px; align-items: stretch;">
-                        <input type="password" id="wf-ops-password-input" autocomplete="current-password" placeholder="Enter password" style="
+                        <input type="password" id="wf-ops-password-input" autocomplete="current-password" style="
                             flex: 1;
                             min-width: 0;
                             padding: 8px 12px;

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -9850,7 +9850,7 @@ const searchOutputMethods = {
                     <p style="margin: 4px 0 0 0; padding: 6px 0 2px 12px; border-left: 3px solid var(--border, #e2e8f0); white-space: pre-wrap; line-height: 1.5; color: var(--foreground, #0f172a);">${reasonBody}</p>
                 </div>`;
         const bodyHtml = display.resolutionAt
-            ? `${reasonHtml}${resolutionHtml}${screenshotHtml}`
+            ? `${reasonHtml}${screenshotHtml}${resolutionHtml}`
             : `${reasonHtml}${screenshotHtml}${resolutionPanelHtml}`;
         return this._actionBlockShellHtml(
             blockId,
@@ -11108,7 +11108,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab: bootstrap, search, hydrate, filters, results cards',
-    _version: '4.0',
+    _version: '4.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '10.0',
+    _version: '10.1',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
 
@@ -27,7 +27,8 @@ const plugin = {
             shouldShowUpdateBanner: () => self._shouldShowUpdateNotification(),
             createUpdateNotificationHTML: () => self._createUpdateNotificationHTML(),
             attachUpdateBannerListeners: (root) => self._attachUpdateBannerListeners(root),
-            refreshUpdateIndicator: () => self._updatePulseAnimation()
+            refreshUpdateIndicator: () => self._updatePulseAnimation(),
+            syncOpsRefreshBanner: (modal) => self._syncOpsRefreshBanner(modal)
         };
         this._ensureDialogBackdropStyles();
         this._ensureSettingsButton();
@@ -432,6 +433,9 @@ const plugin = {
         const updateNotificationHTML = this._shouldShowUpdateNotification()
             ? this._createUpdateNotificationHTML()
             : '';
+        const opsRefreshBannerHTML = this._shouldShowOpsRefreshBanner()
+            ? this._createOpsRefreshBannerHTML()
+            : '';
         
         const hasDevSettings = this._hasActiveDevSettings();
         const tabs = this._getSettingsTabs();
@@ -563,6 +567,7 @@ const plugin = {
                     </button>
                 </div>
                 ${updateNotificationHTML}
+                ${opsRefreshBannerHTML}
                 ${tabRowHTML}
                 <div id="wf-settings-message" style="display: none; margin-top: 12px; padding: 10px 12px; background: #fef3c7; border: 1px solid #f59e0b; border-radius: 6px; font-size: 13px; text-align: center; color: #92400e;">
                     Settings changed. <a href="#" id="wf-settings-refresh-link" style="color: #92400e; text-decoration: underline;">Refresh</a> the page for changes to take effect.
@@ -905,6 +910,8 @@ const plugin = {
         });
 
         this._attachUpdateBannerListeners(modal, 'settings-ui');
+        this._attachOpsRefreshBannerListeners(modal, 'settings-ui');
+        this._syncOpsRefreshBanner(modal);
 
         // Tab buttons
         this._attachTabListeners(modal);
@@ -2416,6 +2423,99 @@ const plugin = {
     _shouldShowUpdateNotification() {
         return (Context.isOutdated && Context.latestVersion) ||
             (Context.isDevBranch && this._getPulseOverrideEnabled());
+    },
+
+    _shouldShowOpsRefreshBanner() {
+        if (!Context.opsTab || typeof Context.opsTab.needsOpsDashboardRefresh !== 'function') return false;
+        return Context.opsTab.needsOpsDashboardRefresh();
+    },
+
+    _syncOpsRefreshBanner(modal) {
+        if (!modal) return;
+        const shouldShow = this._shouldShowOpsRefreshBanner();
+        let banner = modal.querySelector('#wf-ops-refresh-banner');
+        if (!shouldShow) {
+            if (banner) banner.style.display = 'none';
+            return;
+        }
+        if (!banner) {
+            const tabRow = modal.querySelector('#wf-settings-tab-row');
+            const wrapper = document.createElement('div');
+            wrapper.innerHTML = this._createOpsRefreshBannerHTML();
+            banner = wrapper.firstElementChild;
+            if (tabRow && tabRow.parentElement) {
+                tabRow.parentElement.insertBefore(banner, tabRow);
+            } else {
+                const header = modal.querySelector('#wf-settings-content');
+                if (header) header.insertBefore(banner, header.firstChild);
+            }
+            this._attachOpsRefreshBannerListeners(modal, 'settings-ui');
+        }
+        banner.style.display = 'block';
+        Logger.log('settings-ui: ops refresh banner shown');
+    },
+
+    _attachOpsRefreshBannerListeners(root, reloadSource) {
+        const modal = root;
+        if (!modal || modal.dataset.wfOpsRefreshBannerBound === '1') return;
+        const refreshBtn = Context.dom.query('#wf-ops-refresh-fetch-btn', {
+            root: modal,
+            context: `${this.id}.opsRefreshFetchBtn`
+        });
+        if (!refreshBtn) return;
+        modal.dataset.wfOpsRefreshBannerBound = '1';
+        const source = reloadSource || 'settings-ui';
+        refreshBtn.addEventListener('click', () => {
+            if (typeof Context.requestExtensionReload === 'function') {
+                Context.requestExtensionReload(source + ' ops refresh banner');
+            } else {
+                window.location.reload();
+            }
+        });
+    },
+
+    _createOpsRefreshBannerHTML() {
+        return `
+            <div id="wf-ops-refresh-banner" style="
+                margin-bottom: 20px;
+                padding: 14px;
+                background: #fef3c7;
+                border: 2px solid #f59e0b;
+                border-radius: 8px;
+            ">
+                <div style="display: flex; align-items: flex-start; margin-bottom: 10px;">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 10px; color: #b45309; flex-shrink: 0; margin-top: 2px;">
+                        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+                        <line x1="12" y1="9" x2="12" y2="13"></line>
+                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                    </svg>
+                    <div style="flex: 1;">
+                        <h3 style="font-size: 15px; font-weight: 600; margin: 0 0 8px 0; color: #92400e;">
+                            Ops Tab Unlock Pending
+                        </h3>
+                        <p style="font-size: 13px; color: #92400e; margin: 0; line-height: 1.5;">
+                            Refresh the page to activate the Ops tab and load the dashboard plugins.
+                        </p>
+                    </div>
+                </div>
+                <div style="margin-top: 12px; padding-top: 10px; border-top: 1px solid #fcd34d; text-align: center;">
+                    <button type="button" id="wf-ops-refresh-fetch-btn" style="
+                        padding: 8px 14px;
+                        font-size: 13px;
+                        font-weight: 600;
+                        color: #92400e;
+                        background: #fffbeb;
+                        border: 1px solid #f59e0b;
+                        border-radius: 6px;
+                        cursor: pointer;
+                    ">Refresh to Fetch</button>
+                </div>
+            </div>
+        `;
+    },
+
+    syncOpsRefreshBanner(modal) {
+        return this._syncOpsRefreshBanner(modal);
     },
 
     _attachUpdateBannerListeners(root, reloadSource) {


### PR DESCRIPTION
## Summary

Defers heavy Ops dashboard plugin loading until the Ops tab is unlocked, streamlines the unlock/settings flow, and ships small dashboard and dispute-detail UX fixes.

## Changes

- **Ops dashboard lazy load**: Splits dashboard modules (`dashboard-lib`, `search-output`, etc.) into a new `opsDashboardPlugins` list in `archetypes.json`. `fleet.user.js` loads and initializes them only when Ops access is already enabled at page load; otherwise they stay deferred and a settings refresh banner prompts a reload after unlock.
- **Ops settings UX**: Hides the "Enable Ops Dashboard" toggle until the password gate is cleared; renames the unlock field label to "Ops Dashboard" and drops the password placeholder. Settings shows an "Ops Tab Unlock Pending" banner when access is granted but dashboard plugins have not loaded yet.
- **Dashboard polish**: Renames the lifecycle history filter label from "Flagged" to "Flagged as bugged" so it is distinct from senior-review flags. Keeps dispute resolution content last in resolved dispute cards (after screenshots) so async screenshot loads do not push resolution text down.
- **Dispute detail**: Adds `vnc-helper.js` to the `dispute-detail` archetype for embedded noVNC sessions on dispute review pages (prompt cache, scratchpad, clipboard bridge).

## New plugins

| Archetype | Plugin | Notes |
|-----------|--------|-------|
| `dispute-detail` | `vnc-helper.js` (v1.7) | VNC Helper modal for noVNC on dispute review pages |
