### PR TITLE
Add User Story markdown replicas on creation, revision, and QA

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 ### Tool Use Task Creation Page
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Tool Use Task Creation Page (OpenClaw / Special Projects)
 *Loads when the task-creation page matches the OpenClaw / Special Projects disambiguator in `archetypes.json`.*
@@ -94,19 +95,23 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
 - **Text Sanitizer**: Adds a text sanitizer utility for quickly cleaning and transforming text
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Tool Use Task Revision Page
 - **Explore GUI**: Opens the underlying tool environment in a new tab (captures MCP instance URL from network traffic; acknowledgment modal before opening)
 - **Scratchpad**: Adds an adjustable height scratchpad to the page
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Computer Use Task Creation Page
 - **Disable Prompt Text Area Autocorrect**: Disables autocorrect in the prompt text box
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Computer Use Task Revision Page
 - **Scratchpad**: Adds an adjustable height scratchpad to the page
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### QA Tool Use Review Page
 - **"Accept Task" Modal Improvements**: Add a button above the optional comments box to paste a positive blurb
@@ -117,6 +122,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **"Request Revisions" Modal Improvements**: Improvements to the Request Revisions Workflow
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
 - **Useful Link Buttons**: Add useful link buttons to the page
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### QA Computer Use Review Page
 - **"Accept Task" Modal Improvements**: Add a button above the optional comments box to paste a positive blurb
@@ -125,6 +131,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text
 - **Hide Grading Autoclick**: Automatically clicks the "Hide Grading" button once when it becomes available after load.
 - **Request Revisions Improvements**: Improvements to the Request Revisions Workflow
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Dispute Detail Page
 - **Clear Tool Search**: Adds a clear `X` button to the tool search box when it has text

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "12.0",
+  "version": "12.1",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.20",
+  "archetypesVersion": "14.21",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.25",
+  "archetypesVersion": "14.26",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -108,8 +108,8 @@
     },
     {
       "name": "user-story-markdown.js",
-      "version": "1.1",
-      "hash": "sha256-a2ed96af90aa1ff4bc9e5d42bb0d776cabcba3b40ada787c85be9c8f775547c6",
+      "version": "1.2",
+      "hash": "sha256-699ca593d6a2544cc9c2c8214c5ac5ccf05608ae0356ae0deec77252ab37c663",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.26",
+  "archetypesVersion": "14.27",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -224,7 +224,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.31"
+      "version": "1.32"
     }
   ],
   "archetypes": [

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.23",
+  "archetypesVersion": "14.24",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -16,8 +16,8 @@
   "corePlugins": [
     {
       "name": "ui-lib.js",
-      "version": "2.4",
-      "hash": "sha256-bbe1f3fb53a9eb93d7501c825b6753268a7aa2a3369d8cbfbdd251ec843b0213",
+      "version": "2.5",
+      "hash": "sha256-f2482f2641c35fab8e813ff8e113aec1618d6b82c5f4a2c565d68227a49c97e6",
       "log": false
     },
     {
@@ -104,6 +104,12 @@
       "name": "top-nav-horizontal-scroll.js",
       "version": "2.0",
       "hash": "sha256-cf245176446dd7877960b41be0ac65b9ffeae62ded936cb8c7af5662cbbb7e58",
+      "log": false
+    },
+    {
+      "name": "user-story-markdown.js",
+      "version": "1.0",
+      "hash": "sha256-b43ab134602c66a9518befe6343f2a2cdb21a49f3eabacc9e8845ee94a4c2b81",
       "log": false
     },
     {
@@ -256,7 +262,8 @@
       "urlPattern": "work/problems/create-tool-use*",
       "disambiguationSelectors": [],
       "libraries": [
-        "notes-resize-handle.js"
+        "notes-resize-handle.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -282,6 +289,12 @@
           "version": "2.2",
           "hash": "sha256-744e07c945113b7b51ce2b20ba79bbd18aec9b54a380dd376e588c8361bf9fd2",
           "log": false
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
+          "log": false
         }
       ]
     },
@@ -294,7 +307,8 @@
         "text:Task Designers - Special Projects Tasks"
       ],
       "libraries": [
-        "notes-resize-handle.js"
+        "notes-resize-handle.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -320,6 +334,12 @@
           "version": "2.2",
           "hash": "sha256-744e07c945113b7b51ce2b20ba79bbd18aec9b54a380dd376e588c8361bf9fd2",
           "log": false
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
+          "log": false
         }
       ]
     },
@@ -330,7 +350,8 @@
       "urlPattern": "work/problems/respond-feedback/edit-tool-use*",
       "disambiguationSelectors": [],
       "libraries": [
-        "prompt-scratchpad.js"
+        "prompt-scratchpad.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -349,6 +370,12 @@
           "name": "tool-results-resize-handle.js",
           "version": "3.2",
           "hash": "sha256-8911cf93e15914872a6575ba38854a2fcd10b214d2d62a9055b35e08b43569ee",
+          "log": false
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
           "log": false
         }
       ]
@@ -385,7 +412,8 @@
       "libraries": [
         "notes-resize-handle.js",
         "embedded-urlbar-fit.js",
-        "action-counter.js"
+        "action-counter.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -411,6 +439,12 @@
           "version": "4.0",
           "hash": "sha256-8425e2ec9464248eb3f45b335845167a078f918c0c21638bcdaeddcad66b4712",
           "log": false
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
+          "log": false
         }
       ]
     },
@@ -423,7 +457,8 @@
       "libraries": [
         "embedded-urlbar-fit.js",
         "prompt-scratchpad.js",
-        "action-counter.js"
+        "action-counter.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -443,6 +478,12 @@
           "version": "2.3",
           "hash": "sha256-d236db4f8a7b598d20278aa03f53a53a6e185e5c3682a94fe5267dbaeb3b2c9e",
           "log": false
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
+          "log": false
         }
       ]
     },
