### PR TITLE
Fix blank Ops Dashboard when Search Output fails to load

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "10.3",
+  "version": "10.4",
   "coreOnlyMode": false,
-  "archetypesVersion": "12.53",
+  "archetypesVersion": "12.55",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -22,8 +22,8 @@
     },
     {
       "name": "ops-tab.js",
-      "version": "8.13",
-      "hash": "sha256-780a52c46fb1cf5972b81d69582b0ba862f9de8b0a007cb60d5faaefb625900d",
+      "version": "8.14",
+      "hash": "sha256-96d01e4075b9685599823a204daee37eecd8e30056a3d3b2ff980638b1227cfe",
       "log": false
     },
     {
@@ -54,8 +54,8 @@
     },
     {
       "name": "dashboard.js",
-      "version": "6.18",
-      "hash": "sha256-fdabda56d45a4ec2611e1525c2886e19e6f1e4683eafb38d5d592fb5314af98e",
+      "version": "6.19",
+      "hash": "sha256-e7ac3608cd013e49e12eca3f69f10f0d67473ea6f54b01227e527e430ffc4a12",
       "log": false
     },
     {
@@ -66,8 +66,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "4.28",
-      "hash": "sha256-9e2e6d383715e44eef96438d437b0b37c1120c77b2fc7039a48cd3d19a736d1b",
+      "version": "4.29",
+      "hash": "sha256-0783c1e561edae14475276c1b28ee9a58ab11a35344046bd90242b9336adc5ab",
       "log": false
     },
     {

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      10.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -17,8 +17,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -94,7 +94,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      10.3
+// @version      10.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '10.3';
+    const VERSION = '10.4';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -3533,17 +3533,24 @@
                 });
         },
 