@@ -456,7 +497,8 @@
         "accept-task-modal-improvements.js",
         "request-revisions-screenshot-upload-improvement.js",
         "copy-verifier-output.js",
-        "top-nav-horizontal-scroll.js"
+        "top-nav-horizontal-scroll.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -506,6 +548,12 @@
           "version": "3.0",
           "hash": "sha256-8ee1accb7ae9a4173ef6c5603d55455986ffdb3d4ae2f9c703c1f030b1fbd261",
           "log": false
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
+          "log": false
         }
       ]
     },
@@ -544,7 +592,8 @@
         "request-revisions-screenshot-upload-improvement.js",
         "copy-verifier-output.js",
         "embedded-urlbar-fit.js",
-        "top-nav-horizontal-scroll.js"
+        "top-nav-horizontal-scroll.js",
+        "user-story-markdown.js"
       ],
       "plugins": [
         {
@@ -618,6 +667,12 @@
           "version": "1.9",
           "log": false,
           "hash": "sha256-96e76698cdc83a6539a60fa1586d144d1873931df2434eb21066071afad15a38"
+        },
+        {
+          "name": "user-story-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-121a4fb079e347d59dea84d3f9bad5b2617ed79bed0fc4cfc41dc8504234c17e",
+          "log": false
         },
         {
           "name": "vnc-prompt-writer.js",

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.22",
+  "archetypesVersion": "14.23",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -66,8 +66,8 @@
     },
     {
       "name": "copy-verifier-output.js",
-      "version": "5.0",
-      "hash": "sha256-5431ed84ebedb7a98bdfc1c1a0582cf5bcee57fb1d747dcffee963ea6ec827ca",
+      "version": "5.1",
+      "hash": "sha256-2100444ea3d747b509fa6bf5f9ed7cec35d273468e5585b2c8f27a1832585aa9",
       "log": false
     },
     {
@@ -473,8 +473,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "7.0",
-          "hash": "sha256-e008512094c2bdf1b9943d167adc9260c3de029ee1a259433a8262499719897a",
+          "version": "7.1",
+          "hash": "sha256-28f06828e5baa571a28a7c902a54c565a5feb5450d961eeee0cc935ff0ff558c",
           "log": false
         },
         {
@@ -597,8 +597,8 @@
         },
         {
           "name": "request-revisions.js",
-          "version": "6.0",
-          "hash": "sha256-fe2dba0da3080fc178d1248e92161c5c8f7541753f34f7aa9dcda4e77a08d46d",
+          "version": "6.1",
+          "hash": "sha256-be76622b85155a799ef2b4978640392a65f4a68cc89f84346270f7760762ba65",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.24",
+  "archetypesVersion": "14.25",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -108,8 +108,8 @@
     },
     {
       "name": "user-story-markdown.js",
-      "version": "1.0",
-      "hash": "sha256-b43ab134602c66a9518befe6343f2a2cdb21a49f3eabacc9e8845ee94a4c2b81",
+      "version": "1.1",
+      "hash": "sha256-a2ed96af90aa1ff4bc9e5d42bb0d776cabcba3b40ada787c85be9c8f775547c6",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "12.1",
+  "version": "12.2",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.21",
+  "archetypesVersion": "14.22",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [fix/port] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'fix/port';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [fix/port] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'fix/port';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.31
+1.32
 
 ## Features
 
@@ -12,6 +12,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 ### Tool Use Task Creation Page
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Tool Use Task Creation Page (OpenClaw / Special Projects)
 *Loads when the task-creation page matches the OpenClaw / Special Projects disambiguator in `archetypes.json`.*
@@ -22,18 +23,22 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
 - **Text Sanitizer**: Adds a text sanitizer utility for quickly cleaning and transforming text
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Tool Use Task Revision Page
 - **Scratchpad**: Adds an adjustable height scratchpad to the page
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Computer Use Task Creation Page
 - **Disable Prompt Text Area Autocorrect**: Disables autocorrect in the prompt text box
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Computer Use Task Revision Page
 - **Scratchpad**: Adds an adjustable height scratchpad to the page
 - **Remove Textarea Gradient**: Removes the gradient fade overlay from the prompt textarea
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### QA Tool Use Review Page
 - **"Accept Task" Modal Improvements**: Add a button above the optional comments box to paste a positive blurb
@@ -44,6 +49,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **"Request Revisions" Modal Improvements**: Improvements to the Request Revisions Workflow
 - **Tool Results Resize Handle**: Adds a resize handle to tool result boxes so their height can be adjusted by dragging
 - **Useful Link Buttons**: Add useful link buttons to the page
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### QA Computer Use Review Page
 - **"Accept Task" Modal Improvements**: Add a button above the optional comments box to paste a positive blurb
@@ -52,6 +58,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Copy Verifier Output**: Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text
 - **Hide Grading Autoclick**: Automatically clicks the "Hide Grading" button once when it becomes available after load.
 - **Request Revisions Improvements**: Improvements to the Request Revisions Workflow
+- **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 
 ### Dispute Detail Page
 - **Clear Tool Search**: Adds a clear `X` button to the tool search box when it has text

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [fix/port] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.0
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -17,8 +17,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -94,7 +94,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'fix/port',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [fix/port] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      12.1
+// @version      12.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '12.1';
+    const VERSION = '12.2';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -3257,7 +3257,10 @@
                 }
                 
                 const existingPlugins = PluginManager.getAll();
-                const alreadyLoadedByFile = existingPlugins.some(p => p._sourceFile === filename);
+                // Libraries share filenames with thin archetype wrappers; ignore _isLib entries
+                const alreadyLoadedByFile = existingPlugins.some(
+                    (p) => p._sourceFile === filename && p._isLib !== true
+                );
                 
                 const sourcePath = `archetypes/${archetypeId}/main/${filename}`;
                 const alreadyLoadedByPath = this._loadedPluginFiles.has(sourcePath);

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [fix/port] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -17,8 +17,8 @@
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/fix/port/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -94,7 +94,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'fix/port',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [fix/port] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      12.0
+// @version      12.1
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '12.0';
+    const VERSION = '12.1';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -3608,17 +3608,20 @@
         },
 
         runLibraryPluginInit(plugin) {
-            if (plugin.state && plugin.state.libInitialized) {
+            // Prefer the registered entry (has state); callers may pass the pre-register object
+            const registered = (plugin && plugin.id && this.get(plugin.id)) || plugin;
+            if (!registered) return;
+            if (registered.state && registered.state.libInitialized) {
                 return;
             }
             try {
-                if (plugin.init) plugin.init(plugin.state, Context);
+                if (registered.init) registered.init(registered.state, Context);
             } catch (e) {
-                Logger.error(`Error in library plugin ${plugin.id}:`, e);
+                Logger.error(`Error in library plugin ${registered.id}:`, e);
                 return;
             }
-            if (plugin.state) plugin.state.libInitialized = true;
-            Logger.log(`✓ Library plugin initialized: ${plugin.id}`);
+            if (registered.state) registered.state.libInitialized = true;
+            Logger.log(`✓ Library plugin initialized: ${registered.id}`);
         },
 
         runOpsDashboardPluginInit(plugin) {
@@ -3751,7 +3754,8 @@
                     plugin._isCore = true;
                     plugin._isLib = true;
                     PluginManager.register(plugin);
-                    PluginManager.runLibraryPluginInit(plugin);
+                    // register() stores a copy with initialized state; init must use that entry
+                    PluginManager.runLibraryPluginInit(PluginManager.get(plugin.id));
                     loadedLibraryNames.add(filename);
                     Logger.log(`✓ Loaded library: ${filename} v${loadedVersion}`);
                 } catch (err) {

--- a/plugins/archetypes/comp-use-revision/main/user-story-markdown.js
+++ b/plugins/archetypes/comp-use-revision/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/archetypes/comp-use-task-creation/main/user-story-markdown.js
+++ b/plugins/archetypes/comp-use-task-creation/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/archetypes/qa-comp-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-comp-use/main/request-revisions.js
@@ -28,7 +28,7 @@ const plugin = {
     id: 'requestRevisions',
     name: 'Request Revisions Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '6.0',
+    _version: '6.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -614,7 +614,9 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
+            const text = (span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '')
+                .replace(/^\[(?:C|X)\]\s*/i, '')
+                .trim();
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);

--- a/plugins/archetypes/qa-comp-use/main/user-story-markdown.js
+++ b/plugins/archetypes/qa-comp-use/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/archetypes/qa-tool-use/main/request-revisions.js
+++ b/plugins/archetypes/qa-tool-use/main/request-revisions.js
@@ -28,7 +28,7 @@ const plugin = {
     id: 'requestRevisions',
     name: '"Request Revisions" Modal Improvements',
     description: 'Improvements to the Request Revisions Workflow',
-    _version: '7.0',
+    _version: '7.1',
     enabledByDefault: true,
     phase: 'mutation',
     
@@ -512,7 +512,9 @@ const plugin = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
+            const text = (span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '')
+                .replace(/^\[(?:C|X)\]\s*/i, '')
+                .trim();
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);

--- a/plugins/archetypes/qa-tool-use/main/user-story-markdown.js
+++ b/plugins/archetypes/qa-tool-use/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/archetypes/tool-use-revision/main/user-story-markdown.js
+++ b/plugins/archetypes/tool-use-revision/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/archetypes/tool-use-task-creation-openclaw/main/user-story-markdown.js
+++ b/plugins/archetypes/tool-use-task-creation-openclaw/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/archetypes/tool-use-task-creation/main/user-story-markdown.js
+++ b/plugins/archetypes/tool-use-task-creation/main/user-story-markdown.js
@@ -1,0 +1,26 @@
+// ============= user-story-markdown.js =============
+// Thin wrapper: shared Context.userStoryMarkdown library.
+
+const plugin = {
+    id: 'userStoryMarkdown',
+    name: 'User Story Markdown',
+    description: 'Hide native User Story bodies and show markdown-rendered blue-framed replicas',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        styleInjected: false,
+        activationLogged: false,
+        missingLogged: false,
+        activeByBody: null
+    },
+
+    onMutation(state) {
+        const api = Context.userStoryMarkdown;
+        if (!api || typeof api.run !== 'function') return;
+        api.run(state, {
+            pluginId: this.id,
+            logTag: this.id
+        });
+    }
+};

--- a/plugins/core/main/ui-lib.js
+++ b/plugins/core/main/ui-lib.js
@@ -3,6 +3,7 @@
 
 const FLEET_UI_STYLE_ID = 'fleet-ui-styles';
 const FLEET_UI_SCOPED_STYLE_PREFIX = 'fleet-ui-btn-scope-';
+const FLEET_UI_USER_STORY_PROSE_STYLE_ID = 'fleet-ui-user-story-prose';
 
 const FLASH_PULSE_MS = 600;
 const FLASH_PULSE_EASING = 'cubic-bezier(0.22, 1, 0.36, 1)';
@@ -331,11 +332,57 @@ function fleetUiFlashTabSuccess(tabEl) {
     Logger.debug('ui-lib: tab pulse');
 }
 
+function fleetUiUserStoryProseCssText() {
+    const p = '[data-fleet-user-story-prose]';
+    return [
+        p + ' {',
+        '  font-size: 0.875rem;',
+        '  line-height: 1.5;',
+        '  color: inherit;',
+        '}',
+        p + ' > :first-child { margin-top: 0; }',
+        p + ' > :last-child { margin-bottom: 0; }',
+        p + ' p { margin: 0.4em 0; }',
+        p + ' h1, ' + p + ' h2, ' + p + ' h3, ' + p + ' h4, ' + p + ' h5 {',
+        '  font-weight: 600;',
+        '  line-height: 1.35;',
+        '  color: inherit;',
+        '  margin: 0.75em 0 0.35em;',
+        '}',
+        p + ' h1 { font-size: 1.15em; }',
+        p + ' h2 { font-size: 1.08em; }',
+        p + ' h3 { font-size: 1.02em; }',
+        p + ' h4, ' + p + ' h5 { font-size: 1em; }',
+        p + ' ul {',
+        '  margin: 0.4em 0;',
+        '  padding-left: 1.35em;',
+        '  list-style-type: disc;',
+        '}',
+        p + ' li {',
+        '  margin: 0.15em 0;',
+        '  display: list-item;',
+        '}',
+        p + ' strong { font-weight: 700; color: inherit; }',
+        p + ' code {',
+        '  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;',
+        '  font-size: 0.92em;',
+        '  padding: 0.1em 0.3em;',
+        '  border-radius: 0.25rem;',
+        '  background: color-mix(in srgb, currentColor 10%, transparent);',
+        '}',
+        p + ' a {',
+        '  color: var(--brand, #2563eb);',
+        '  text-decoration: underline;',
+        '  text-underline-offset: 2px;',
+        '}'
+    ].join('\n');
+}
+
 const plugin = {
     id: 'ui-lib',
     name: 'UI Lib',
     description: 'Shared UI tokens, button styles, spinners, and copy feedback',
-    _version: '2.4',
+    _version: '2.5',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -368,6 +415,18 @@ const plugin = {
             target.appendChild(style);
         }
 
+        function ensureUserStoryMarkdownStyles() {
+            ensureStyles();
+            if (document.getElementById(FLEET_UI_USER_STORY_PROSE_STYLE_ID)) return;
+            const style = document.createElement('style');
+            style.id = FLEET_UI_USER_STORY_PROSE_STYLE_ID;
+            style.textContent = fleetUiUserStoryProseCssText();
+            (document.head || document.documentElement).appendChild(style);
+            if (typeof CleanupRegistry !== 'undefined' && CleanupRegistry.registerElement) {
+                CleanupRegistry.registerElement(style);
+            }
+        }
+
         ensureStyles();
 
         Context.uiLib = {
@@ -382,6 +441,7 @@ const plugin = {
 
             ensureStyles,
             ensureButtonStyles,
+            ensureUserStoryMarkdownStyles,
             btnClass: fleetUiBtnClass,
             spinnerHtml: fleetUiSpinnerHtml,
             loadingDotsAttr: fleetUiLoadingDotsAttr,

--- a/plugins/libs/copy-verifier-output.js
+++ b/plugins/libs/copy-verifier-output.js
@@ -8,6 +8,11 @@ const COPY_BUTTON_MARKER = 'data-fleet-copy-verifier-output';
 const COPY_RAW_OUTPUT_MARKER = 'data-fleet-copy-verifier-raw-output';
 const RAW_OUTPUT_ROW_MARKER = 'data-fleet-copy-verifier-raw-row';
 const EPIC_CRITERION_LINE_RE = /^\[C\]\s+((?:\[NICE\]\s+)?.+:\s+(0\.0|1\.0)\/1\.0\s+—\s+.+)$/;
+const VERIFIER_CHECK_PREFIX_RE = /^\[(?:C|X)\]\s*/i;
+
+function stripVerifierCheckPrefix(text) {
+    return String(text || '').replace(VERIFIER_CHECK_PREFIX_RE, '').trim();
+}
 
 function markdownFenceFor(content) {
     let maxRun = 0;
@@ -28,7 +33,7 @@ const CopyVerifierOutputApi = {
     name: 'Copy Verifier Output',
     description:
         'Add a copy button after Stdout or Score; when checklist Raw Output is expanded, a copy icon beside Raw Output copies the raw pre text',
-    _version: '5.0',
+    _version: '5.1',
     enabledByDefault: true,
     phase: 'mutation',
 
@@ -447,8 +452,12 @@ const CopyVerifierOutputApi = {
         const pct = total ? Math.round((passCount / total) * 100) : 0;
         lines.push(`## ${label}: ${passCount}/${total} (${pct}%)`);
         const sections = [];
-        const failures = criteria.filter((c) => c.score === '0.0').map((c) => `❌ ${c.line}`);
-        const successes = criteria.filter((c) => c.score === '1.0').map((c) => `✅ ${c.line}`);
+        const failures = criteria
+            .filter((c) => c.score === '0.0')
+            .map((c) => `❌ ${stripVerifierCheckPrefix(c.line)}`);
+        const successes = criteria
+            .filter((c) => c.score === '1.0')
+            .map((c) => `✅ ${stripVerifierCheckPrefix(c.line)}`);
         if (failures.length > 0) {
             sections.push({ label: 'Failures', items: failures });
         }
@@ -525,7 +534,9 @@ const CopyVerifierOutputApi = {
             if (!svg) continue;
             const cls = svg.getAttribute('class') || '';
             const span = row.querySelector(':scope > span');
-            const text = span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : '';
+            const text = stripVerifierCheckPrefix(
+                span ? String(span.textContent || '').replace(/\s+/g, ' ').trim() : ''
+            );
             if (!text) continue;
             if (cls.includes('text-emerald')) {
                 successes.push(text);
@@ -787,7 +798,7 @@ const plugin = {
     id: 'copyVerifierOutputLib',
     name: 'Copy Verifier Output (library)',
     description: 'Shared API for copying verifier expected/actual output',
-    _version: '5.0',
+    _version: '5.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/libs/user-story-markdown.js
+++ b/plugins/libs/user-story-markdown.js
@@ -7,6 +7,7 @@ const REPLICA_MARKER = 'data-fleet-user-story-replica';
 const PROSE_ATTR = 'data-fleet-user-story-prose';
 const LABEL_TEXT = 'User Story';
 const TASK_INSTRUCTIONS_RE = /^\s*Task Instructions\s*$/i;
+const SCENARIO_INTRO_RE = /Write a problem inspired by the following scenario/i;
 
 const MODAL_FRAME_CLASSES = [
     'mt-1',
@@ -27,6 +28,13 @@ const MODAL_FRAME_CLASSES = [
 
 const EMBEDDED_BODY_CLASSES = [
     'mt-1',
+    'text-sm',
+    'text-blue-700',
+    'dark:text-blue-300'
+].join(' ');
+
+const CREATION_EMBEDDED_BODY_CLASSES = [
+    'mt-2',
     'text-sm',
     'text-blue-700',
     'dark:text-blue-300'
@@ -146,9 +154,39 @@ const UserStoryMarkdownApi = {
         return bodies;
     },
 
+    isBlueStoryBox(el) {
+        if (!el || !el.className) return false;
+        const cls = String(el.className);
+        return /\bborder-blue-200\b/.test(cls) && /\bbg-blue-50\b/.test(cls);
+    },
+
+    findCreationScenarioBodies(seen) {
+        const intros = document.querySelectorAll('p');
+        const bodies = [];
+        for (const intro of intros) {
+            if (!SCENARIO_INTRO_RE.test(this.normalizeLabelText(intro.textContent))) continue;
+
+            const blueBox = intro.closest('div.rounded-lg.border');
+            if (!blueBox || !this.isBlueStoryBox(blueBox)) continue;
+
+            const scope = intro.parentElement || blueBox;
+            const candidates = scope.querySelectorAll('p.whitespace-pre-wrap, div.whitespace-pre-wrap');
+            for (const body of candidates) {
+                if (body === intro) continue;
+                if (seen.has(body)) continue;
+                if (body.closest('[' + REPLICA_MARKER + '="true"]')) continue;
+                seen.add(body);
+                bodies.push(body);
+            }
+        }
+        return bodies;
+    },
+
     findBodies() {
         const seen = new Set();
-        return this.findLabeledBodies(seen).concat(this.findCreationInstructionBodies(seen));
+        return this.findLabeledBodies(seen)
+            .concat(this.findCreationInstructionBodies(seen))
+            .concat(this.findCreationScenarioBodies(seen));
     },
 
     getVariant(body) {
@@ -162,6 +200,9 @@ const UserStoryMarkdownApi = {
         }
         if (hasLeftAccent || hasBlueFill) {
             return 'modal';
+        }
+        if (/\bmt-2\b/.test(cls)) {
+            return 'creationEmbedded';
         }
         return 'embedded';
     },
@@ -182,9 +223,15 @@ const UserStoryMarkdownApi = {
             ['\u2018', '\u2019'],
             ["'", "'"]
         ];
-        for (const [open, close] of pairs) {
-            if (s.length >= 2 && s.startsWith(open) && s.endsWith(close)) {
-                return s.slice(open.length, s.length - close.length).trim();
+        let changed = true;
+        while (changed && s.length >= 2) {
+            changed = false;
+            for (const [open, close] of pairs) {
+                if (s.startsWith(open) && s.endsWith(close)) {
+                    s = s.slice(open.length, s.length - close.length).trim();
+                    changed = true;
+                    break;
+                }
             }
         }
         return s;
@@ -268,6 +315,7 @@ const UserStoryMarkdownApi = {
         const variant = this.getVariant(body);
         if (variant === 'creationQuote') return CREATION_QUOTE_CLASSES;
         if (variant === 'modal') return MODAL_FRAME_CLASSES;
+        if (variant === 'creationEmbedded') return CREATION_EMBEDDED_BODY_CLASSES;
         return EMBEDDED_BODY_CLASSES;
     },
 
@@ -399,7 +447,7 @@ const plugin = {
     id: 'userStoryMarkdownLib',
     name: 'User Story Markdown (library)',
     description: 'Shared API: hide native User Story bodies and show markdown replicas',
-    _version: '1.1',
+    _version: '1.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/libs/user-story-markdown.js
+++ b/plugins/libs/user-story-markdown.js
@@ -1,0 +1,360 @@
+// ============= user-story-markdown.js (library) =============
+// Hides native User Story blue bodies and injects blue-framed markdown replicas.
+
+const USER_STORY_STYLE_ID = 'fleet-user-story-markdown-hide';
+const ORIGINAL_MARKER = 'data-fleet-user-story-original';
+const REPLICA_MARKER = 'data-fleet-user-story-replica';
+const PROSE_ATTR = 'data-fleet-user-story-prose';
+const LABEL_TEXT = 'User Story';
+
+const MODAL_FRAME_CLASSES = [
+    'mt-1',
+    'rounded',
+    'border',
+    'border-l-4',
+    'border-blue-200',
+    'border-l-blue-300',
+    'bg-blue-50',
+    'p-3',
+    'text-sm',
+    'text-blue-700',
+    'dark:border-blue-800',
+    'dark:border-l-blue-600',
+    'dark:bg-blue-950/30',
+    'dark:text-blue-300'
+].join(' ');
+
+const EMBEDDED_BODY_CLASSES = [
+    'mt-1',
+    'text-sm',
+    'text-blue-700',
+    'dark:text-blue-300'
+].join(' ');
+
+const UserStoryMarkdownApi = {
+    ensureHideStyles(state) {
+        if (state.styleInjected || document.getElementById(USER_STORY_STYLE_ID)) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = USER_STORY_STYLE_ID;
+        style.textContent = [
+            '[' + ORIGINAL_MARKER + '="true"] {',
+            '  position: absolute !important;',
+            '  width: 1px !important;',
+            '  height: 1px !important;',
+            '  overflow: hidden !important;',
+            '  clip: rect(0,0,0,0) !important;',
+            '  white-space: nowrap !important;',
+            '  border: 0 !important;',
+            '  padding: 0 !important;',
+            '  margin: 0 !important;',
+            '  pointer-events: none !important;',
+            '  user-select: none !important;',
+            '}'
+        ].join('\n');
+        (document.head || document.documentElement).appendChild(style);
+        if (typeof CleanupRegistry !== 'undefined' && CleanupRegistry.registerElement) {
+            CleanupRegistry.registerElement(style);
+        }
+        state.styleInjected = true;
+    },
+
+    ensureProseStyles() {
+        if (Context.uiLib && typeof Context.uiLib.ensureUserStoryMarkdownStyles === 'function') {
+            Context.uiLib.ensureUserStoryMarkdownStyles();
+        }
+    },
+
+    normalizeLabelText(text) {
+        return String(text || '').replace(/\s+/g, ' ').trim();
+    },
+
+    isUserStoryLabel(el) {
+        if (!el) return false;
+        return this.normalizeLabelText(el.textContent) === LABEL_TEXT;
+    },
+
+    findBodyForLabel(label) {
+        if (!label) return null;
+        const parent = label.parentElement;
+        if (!parent) return null;
+
+        let sibling = label.nextElementSibling;
+        while (sibling) {
+            if (sibling.getAttribute && sibling.getAttribute(REPLICA_MARKER) === 'true') {
+                sibling = sibling.nextElementSibling;
+                continue;
+            }
+            if (sibling.matches && sibling.matches('.whitespace-pre-wrap')) {
+                return sibling;
+            }
+            sibling = sibling.nextElementSibling;
+        }
+
+        const nested = parent.querySelector('.whitespace-pre-wrap');
+        if (nested && !nested.closest('[' + REPLICA_MARKER + '="true"]')) {
+            return nested;
+        }
+        return null;
+    },
+
+    findBodies() {
+        const labels = document.querySelectorAll('label, span');
+        const bodies = [];
+        const seen = new Set();
+        for (const el of labels) {
+            if (!this.isUserStoryLabel(el)) continue;
+            const body = this.findBodyForLabel(el);
+            if (!body || seen.has(body)) continue;
+            seen.add(body);
+            bodies.push(body);
+        }
+        return bodies;
+    },
+
+    isModalVariant(body) {
+        const cls = body.className || '';
+        return /\bborder-l-4\b/.test(cls) || /\bborder-blue-200\b/.test(cls);
+    },
+
+    escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    },
+
+    stripWrappingQuotes(text) {
+        let s = String(text || '').trim();
+        const pairs = [
+            ['\u201C', '\u201D'],
+            ['"', '"'],
+            ['\u2018', '\u2019'],
+            ["'", "'"]
+        ];
+        for (const [open, close] of pairs) {
+            if (s.length >= 2 && s.startsWith(open) && s.endsWith(close)) {
+                return s.slice(open.length, s.length - close.length).trim();
+            }
+        }
+        return s;
+    },
+
+    processInlines(escapedLine) {
+        let s = escapedLine;
+        s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+        s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, href) => {
+            const safeHref = /^(https?:|mailto:|\/|#)/i.test(href) ? href : '#';
+            return '<a href="' + safeHref + '" target="_blank" rel="noopener noreferrer">' + text + '</a>';
+        });
+        s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+        return s;
+    },
+
+    markdownToHtml(md) {
+        const raw = this.stripWrappingQuotes(md);
+        if (!raw) return '';
+        const lines = raw.split(/\r?\n/);
+        const out = [];
+        let inList = false;
+
+        const closeList = () => {
+            if (inList) {
+                out.push('</ul>');
+                inList = false;
+            }
+        };
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const trimmed = line.trim();
+            if (trimmed === '') {
+                closeList();
+                continue;
+            }
+
+            const h4 = /^####\s+(.+)$/.exec(trimmed);
+            const h3 = /^###\s+(.+)$/.exec(trimmed);
+            const h2 = /^##\s+(.+)$/.exec(trimmed);
+            const h1 = /^#\s+(.+)$/.exec(trimmed);
+            const ul = /^-\s+(.+)$/.exec(trimmed);
+
+            if (h1 || h2 || h3 || h4) {
+                closeList();
+                const content = this.processInlines(this.escapeHtml((h1 || h2 || h3 || h4)[1]));
+                if (h1) out.push('<h1>' + content + '</h1>');
+                else if (h2) out.push('<h2>' + content + '</h2>');
+                else if (h3) out.push('<h3>' + content + '</h3>');
+                else out.push('<h4>' + content + '</h4>');
+                continue;
+            }
+
+            if (ul) {
+                if (!inList) {
+                    inList = true;
+                    out.push('<ul>');
+                }
+                out.push('<li>' + this.processInlines(this.escapeHtml(ul[1])) + '</li>');
+                continue;
+            }
+
+            closeList();
+            out.push('<p>' + this.processInlines(this.escapeHtml(trimmed)) + '</p>');
+        }
+        closeList();
+        return out.join('');
+    },
+
+    replicaClassName(body) {
+        if (this.isModalVariant(body)) {
+            return MODAL_FRAME_CLASSES;
+        }
+        return EMBEDDED_BODY_CLASSES;
+    },
+
+    syncReplica(original, replica) {
+        if (!original || !replica) return;
+        const next = original.textContent || '';
+        if (replica.dataset.fleetUserStorySource === next) return;
+        replica.dataset.fleetUserStorySource = next;
+        replica.innerHTML = this.markdownToHtml(next);
+    },
+
+    detachObserver(entry) {
+        if (entry && entry.observer) {
+            entry.observer.disconnect();
+            entry.observer = null;
+        }
+    },
+
+    attachObserver(original, replica, entry) {
+        if (entry.observer && entry.source === original) return;
+        this.detachObserver(entry);
+        const self = this;
+        const observer = new MutationObserver(() => {
+            self.syncReplica(original, replica);
+        });
+        observer.observe(original, {
+            characterData: true,
+            childList: true,
+            subtree: true
+        });
+        if (typeof CleanupRegistry !== 'undefined' && CleanupRegistry.registerObserver) {
+            CleanupRegistry.registerObserver(observer);
+        }
+        entry.observer = observer;
+        entry.source = original;
+        entry.replica = replica;
+    },
+
+    ensureReplica(body, state, logTag) {
+        body.setAttribute(ORIGINAL_MARKER, 'true');
+
+        let replica = body.nextElementSibling;
+        if (!replica || replica.getAttribute(REPLICA_MARKER) !== 'true') {
+            replica = document.createElement('div');
+            replica.setAttribute(REPLICA_MARKER, 'true');
+            replica.setAttribute(PROSE_ATTR, '');
+            replica.setAttribute('data-fleet-plugin', logTag);
+            body.insertAdjacentElement('afterend', replica);
+        }
+
+        replica.className = this.replicaClassName(body);
+        replica.setAttribute(PROSE_ATTR, '');
+        this.syncReplica(body, replica);
+
+        let entry = state.activeByBody.get(body);
+        if (!entry) {
+            entry = { observer: null, source: null, replica: null };
+            state.activeByBody.set(body, entry);
+        }
+        this.attachObserver(body, replica, entry);
+    },
+
+    teardownBody(body, entry) {
+        this.detachObserver(entry);
+        if (body && body.getAttribute(ORIGINAL_MARKER) === 'true') {
+            body.removeAttribute(ORIGINAL_MARKER);
+        }
+        const replica = body && body.nextElementSibling;
+        if (replica && replica.getAttribute(REPLICA_MARKER) === 'true') {
+            replica.remove();
+        }
+    },
+
+    teardownAll(state, logTag) {
+        if (!state.activeByBody || state.activeByBody.size === 0) return;
+        for (const [body, entry] of state.activeByBody.entries()) {
+            this.teardownBody(body, entry);
+        }
+        state.activeByBody.clear();
+        if (state.activationLogged) {
+            Logger.debug(logTag + ': User Story markdown replicas cleared');
+            state.activationLogged = false;
+        }
+    },
+
+    run(state, options) {
+        const logTag = (options && (options.logTag || options.pluginId)) || 'userStoryMarkdown';
+
+        if (!state.activeByBody) {
+            state.activeByBody = new Map();
+        }
+
+        const bodies = this.findBodies();
+        if (bodies.length === 0) {
+            if (state.activeByBody.size > 0) {
+                this.teardownAll(state, logTag);
+            }
+            if (!state.missingLogged) {
+                Logger.debug(logTag + ': User Story body not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        this.ensureHideStyles(state);
+        this.ensureProseStyles();
+
+        const live = new Set(bodies);
+        for (const [body, entry] of Array.from(state.activeByBody.entries())) {
+            if (!live.has(body) || !body.isConnected) {
+                this.teardownBody(body, entry);
+                state.activeByBody.delete(body);
+            }
+        }
+
+        for (const body of bodies) {
+            this.ensureReplica(body, state, logTag);
+        }
+
+        if (!state.activationLogged) {
+            Logger.log(logTag + ': User Story markdown replicas active (' + bodies.length + ')');
+            state.activationLogged = true;
+        }
+    }
+};
+
+const plugin = {
+    id: 'userStoryMarkdownLib',
+    name: 'User Story Markdown (library)',
+    description: 'Shared API: hide native User Story bodies and show markdown replicas',
+    _version: '1.0',
+    phase: 'core',
+    enabledByDefault: true,
+    initialState: { registered: false },
+
+    init(state) {
+        Context.userStoryMarkdown = {
+            run: (s, options) => UserStoryMarkdownApi.run(s, options)
+        };
+        if (!state.registered) {
+            Logger.log('userStoryMarkdownLib: module registered (Context.userStoryMarkdown)');
+            state.registered = true;
+        }
+    }
+};

--- a/plugins/libs/user-story-markdown.js
+++ b/plugins/libs/user-story-markdown.js
@@ -6,6 +6,7 @@ const ORIGINAL_MARKER = 'data-fleet-user-story-original';
 const REPLICA_MARKER = 'data-fleet-user-story-replica';
 const PROSE_ATTR = 'data-fleet-user-story-prose';
 const LABEL_TEXT = 'User Story';
+const TASK_INSTRUCTIONS_RE = /^\s*Task Instructions\s*$/i;
 
 const MODAL_FRAME_CLASSES = [
     'mt-1',
@@ -27,6 +28,15 @@ const MODAL_FRAME_CLASSES = [
 const EMBEDDED_BODY_CLASSES = [
     'mt-1',
     'text-sm',
+    'text-blue-700',
+    'dark:text-blue-300'
+].join(' ');
+
+const CREATION_QUOTE_CLASSES = [
+    'border-l-4',
+    'border-blue-300',
+    'pl-4',
+    'text-base',
     'text-blue-700',
     'dark:text-blue-300'
 ].join(' ');
@@ -76,6 +86,11 @@ const UserStoryMarkdownApi = {
         return this.normalizeLabelText(el.textContent) === LABEL_TEXT;
     },
 
+    isTaskInstructionsHeading(el) {
+        if (!el) return false;
+        return TASK_INSTRUCTIONS_RE.test(this.normalizeLabelText(el.textContent));
+    },
+
     findBodyForLabel(label) {
         if (!label) return null;
         const parent = label.parentElement;
@@ -100,10 +115,9 @@ const UserStoryMarkdownApi = {
         return null;
     },
 
-    findBodies() {
+    findLabeledBodies(seen) {
         const labels = document.querySelectorAll('label, span');
         const bodies = [];
-        const seen = new Set();
         for (const el of labels) {
             if (!this.isUserStoryLabel(el)) continue;
             const body = this.findBodyForLabel(el);
@@ -114,9 +128,42 @@ const UserStoryMarkdownApi = {
         return bodies;
     },
 
-    isModalVariant(body) {
+    findCreationInstructionBodies(seen) {
+        const dialogs = document.querySelectorAll('[role="alertdialog"], [role="dialog"]');
+        const bodies = [];
+        for (const dialog of dialogs) {
+            const heading = dialog.querySelector('h2');
+            if (!heading || !this.isTaskInstructionsHeading(heading)) continue;
+
+            const quotes = dialog.querySelectorAll('blockquote.whitespace-pre-wrap');
+            for (const quote of quotes) {
+                if (seen.has(quote)) continue;
+                if (quote.closest('[' + REPLICA_MARKER + '="true"]')) continue;
+                seen.add(quote);
+                bodies.push(quote);
+            }
+        }
+        return bodies;
+    },
+
+    findBodies() {
+        const seen = new Set();
+        return this.findLabeledBodies(seen).concat(this.findCreationInstructionBodies(seen));
+    },
+
+    getVariant(body) {
         const cls = body.className || '';
-        return /\bborder-l-4\b/.test(cls) || /\bborder-blue-200\b/.test(cls);
+        const isBlockquote = body.tagName === 'BLOCKQUOTE';
+        const hasLeftAccent = /\bborder-l-4\b/.test(cls);
+        const hasBlueFill = /\bbg-blue-50\b/.test(cls) || /\bborder-blue-200\b/.test(cls);
+
+        if (isBlockquote || (hasLeftAccent && !hasBlueFill)) {
+            return 'creationQuote';
+        }
+        if (hasLeftAccent || hasBlueFill) {
+            return 'modal';
+        }
+        return 'embedded';
     },
 
     escapeHtml(s) {
@@ -151,6 +198,15 @@ const UserStoryMarkdownApi = {
             return '<a href="' + safeHref + '" target="_blank" rel="noopener noreferrer">' + text + '</a>';
         });
         s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+        // Autolink bare URLs only in text segments (not inside tags we just emitted).
+        s = s.split(/(<[^>]+>)/).map((part, idx) => {
+            if (idx % 2 === 1) return part;
+            return part.replace(/(https?:\/\/[^\s<]+)/g, (url) => {
+                const trimmed = url.replace(/[.,;:!?)]+$/, '');
+                const trailing = url.slice(trimmed.length);
+                return '<a href="' + trimmed + '" target="_blank" rel="noopener noreferrer">' + trimmed + '</a>' + trailing;
+            });
+        }).join('');
         return s;
     },
 
@@ -180,7 +236,7 @@ const UserStoryMarkdownApi = {
             const h3 = /^###\s+(.+)$/.exec(trimmed);
             const h2 = /^##\s+(.+)$/.exec(trimmed);
             const h1 = /^#\s+(.+)$/.exec(trimmed);
-            const ul = /^-\s+(.+)$/.exec(trimmed);
+            const ul = /^[-•]\s+(.+)$/.exec(trimmed);
 
             if (h1 || h2 || h3 || h4) {
                 closeList();
@@ -209,9 +265,9 @@ const UserStoryMarkdownApi = {
     },
 
     replicaClassName(body) {
-        if (this.isModalVariant(body)) {
-            return MODAL_FRAME_CLASSES;
-        }
+        const variant = this.getVariant(body);
+        if (variant === 'creationQuote') return CREATION_QUOTE_CLASSES;
+        if (variant === 'modal') return MODAL_FRAME_CLASSES;
         return EMBEDDED_BODY_CLASSES;
     },
 
@@ -343,7 +399,7 @@ const plugin = {
     id: 'userStoryMarkdownLib',
     name: 'User Story Markdown (library)',
     description: 'Shared API: hide native User Story bodies and show markdown replicas',
-    _version: '1.0',
+    _version: '1.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },


### PR DESCRIPTION
## Summary

Adds markdown rendering for User Story content across tool-use and computer-use creation, revision, and QA workflows, and fixes host library loading so shared libs and thin archetype wrappers both initialize correctly. Also cleans `[X]`/`[C]` status prefixes out of formatted verifier copy output.

## Changes

- Introduces a shared `user-story-markdown` library that hides native blue User Story bodies and injects matching blue-framed replicas with rendered markdown (headings, lists, links, code), including creation-page Task Instructions blockquotes and embedded bodies.
- Wires thin archetype wrappers on TU/CU creation (including OpenClaw), revision, and QA pages, with shared prose styles in `ui-lib`.
- Fixes library plugin init to use the registered entry (avoids crash when `state` is missing on the pre-register object) and ignores `_isLib` entries in filename dedupe so archetype wrappers that share a library filename still load.
- Strips leading `[X]`/`[C]` prefixes from checklist and epic criterion lines in Copy Verifier Output clipboard formatting.

## New plugins

| Plugin | Archetype(s) | Description |
|--------|--------------|-------------|
| `user-story-markdown.js` (library) | Shared (`libraries`) | Hide native User Story bodies and show markdown replicas |
| `user-story-markdown.js` | tool-use-task-creation, tool-use-task-creation-openclaw, tool-use-revision, comp-use-task-creation, comp-use-revision, qa-tool-use, qa-comp-use | Thin mutation wrappers for the shared library |

## Issues

Closes #231