+        runOpsDashboardPluginInit(plugin) {
+            if (plugin.state && plugin.state.opsInitialized) {
+                return;
+            }
+            try {
+                if (plugin.init) plugin.init(plugin.state, Context);
+            } catch (e) {
+                Logger.error(`Error in ops dashboard plugin ${plugin.id}:`, e);
+                return;
+            }
+            if (plugin.state) plugin.state.opsInitialized = true;
+            Logger.log(`✓ Ops dashboard plugin initialized: ${plugin.id}`);
+        },
+
         runOpsDashboardPlugins() {
             this.getOpsDashboardPlugins()
                 .filter(p => this.isEnabled(p.id))
-                .forEach(plugin => {
-                    try {
-                        if (plugin.init) plugin.init(plugin.state, Context);
-                        Logger.log(`✓ Ops dashboard plugin initialized: ${plugin.id}`);
-                    } catch (e) {
-                        Logger.error(`Error in ops dashboard plugin ${plugin.id}:`, e);
-                    }
-                });
+                .forEach(plugin => this.runOpsDashboardPluginInit(plugin));
         },
         
         runEarlyPlugins() {
@@ -3593,6 +3600,59 @@
     let corePluginsLoaded = false;
     let navigationHandlerActive = false;
     let navigationPendingUrl = null;
+
+    let opsDashboardLoadPromise = null;
+
+    async function loadMissingOpsDashboardPluginsFromConfig(configList) {
+        if (!configList || configList.length === 0) return;
+        const toLoad = [];
+        for (const def of configList) {
+            const filename = def && def.name ? def.name : (typeof def === 'string' ? def : '');
+            if (!filename) continue;
+            const exists = PluginManager.getAll().some((p) => p._sourceFile === filename);
+            if (!exists) toLoad.push(def);
+        }
+        if (toLoad.length === 0) return;
+        const beforeIds = new Set(PluginManager.getAll().map((p) => p.id));
+        await PluginLoader.loadPluginsFromConfig(toLoad, 'core');
+        PluginManager.getAll()
+            .filter((p) => !beforeIds.has(p.id))
+            .forEach((p) => { p._isOps = true; });
+        Logger.log('ops dashboard: loaded ' + toLoad.length + ' missing plugin(s)');
+    }
+
+    async function ensureOpsDashboardPluginsLoaded() {
+        if (!Context.opsTab || !Context.opsTab.isEnabled()) {
+            return false;
+        }
+        if (opsDashboardLoadPromise) {
+            return opsDashboardLoadPromise;
+        }
+        opsDashboardLoadPromise = (async () => {
+            await ArchetypeManager.loadArchetypes();
+            const configList = ArchetypeManager.getOpsDashboardPlugins();
+            if (!configList.length) {
+                Context.opsDashboardPluginsLoaded = true;
+                return true;
+            }
+            if (!Context.opsDashboardPluginsLoaded) {
+                Logger.log('ops tab enabled: loading ops dashboard plugins...');
+            }
+            await loadMissingOpsDashboardPluginsFromConfig(configList);
+            PluginManager.getOpsDashboardPlugins()
+                .filter((p) => PluginManager.isEnabled(p.id))
+                .forEach((p) => PluginManager.runOpsDashboardPluginInit(p));
+            Context.opsDashboardPluginsLoaded = true;
+            return true;
+        })();
+        try {
+            return await opsDashboardLoadPromise;
+        } finally {
+            opsDashboardLoadPromise = null;
+        }
+    }
+
+    Context.ensureOpsDashboardPluginsLoaded = ensureOpsDashboardPluginsLoaded;
     
     async function initializeCorePlugins() {
         if (corePluginsLoaded) {
@@ -3624,14 +3684,7 @@
         const opsDashboardPlugins = ArchetypeManager.getOpsDashboardPlugins();
         if (opsDashboardPlugins.length > 0) {
             if (Context.opsTab && Context.opsTab.isEnabled()) {
-                Logger.log('ops tab enabled: loading ops dashboard plugins...');
-                const beforeIds = new Set(PluginManager.getAll().map(p => p.id));
-                await PluginLoader.loadPluginsFromConfig(opsDashboardPlugins, 'core');
-                PluginManager.getAll()
-                    .filter(p => !beforeIds.has(p.id))
-                    .forEach(p => { p._isOps = true; });
-                PluginManager.runOpsDashboardPlugins();
-                Context.opsDashboardPluginsLoaded = true;
+                await ensureOpsDashboardPluginsLoaded();
             } else {
                 Context.opsDashboardPluginsLoaded = false;
                 Logger.log('ops dashboard plugins deferred — reload page after granting ops access');

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      10.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -17,8 +17,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -94,7 +94,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/dashboard.js
+++ b/plugins/core/main/dashboard.js
@@ -85,7 +85,7 @@ const plugin = {
     id: 'dashboard',
     name: 'Dashboard',
     description: 'Ops dashboard loader: modal shell, tab registry, shared UI primitives',
-    _version: '6.18',
+    _version: '6.19',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -100,8 +100,13 @@ const plugin = {
     _keydownDoc: null,
     _splitResizeAttached: false,
     _flyoutResizeTimer: null,
+    _activeTabFallbackLogged: false,
 
-    init() {
+    init(state) {
+        if (state && state.loaderRegistered) {
+            Logger.debug('dashboard: loader already registered — skipping re-init');
+            return;
+        }
         this._state = this._createInitialState();
         this._tabs = [];
         this._tabsById = {};
@@ -113,11 +118,21 @@ const plugin = {
                     Logger.warn('dashboard: registerTab skipped — missing id');
                     return;
                 }
+                const isNew = !self._tabsById[def.id];
                 self._tabsById[def.id] = def;
                 const idx = self._tabs.findIndex((t) => t.id === def.id);
                 if (idx >= 0) self._tabs[idx] = def;
                 else self._tabs.push(def);
                 Logger.log('dashboard: tab registered — ' + def.id);
+                if (isNew && self._built && self._overlay && self._overlay.isConnected) {
+                    const wasOpen = self._isOpen();
+                    self._built = false;
+                    if (wasOpen) {
+                        self._ensureBuilt();
+                        self._setActiveTab(self._resolveActiveTabId(self._state.activeTab));
+                        self._syncIncompleteTabsBanner();
+                    }
+                }
             },
             open: () => self.open(),
             close: () => self.close(),
@@ -197,6 +212,7 @@ const plugin = {
                 }
             }
         };
+        if (state) state.loaderRegistered = true;
         Logger.log('dashboard: loader registered (Context.dashboard)');
     },
 
@@ -307,6 +323,42 @@ const plugin = {
         return required.every((id) => Boolean(this._tabsById && this._tabsById[id]));
     },
 
+    _resolveActiveTabId(preferred) {
+        const preferredId = String(preferred || '').trim();
+        if (preferredId && this._tabsById && this._tabsById[preferredId]) {
+            return preferredId;
+        }
+        if (this._tabs && this._tabs.length > 0) {
+            const firstId = this._tabs[0].id;
+            if (preferredId && preferredId !== firstId) {
+                this._logActiveTabFallbackIfNeeded(preferredId, firstId);
+            }
+            return firstId;
+        }
+        return preferredId || 'search-output';
+    },
+
+    _logActiveTabFallbackIfNeeded(preferred, resolved) {
+        if (this._activeTabFallbackLogged) return;
+        this._activeTabFallbackLogged = true;
+        Logger.warn('dashboard: active tab ' + preferred + ' unavailable — showing ' + resolved);
+    },
+
+    _syncIncompleteTabsBanner() {
+        if (!this._modal) return;
+        const banner = this._modal.querySelector('#wf-dash-incomplete-banner');
+        if (!banner) return;
+        const show = !this._isDashboardReady();
+        banner.style.display = show ? 'block' : 'none';
+        if (!show) return;
+        const missing = ['search-output', 'team-members', 'verifier-fetcher', 'diff-viewer']
+            .filter((id) => !this._tabsById || !this._tabsById[id]);
+        banner.textContent = missing.length > 0
+            ? 'Some dashboard modules failed to load (' + missing.join(', ') + '). Check the console or refresh the page.'
+            : 'Some dashboard modules failed to load. Check the console or refresh the page.';
+        Logger.warn('dashboard: incomplete — missing tab(s): ' + (missing.join(', ') || 'unknown'));
+    },
+
     open() {
         const doOpen = () => {
             try {
@@ -333,6 +385,10 @@ const plugin = {
                     Logger.debug('dashboard: could not close settings modal', e);
                 }
                 this._syncDashboardUpdateMode();
+                if (!this._shouldShowDashboardUpdateTab()) {
+                    this._setActiveTab(this._resolveActiveTabId(this._state.activeTab));
+                }
+                this._syncIncompleteTabsBanner();
                 for (const tab of this._tabs) {
                     if (typeof tab.onOpen === 'function') {
                         try {
@@ -350,11 +406,24 @@ const plugin = {
             }
         };
 
-        if (Context.opsTab && typeof Context.opsTab.ensureOpsSessionReady === 'function') {
-            void Context.opsTab.ensureOpsSessionReady(this._modal).finally(doOpen);
-            return;
-        }
-        doOpen();
+        const prepOpen = async () => {
+            try {
+                if (typeof Context.ensureOpsDashboardPluginsLoaded === 'function') {
+                    await Context.ensureOpsDashboardPluginsLoaded();
+                }
+            } catch (e) {
+                Logger.warn('dashboard: ensureOpsDashboardPluginsLoaded failed', e);
+            }
+            try {
+                if (Context.opsTab && typeof Context.opsTab.ensureOpsSessionReady === 'function') {
+                    await Context.opsTab.ensureOpsSessionReady(this._modal);
+                }
+            } catch (e) {
+                Logger.debug('dashboard: ensureOpsSessionReady failed', e);
+            }
+            doOpen();
+        };
+        void prepOpen();
     },
 
     close() {
@@ -453,6 +522,7 @@ const plugin = {
             this._applyAllSidePanelWidths();
             this._applyAllResultsPanelMaxWidths();
             this._syncDashboardUpdateMode();
+            this._syncIncompleteTabsBanner();
             this._syncAllMsDropdowns();
             for (const tab of this._tabs) {
                 if (typeof tab.onBuilt === 'function') {
@@ -908,8 +978,8 @@ const plugin = {
         normalTabs.forEach((btn) => { btn.style.display = ''; });
         if (headerTask) headerTask.style.display = '';
         if (headerOps) headerOps.style.display = '';
-        const restoreTab = this._state.activeTab === 'update' ? 'search-output' : this._state.activeTab;
-        this._setActiveTab(restoreTab || 'search-output');
+        const restorePreferred = this._state.activeTab === 'update' ? 'search-output' : this._state.activeTab;
+        this._setActiveTab(this._resolveActiveTabId(restorePreferred || 'search-output'));
     },
 
     _modalHtml() {
@@ -938,7 +1008,9 @@ const plugin = {
         const gradeAssessmentsLink = ops && typeof ops.renderGradeAssessmentsHeaderLink === 'function'
             ? ops.renderGradeAssessmentsHeaderLink()
             : '';
-        const activeTabId = this._state.activeTab || (tabs[0] ? tabs[0].id : 'search-output');
+        const activeTabId = this._resolveActiveTabId(
+            this._state.activeTab || (tabs[0] ? tabs[0].id : 'search-output')
+        );
         const panelHtml = tabs.map((t) => {
             const def = this._tabsById[t.id];
             let inner = '';
@@ -973,6 +1045,7 @@ const plugin = {
                 </div>
             </div>
             <div id="wf-dash-body" style="flex: 1; min-height: 0; overflow: hidden; padding: 16px 18px; display: flex; flex-direction: column;">
+                <div id="wf-dash-incomplete-banner" style="display: none; margin-bottom: 12px; padding: 10px 12px; font-size: 12px; color: #92400e; background: #fef3c7; border: 1px solid #f59e0b; border-radius: 8px; flex-shrink: 0;"></div>
                 ${panelHtml}
                 <div data-wf-dash-panel="update" style="flex: 1; min-height: 0; display: none; flex-direction: column; overflow-y: auto; align-items: center; padding: 8px 0;">
                     <div style="width: 100%; max-width: 720px; box-sizing: border-box;">${updatePanelHtml}</div>
@@ -2743,6 +2816,8 @@ const plugin = {
     _setActiveTab(tabId) {
         if (this._shouldShowDashboardUpdateTab() && tabId !== 'update') {
             tabId = 'update';
+        } else {
+            tabId = this._resolveActiveTabId(tabId);
         }
         this._state.activeTab = tabId;
         this._modal.querySelectorAll('[data-wf-dash-tab]').forEach((btn) => {

--- a/plugins/core/main/ops-tab.js
+++ b/plugins/core/main/ops-tab.js
@@ -202,7 +202,7 @@ const plugin = {
     id: 'ops-tab',
     name: 'Ops Tab',
     description: 'Ops dashboard backend: password gate, PostgREST, team search, verifier fetch, task links',
-    _version: '8.13',
+    _version: '8.14',
     phase: 'core',
     enabledByDefault: true,
 
@@ -4638,6 +4638,13 @@ const plugin = {
         Logger.log('ops-tab: password saved on device');
         this._persistOpsPasswordHashSeen(this._getOpsPasswordHash());
         void this._loadOpsSecrets(true);
+        if (typeof Context.ensureOpsDashboardPluginsLoaded === 'function') {
+            try {
+                await Context.ensureOpsDashboardPluginsLoaded();
+            } catch (e) {
+                Logger.warn('ops-tab: ensureOpsDashboardPluginsLoaded after unlock failed', e);
+            }
+        }
         if (settingsPlugin && typeof settingsPlugin.rebuildSettingsTabRow === 'function') {
             settingsPlugin.rebuildSettingsTabRow(modal, null, { keepCurrentPane: true });
         }
@@ -4645,6 +4652,7 @@ const plugin = {
             settingsPlugin.syncOpsRefreshBanner(modal);
         }
         this._syncOpsSettingsSubmoduleVisibility(modal);
+        this._syncOpsDashboardIncompleteMessage(modal);
         return true;
     },
 
@@ -4692,6 +4700,9 @@ const plugin = {
                             margin-top: 10px;
                             box-sizing: border-box;
                         ">Open Dashboard</button>
+                        <div id="wf-ops-dashboard-incomplete-msg" style="display: none; margin-top: 10px; padding: 10px 12px; font-size: 12px; color: #92400e; background: #fef3c7; border: 1px solid #f59e0b; border-radius: 8px; line-height: 1.45;">
+                            Search Output module failed to load. Check the console or refresh the page.
+                        </div>
                     </div>
                 </div>
                 </div>
@@ -4729,6 +4740,21 @@ const plugin = {
         if (passwordPanel) passwordPanel.style.display = hasPassword ? 'none' : 'block';
         if (wrap) wrap.style.display = hasPassword && wanted ? 'block' : 'none';
         if (openBtn) openBtn.style.display = hasPassword && wanted ? 'block' : 'none';
+        this._syncOpsDashboardIncompleteMessage(modal);
+    },
+
+    _syncOpsDashboardIncompleteMessage(modal) {
+        const el = this._opsQuery(modal, '#wf-ops-dashboard-incomplete-msg', 'opsDashboardIncompleteMsg');
+        if (!el) return;
+        const show = this._getOpsTabWanted()
+            && this._hasOpsStoredPassword()
+            && Context.dashboard
+            && typeof Context.dashboard.isReady === 'function'
+            && !Context.dashboard.isReady();
+        el.style.display = show ? 'block' : 'none';
+        if (show) {
+            Logger.warn('ops-tab: dashboard modules incomplete — Search Output may be unavailable');
+        }
     },
 
     _renderOpsSwitchHTML(id, isEnabled) {
@@ -4986,12 +5012,23 @@ const plugin = {
                 Logger.warn('ops-tab: Open Dashboard skipped — not unlocked');
                 return;
             }
-            if (Context.dashboard && typeof Context.dashboard.open === 'function') {
-                Context.dashboard.open();
-                Logger.log('ops-tab: opened Ops dashboard from settings');
-            } else {
-                Logger.warn('ops-tab: Open Dashboard skipped — Context.dashboard unavailable');
-            }
+            const self = this;
+            void (async () => {
+                if (typeof Context.ensureOpsDashboardPluginsLoaded === 'function') {
+                    try {
+                        await Context.ensureOpsDashboardPluginsLoaded();
+                    } catch (e) {
+                        Logger.warn('ops-tab: ensureOpsDashboardPluginsLoaded before open failed', e);
+                    }
+                }
+                self._syncOpsDashboardIncompleteMessage(modal);
+                if (Context.dashboard && typeof Context.dashboard.open === 'function') {
+                    Context.dashboard.open();
+                    Logger.log('ops-tab: opened Ops dashboard from settings');
+                } else {
+                    Logger.warn('ops-tab: Open Dashboard skipped — Context.dashboard unavailable');
+                }
+            })();
         });
     },
 

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -11255,26 +11255,40 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab: bootstrap, search, hydrate, filters, results cards',
-    _version: '4.28',
+    _version: '4.29',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
 
-    init() {
-        const loader = Context.dashboard && Context.dashboard._loader;
-        if (!loader) {
-            Logger.error('search-output: dashboard loader not registered');
+    init(state) {
+        if (state && state.registered) {
+            Logger.debug('search-output: tab already registered — skipping re-init');
             return;
         }
-        Object.assign(loader, searchOutputMethods);
-        const de = Context.diffEngine;
-        if (de && typeof de.onFleetThemeChange === 'function') {
-            de.onFleetThemeChange(() => {
-                if (typeof loader._renderResults === 'function') loader._renderResults();
-            });
+        const loader = Context.dashboard && Context.dashboard._loader;
+        if (!loader) {
+            const err = new Error('search-output: dashboard loader not registered');
+            Logger.error(err.message);
+            throw err;
         }
-        if (loader._state && loader._state.catalog == null && typeof loader._readBootstrapCache === 'function') {
-            loader._state.catalog = loader._readBootstrapCache();
+        try {
+            Object.assign(loader, searchOutputMethods);
+        } catch (e) {
+            Logger.error('search-output: attach to dashboard loader failed', e);
+            throw e;
+        }
+        try {
+            const de = Context.diffEngine;
+            if (de && typeof de.onFleetThemeChange === 'function') {
+                de.onFleetThemeChange(() => {
+                    if (typeof loader._renderResults === 'function') loader._renderResults();
+                });
+            }
+            if (loader._state && loader._state.catalog == null && typeof loader._readBootstrapCache === 'function') {
+                loader._state.catalog = loader._readBootstrapCache();
+            }
+        } catch (e) {
+            Logger.warn('search-output: pre-register setup failed', e);
         }
         Context.dashboard.registerTab({
             id: 'search-output',
@@ -11308,6 +11322,7 @@ const plugin = {
                 requestAnimationFrame(() => dash._applyAllSidePanelWidths());
             }
         });
+        if (state) state.registered = true;
         Logger.log('search-output: tab registered');
     }
 


### PR DESCRIPTION
## Summary

Fixes a race where the Ops Dashboard could open blank because Search Output had not finished loading or registering its tab. Defers and retries ops-dashboard plugin loading until the ops password gate is unlocked or the user opens the dashboard, and surfaces a clear warning when modules are still incomplete.

## Changes

- **Host (`fleet.user.js`)**: Adds `ensureOpsDashboardPluginsLoaded()` on `Context` so ops-dashboard plugins load on demand (after unlock or before open), with idempotent init via `opsInitialized` flags to avoid double-registration.
- **Dashboard (`dashboard.js`)**: Resolves the active tab to the first available tab when Search Output is missing; shows an in-modal incomplete-modules banner; guards loader registration with `loaderRegistered`; exposes `isReady()` for callers.
- **Search Output (`search-output.js`)**: Fails loudly (throws) when the dashboard loader is not ready instead of silently returning; skips re-init when already registered.
- **Ops tab (`ops-tab.js`)**: Awaits plugin load after password unlock and before "Open Dashboard"; shows a settings-panel warning when dashboard modules are incomplete.
