### PR TITLE
Fix Verifier chat transcript wipes and Retrieve Task list parsing

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.224",
+  "archetypesVersion": "14.225",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -212,8 +212,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "6.0",
-      "hash": "sha256-5a41c1d13782c55b374ebc2ddadccfe9b0f5af3a2f8bdfd8f1aad81486cec3ab",
+      "version": "6.1",
+      "hash": "sha256-cbefb045d6f14a7c2a4a7d14d96f27f4a2f67a922565702539aba61f36a5b981",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.223",
+  "archetypesVersion": "14.224",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -212,8 +212,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "5.19",
-      "hash": "sha256-af73a676ea0d28c718b5bd00c4822cbe8268128752d810b9bc666188089a60c1",
+      "version": "6.0",
+      "hash": "sha256-5a41c1d13782c55b374ebc2ddadccfe9b0f5af3a2f8bdfd8f1aad81486cec3ab",
       "log": false
     },
     {
@@ -236,8 +236,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.24",
-      "hash": "sha256-bd09e6d1d80bc1a8d7b1a4ebea096699a5eb8868c205a541c0f1861c5b336c38",
+      "version": "9.25",
+      "hash": "sha256-05bd00c19eb5478d2fb87f19751119d3e632cd242fe9eaf77e127057824c1808",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.225",
+  "archetypesVersion": "14.226",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -60,8 +60,8 @@
     },
     {
       "name": "ai-chat.js",
-      "version": "6.4",
-      "hash": "sha256-b24a0fa8fa5489df587ace183f69becc9945d7052fff4296a1f6a9b473234c54",
+      "version": "6.5",
+      "hash": "sha256-3941376899837286f40a77d28bd6507b3b6f3aa2314771a713aa31fc717647dd",
       "log": false
     },
     {
@@ -254,8 +254,8 @@
     },
     {
       "name": "verifier-fetcher.js",
-      "version": "7.0",
-      "hash": "sha256-37e60bc2d80797d5724d50919b1650055a94c195a23cda157e000bf7226468c3",
+      "version": "7.1",
+      "hash": "sha256-a8a40edf3553e3cfddc03ae5ba6893bc711c28462a80d05209c0be35cadcf957",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.14",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.219",
+  "archetypesVersion": "14.220",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -206,8 +206,8 @@
     },
     {
       "name": "search-output-left-pane.js",
-      "version": "5.2",
-      "hash": "sha256-f6b08d4c744dca9a9d26946ebf031314d010b5f2f4a737d60c5fbd3c8b8aac56",
+      "version": "5.3",
+      "hash": "sha256-8412f96f5bb3a71edeb8e5b7650f5e04a422f44e37e78bed66857310e867ae8c",
       "log": false
     },
     {
@@ -236,8 +236,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.23",
-      "hash": "sha256-99d0ee1cacc676b560b81d01eac6653a55c4e9c28a3ca12cf6a3f87b48ba8ae9",
+      "version": "9.24",
+      "hash": "sha256-bd09e6d1d80bc1a8d7b1a4ebea096699a5eb8868c205a541c0f1861c5b336c38",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.222",
+  "archetypesVersion": "14.223",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -206,8 +206,8 @@
     },
     {
       "name": "search-output-left-pane.js",
-      "version": "5.3",
-      "hash": "sha256-8412f96f5bb3a71edeb8e5b7650f5e04a422f44e37e78bed66857310e867ae8c",
+      "version": "5.4",
+      "hash": "sha256-e29a3b94dbb93970ea7558a41319ed1fcbaa697d3283a871846849b0b06bb556",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "12.4.14",
+  "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.220",
+  "archetypesVersion": "14.222",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -150,8 +150,8 @@
     },
     {
       "name": "vnc-helper.js",
-      "version": "2.3",
-      "hash": "sha256-2ecf941a82b97a179bd49849dccc48ee17aadb4c1f604197dd5cfa3d5a0ab547",
+      "version": "2.4",
+      "hash": "sha256-d45c8606a217dc156339723c376bd7bc83863e080eaa2480d03ecba7d6fd4f8b",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.14",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.218",
+  "archetypesVersion": "14.219",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -206,8 +206,8 @@
     },
     {
       "name": "search-output-left-pane.js",
-      "version": "5.1",
-      "hash": "sha256-c793af80ed4ae44df48f840de03cae56e0977a1bbbd4fa8af27fdb74a29b586f",
+      "version": "5.2",
+      "hash": "sha256-f6b08d4c744dca9a9d26946ebf031314d010b5f2f4a737d60c5fbd3c8b8aac56",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.226",
+  "archetypesVersion": "14.227",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -60,8 +60,8 @@
     },
     {
       "name": "ai-chat.js",
-      "version": "6.5",
-      "hash": "sha256-3941376899837286f40a77d28bd6507b3b6f3aa2314771a713aa31fc717647dd",
+      "version": "7.0",
+      "hash": "sha256-e179abad15940e63f2a6044001dbdb4b683afa4c8336dc0d41cd90b079d3c8e8",
       "log": false
     },
     {
@@ -254,8 +254,8 @@
     },
     {
       "name": "verifier-fetcher.js",
-      "version": "7.1",
-      "hash": "sha256-a8a40edf3553e3cfddc03ae5ba6893bc711c28462a80d05209c0be35cadcf957",
+      "version": "7.2",
+      "hash": "sha256-2f08f18ee6c5572c9185b4db2893f39b2c22d7752d69947df57ee5cc4311cbb6",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.15",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.227",
+  "archetypesVersion": "14.228",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -60,8 +60,8 @@
     },
     {
       "name": "ai-chat.js",
-      "version": "7.0",
-      "hash": "sha256-e179abad15940e63f2a6044001dbdb4b683afa4c8336dc0d41cd90b079d3c8e8",
+      "version": "7.1",
+      "hash": "sha256-26235dad8bdb53c8f5ec50fd0301a8c412b53402646c49dfe085ac620a0d5e09",
       "log": false
     },
     {
@@ -254,8 +254,8 @@
     },
     {
       "name": "verifier-fetcher.js",
-      "version": "7.2",
-      "hash": "sha256-2f08f18ee6c5572c9185b4db2893f39b2c22d7752d69947df57ee5cc4311cbb6",
+      "version": "7.3",
+      "hash": "sha256-b74dc437e15d3947190d12cc6fb5c130560cbce41a31c36d162d463330c5694a",
       "log": false
     },
     {

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      12.4.14
+// @version      12.4.15
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '12.4.14';
+    const VERSION = '12.4.15';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -593,35 +593,34 @@
             }
         }
 
+        // Solid inline flash only — this iframe bootstrap returns before Context/ui-lib
+        // exist, and these buttons use the `background` shorthand (not background-color).
+        const CLIP_BTN_BG = 'rgba(255,255,255,0.08)';
+
         function flashSuccess(btn) {
-            if (Context.buttonFeedback && typeof Context.buttonFeedback.flashSuccess === 'function') {
-                Context.buttonFeedback.flashSuccess(btn);
-                return;
-            }
+            if (!btn) return;
             if (btn._fosClipResetTimeout) clearTimeout(btn._fosClipResetTimeout);
             btn.style.transition = '';
-            btn.style.backgroundColor = 'rgb(34, 197, 94)';
+            btn.style.background = 'rgb(34, 197, 94)';
             btn.style.color = '#ffffff';
             btn._fosClipResetTimeout = setTimeout(() => {
                 btn._fosClipResetTimeout = null;
-                btn.style.backgroundColor = 'rgba(255,255,255,0.08)';
+                btn.style.background = CLIP_BTN_BG;
                 btn.style.color = '#f2f2f2';
             }, COPY_SUCCESS_MS);
         }
 
         function flashFailure(btn) {
-            if (Context.buttonFeedback && typeof Context.buttonFeedback.flashFailure === 'function') {
-                Context.buttonFeedback.flashFailure(btn);
-                return;
-            }
+            if (!btn) return;
             if (btn._fosClipResetTimeout) clearTimeout(btn._fosClipResetTimeout);
             const prevT = btn.style.transition;
             btn.style.transition = 'none';
-            btn.style.backgroundColor = 'rgb(239, 68, 68)';
+            btn.style.background = 'rgb(239, 68, 68)';
             btn.style.color = '#ffffff';
             void btn.offsetHeight;
-            btn.style.transition = 'background-color ' + COPY_FAIL_MS + 'ms ease-out, color ' + COPY_FAIL_MS + 'ms ease-out';
-            btn.style.backgroundColor = 'rgba(255,255,255,0.08)';
+            btn.style.transition =
+                'background ' + COPY_FAIL_MS + 'ms ease-out, color ' + COPY_FAIL_MS + 'ms ease-out';
+            btn.style.background = CLIP_BTN_BG;
             btn.style.color = '#f2f2f2';
             btn._fosClipResetTimeout = setTimeout(() => {
                 btn.style.transition = prevT || '';

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.4.15
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.4.14
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/search-output-left-pane.js
+++ b/plugins/core/main/search-output-left-pane.js
@@ -1930,8 +1930,7 @@ const searchOutputLeftPaneMethods = {
         const { parsed, invalid } = this._parseRetrieveInputList(raw);
         if (!parsed.length) {
             this._setRetrieveError(
-                invalid.length
-                    'Enter a valid task ID, version ID, task key, or Fleet URL.'
+                'Enter a valid task ID, version ID, task key, or Fleet URL.'
             );
             if (clipboardBtn && Context.buttonFeedback) {
                 Context.buttonFeedback.flashFailure(clipboardBtn);
@@ -2471,7 +2470,7 @@ const plugin = {
     id: 'search-output-left-pane',
     name: 'Search Output left pane',
     description: 'Worker Output Search tab — left pane',
-    _version: '5.3',
+    _version: '5.4',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-left-pane.js
+++ b/plugins/core/main/search-output-left-pane.js
@@ -424,7 +424,7 @@ const searchOutputLeftPaneMethods = {
                             </div>
                             <div id="wf-dash-section-retrieve" style="${section}">
                                 <div style="${label} font-weight: 600;">Retrieve Task</div>
-                                <p style="${hint} margin: 0; line-height: 1.45;">Enter a task ID, version ID, or task key — or a comma-separated list (spaces stripped). Pasted JSON arrays work too (brackets, quotes, and newlines are ignored). Full Fleet URLs are also accepted.</p>
+                                <p style="${hint} margin: 0; line-height: 1.45;">Enter a task ID, version ID, task key, or list of such items. URLs also accepted</p>
                                 <input type="text" id="wf-dash-retrieve-input" value="${retrieveInputVal}" autocomplete="off" placeholder="Task ID(s), key(s), URL(s), or pasted JSON list" style="${input}">
                                 <div id="wf-dash-retrieve-error" style="display: none; font-size: 11px; color: var(--destructive, #dc2626);"></div>
                                 ${this._resultsModeToggleHtml('retrieve')}
@@ -2452,7 +2452,7 @@ const plugin = {
     id: 'search-output-left-pane',
     name: 'Search Output left pane',
     description: 'Worker Output Search tab — left pane',
-    _version: '5.1',
+    _version: '5.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-left-pane.js
+++ b/plugins/core/main/search-output-left-pane.js
@@ -425,7 +425,7 @@ const searchOutputLeftPaneMethods = {
                             <div id="wf-dash-section-retrieve" style="${section}">
                                 <div style="${label} font-weight: 600;">Retrieve Task</div>
                                 <p style="${hint} margin: 0; line-height: 1.45;">Enter a task ID, version ID, task key, or list of such items. URLs also accepted</p>
-                                <input type="text" id="wf-dash-retrieve-input" value="${retrieveInputVal}" autocomplete="off" placeholder="Task ID(s), key(s), URL(s), or pasted JSON list" style="${input}">
+                                <textarea id="wf-dash-retrieve-input" rows="2" autocomplete="off" placeholder="Task ID(s), key(s), URL(s), or list" style="${input} resize: vertical; min-height: 36px; line-height: 1.4;">${retrieveInputVal}</textarea>
                                 <div id="wf-dash-retrieve-error" style="display: none; font-size: 11px; color: var(--destructive, #dc2626);"></div>
                                 ${this._resultsModeToggleHtml('retrieve')}
                                 <div style="display: flex; justify-content: flex-end; align-items: center; gap: 8px; margin-top: 4px;">
@@ -1746,17 +1746,39 @@ const searchOutputLeftPaneMethods = {
         return null;
     },
 
-    _parseRetrieveInputList(raw) {
-        // Strip JSON array chrome ([ ] " ') and turn newlines into commas so pasted
-        // lists like ["uuid-a", "uuid-b"] or multiline task_ids arrays work. Those
-        // characters never appear in UUIDs, task keys, or Fleet URLs.
-        const normalized = String(raw || '')
-            .replace(/[\[\]"']/g, '')
-            .replace(/[\r\n]+/g, ',');
-        const tokens = normalized
-            .split(',')
+    _tokenizeRetrieveInput(raw) {
+        // Strip JSON array chrome ([ ] " ') — never appears in UUIDs, task keys, or URLs.
+        const normalized = String(raw || '').replace(/[\[\]"']/g, '');
+        const primary = normalized
+            .split(/[,\r\n]+/)
             .map((t) => t.trim())
             .filter(Boolean);
+        const tokens = [];
+        for (const chunk of primary) {
+            if (/^https?:\/\//i.test(chunk)) {
+                tokens.push(chunk);
+                continue;
+            }
+            // Whitespace (text inputs / pasted blobs) and concatenated task_… keys.
+            const pieces = chunk.split(/\s+/).filter(Boolean);
+            for (const piece of pieces) {
+                if (/^https?:\/\//i.test(piece)) {
+                    tokens.push(piece);
+                    continue;
+                }
+                const taskHits = piece.match(/task_/g);
+                if (taskHits && taskHits.length > 1) {
+                    tokens.push(...piece.split(/(?=task_)/).map((s) => s.trim()).filter(Boolean));
+                } else {
+                    tokens.push(piece);
+                }
+            }
+        }
+        return tokens;
+    },
+
+    _parseRetrieveInputList(raw) {
+        const tokens = this._tokenizeRetrieveInput(raw);
         const parsed = [];
         const invalid = [];
         for (const token of tokens) {
@@ -1909,8 +1931,7 @@ const searchOutputLeftPaneMethods = {
         if (!parsed.length) {
             this._setRetrieveError(
                 invalid.length
-                    ? 'Enter a valid task ID, version ID, task key, or Fleet URL (comma-separated lists are supported).'
-                    : 'Enter a valid task ID, version ID, task key, or Fleet URL.'
+                    'Enter a valid task ID, version ID, task key, or Fleet URL.'
             );
             if (clipboardBtn && Context.buttonFeedback) {
                 Context.buttonFeedback.flashFailure(clipboardBtn);
@@ -1934,9 +1955,7 @@ const searchOutputLeftPaneMethods = {
         if (!parsed.length) {
             this._logDashApiSkip('retrieve-task', 'invalid input');
             this._setRetrieveError(
-                invalid.length
-                    ? 'Enter a valid task ID, version ID, task key, or Fleet URL (comma-separated lists are supported).'
-                    : 'Enter a valid task ID, version ID, task key, or Fleet URL.'
+                'Enter a valid task ID, version ID, task key, or Fleet URL.'
             );
             return;
         }
@@ -2452,7 +2471,7 @@ const plugin = {
     id: 'search-output-left-pane',
     name: 'Search Output left pane',
     description: 'Worker Output Search tab — left pane',
-    _version: '5.2',
+    _version: '5.3',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -1566,6 +1566,7 @@ const searchOutputResultsPaneMethods = {
 
         try {
             await this._runConcurrentWorkers(items, concurrency, async (item) => {
+                const taskKey = String(item && item.task && item.task.key || '').trim();
                 const taskId = String(item && item.task && item.task.id || '').trim();
                 try {
                     const fields = await this._fetchUserStoryFieldsForExportCached(item, runCache, opsTab);
@@ -1590,18 +1591,18 @@ const searchOutputResultsPaneMethods = {
                             scenarioTitle: scenarioTitle,
                             userStory: userStory,
                             humanAnnotatorInstructions: annotator,
-                            taskIds: []
+                            taskKeys: []
                         };
                         byFingerprint.set(fp, entry);
                     }
-                    if (taskId && entry.taskIds.indexOf(taskId) === -1) {
-                        entry.taskIds.push(taskId);
+                    if (taskKey && entry.taskKeys.indexOf(taskKey) === -1) {
+                        entry.taskKeys.push(taskKey);
                     }
                 } catch (err) {
                     stats.failed++;
                     Logger.warn(
                         'search-output-results-pane: user story export fetch failed — '
-                        + (taskId ? taskId.slice(0, 8) + '…' : '(no id)'),
+                        + (taskKey || (taskId ? taskId.slice(0, 8) + '…' : '(no key)')),
                         err
                     );
                 } finally {
@@ -1611,7 +1612,7 @@ const searchOutputResultsPaneMethods = {
             });
 
             const stories = Array.from(byFingerprint.values()).map((entry) => {
-                entry.taskIds.sort();
+                entry.taskKeys.sort();
                 return entry;
             });
             stories.sort((a, b) => {
@@ -6738,7 +6739,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '6.0',
+    _version: '6.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -359,6 +359,7 @@ const searchOutputResultsPaneMethods = {
                                 <button type="button" id="wf-dash-drop-included" title="May be helpful for performance" class="${this._dashBtnClass('basic', 'nav')}" style="display: none; flex-shrink: 0;">Drop Included Results</button>
                                 <button type="button" id="wf-dash-drop-excluded" title="May be helpful for performance" class="${this._dashBtnClass('basic', 'nav')}" style="display: none; flex-shrink: 0;">Drop Excluded Results</button>
                                 <button type="button" id="wf-dash-export-tasks-json" title="Export filtered task cards as JSON (dev builds only)" class="${this._dashBtnClass('basic', 'nav')}" style="display: none; flex-shrink: 0;">Export JSON</button>
+                                <button type="button" id="wf-dash-export-user-stories" title="Export unique user stories for filtered results" class="${this._dashBtnClass('basic', 'nav')}" style="display: none; flex-shrink: 0;">Export User Stories</button>
                                 <button type="button" id="wf-dash-results-retrieve-clipboard" title="Read task IDs from the clipboard and retrieve" class="${this._dashBtnClass('basic', 'nav')}" style="flex-shrink: 0;">Retrieve Clipboard</button>
                                 <button type="button" id="wf-dash-clear-results" class="${this._dashBtnClass('basic', 'nav')}" style="flex-shrink: 0;">Clear Results</button>
                                 <div data-wf-dash-results-header-actions style="display: inline-flex; align-items: center; gap: 8px; flex-shrink: 0;"></div>
@@ -1357,10 +1358,19 @@ const searchOutputResultsPaneMethods = {
     },
 
     _syncTaskExportUi() {
-        const btn = this._q('#wf-dash-export-tasks-json');
-        if (!btn) return;
+        const jsonBtn = this._q('#wf-dash-export-tasks-json');
+        const storiesBtn = this._q('#wf-dash-export-user-stories');
         if (!Context.isDevBranch) {
-            btn.style.display = 'none';
+            if (jsonBtn) jsonBtn.style.display = 'none';
+            if (storiesBtn) {
+                storiesBtn.style.display = 'none';
+                storiesBtn.disabled = true;
+                storiesBtn.removeAttribute('aria-busy');
+                if (storiesBtn.getAttribute('data-idle-label') == null) {
+                    storiesBtn.setAttribute('data-idle-label', 'Export User Stories');
+                }
+                storiesBtn.textContent = storiesBtn.getAttribute('data-idle-label') || 'Export User Stories';
+            }
             return;
         }
         const viewItems = this._getViewItems();
@@ -1369,8 +1379,280 @@ const searchOutputResultsPaneMethods = {
             && viewItems
             && viewItems.length > 0
             && !this._state.loading;
-        btn.style.display = show ? '' : 'none';
-        btn.disabled = !show;
+        if (jsonBtn) {
+            jsonBtn.style.display = show ? '' : 'none';
+            jsonBtn.disabled = !show;
+        }
+        if (storiesBtn) {
+            if (storiesBtn.getAttribute('data-idle-label') == null) {
+                storiesBtn.setAttribute('data-idle-label', 'Export User Stories');
+            }
+            const exporting = Boolean(this._state.userStoryExportRunning);
+            storiesBtn.style.display = show || exporting ? '' : 'none';
+            storiesBtn.disabled = !show || exporting;
+            if (exporting) {
+                storiesBtn.setAttribute('aria-busy', 'true');
+            } else {
+                storiesBtn.removeAttribute('aria-busy');
+                storiesBtn.textContent = storiesBtn.getAttribute('data-idle-label') || 'Export User Stories';
+            }
+        }
+    },
+
+    _setUserStoryExportProgress(done, total) {
+        const btn = this._q('#wf-dash-export-user-stories');
+        if (!btn) return;
+        if (btn.getAttribute('data-idle-label') == null) {
+            btn.setAttribute('data-idle-label', 'Export User Stories');
+        }
+        if (total > 0) {
+            btn.textContent = 'Exporting… ' + done + '/' + total;
+        } else {
+            btn.textContent = 'Exporting…';
+        }
+        btn.setAttribute('aria-busy', 'true');
+        btn.disabled = true;
+    },
+
+    _userStoryExportOmitAnnotator(userStory, annotator) {
+        const story = userStory != null ? String(userStory).trim() : '';
+        const instructions = annotator != null ? String(annotator).trim() : '';
+        if (!instructions) return null;
+        if (!story) return instructions;
+        if (instructions === story) return null;
+        if (story.indexOf(instructions) !== -1) return null;
+        return instructions;
+    },
+
+    _userStoryExportFingerprint(scenarioTitle, userStory, annotator) {
+        return [
+            scenarioTitle != null ? String(scenarioTitle) : '',
+            userStory != null ? String(userStory) : '',
+            annotator != null ? String(annotator) : ''
+        ].join('\u0000');
+    },
+
+    _userStoryExportHasContent(fields) {
+        if (!fields) return false;
+        return Boolean(
+            (fields.scenarioTitle && String(fields.scenarioTitle).trim())
+            || (fields.userStory && String(fields.userStory).trim())
+            || (fields.humanAnnotatorInstructions && String(fields.humanAnnotatorInstructions).trim())
+        );
+    },
+
+    _resolveUserStoryFieldsFromCache(itemId) {
+        const ui = this._getUserStoryUi(itemId);
+        if (ui.status !== 'loaded' || !this._userStoryHasContent(ui)) return null;
+        return {
+            scenarioTitle: ui.scenarioTitle != null ? String(ui.scenarioTitle).trim() || null : null,
+            humanAnnotatorInstructions: ui.humanAnnotatorInstructions != null
+                ? String(ui.humanAnnotatorInstructions).trim() || null
+                : null,
+            userStory: ui.userStory != null ? String(ui.userStory).trim() || null : null,
+            taskScenarioId: null,
+            fromCache: true
+        };
+    },
+
+    _normalizeFetchedUserStoryResult(result) {
+        const scenarioTitle = result && result.scenarioTitle != null
+            ? String(result.scenarioTitle).trim() || null
+            : null;
+        const humanAnnotatorInstructions = result && result.humanAnnotatorInstructions != null
+            ? String(result.humanAnnotatorInstructions).trim() || null
+            : null;
+        const userStory = result && result.userStory != null
+            ? String(result.userStory).trim() || null
+            : null;
+        const taskScenarioId = result && result.taskScenarioId != null
+            ? result.taskScenarioId
+            : null;
+        return {
+            scenarioTitle,
+            humanAnnotatorInstructions,
+            userStory,
+            taskScenarioId,
+            fromCache: false
+        };
+    },
+
+    async _fetchUserStoryFieldsForExportCached(item, runCache, opsTab) {
+        const itemId = String(item && item.id || '').trim();
+        const taskKey = String(item && item.task && item.task.key || '').trim();
+        const taskId = String(item && item.task && item.task.id || '').trim();
+        const taskCacheKey = taskId ? 'id:' + taskId : (taskKey ? 'key:' + taskKey : '');
+
+        if (taskCacheKey && runCache.byTask.has(taskCacheKey)) {
+            return runCache.byTask.get(taskCacheKey);
+        }
+
+        const cachedUi = itemId ? this._resolveUserStoryFieldsFromCache(itemId) : null;
+        if (cachedUi) {
+            if (taskCacheKey) runCache.byTask.set(taskCacheKey, cachedUi);
+            return cachedUi;
+        }
+
+        if (!taskKey && !taskId) {
+            const missing = { empty: true, reason: 'missing_task' };
+            if (taskCacheKey) runCache.byTask.set(taskCacheKey, missing);
+            return missing;
+        }
+
+        const result = await opsTab.fetchTaskUserStory({ taskKey, taskId });
+        const fields = this._normalizeFetchedUserStoryResult(result);
+        if (!this._userStoryExportHasContent(fields)) {
+            const empty = {
+                empty: true,
+                reason: result && result.reason ? result.reason : 'empty',
+                taskScenarioId: fields.taskScenarioId
+            };
+            if (taskCacheKey) runCache.byTask.set(taskCacheKey, empty);
+            return empty;
+        }
+        if (taskCacheKey) runCache.byTask.set(taskCacheKey, fields);
+        return fields;
+    },
+
+    _buildUserStoriesExportPayload(items, stories, stats) {
+        const identityPayload = this._buildTaskCardsExportPayload(items);
+        return {
+            schemaVersion: 1,
+            exportedAt: new Date().toISOString(),
+            source: {
+                filteredCount: items.length,
+                uniqueStories: stories.length,
+                fetched: stats.fetched,
+                skippedEmpty: stats.skippedEmpty,
+                failed: stats.failed,
+                fromCache: stats.fromCache
+            },
+            search: identityPayload.search,
+            view: identityPayload.view,
+            stories
+        };
+    },
+
+    async _exportFilteredUserStories() {
+        if (!Context.isDevBranch) {
+            Logger.warn('search-output-results-pane: user story export skipped — not a dev build');
+            return;
+        }
+        if (this._state.userStoryExportRunning) {
+            Logger.debug('search-output-results-pane: user story export already running');
+            return;
+        }
+        const items = this._getViewItems();
+        if (!items || items.length === 0) {
+            Logger.warn('search-output-results-pane: user story export skipped — no filtered items');
+            return;
+        }
+        const opsTab = Context.opsTab;
+        if (!opsTab || typeof opsTab.fetchTaskUserStory !== 'function') {
+            Logger.warn('search-output-results-pane: user story export skipped — ops module missing');
+            return;
+        }
+
+        this._state.userStoryExportRunning = true;
+        this._syncTaskExportUi();
+        const total = items.length;
+        let done = 0;
+        this._setUserStoryExportProgress(done, total);
+
+        const runCache = { byTask: new Map() };
+        const byFingerprint = new Map();
+        const stats = { fetched: 0, skippedEmpty: 0, failed: 0, fromCache: 0 };
+        const concurrency = Math.min(5, items.length);
+
+        try {
+            await this._runConcurrentWorkers(items, concurrency, async (item) => {
+                const taskId = String(item && item.task && item.task.id || '').trim();
+                try {
+                    const fields = await this._fetchUserStoryFieldsForExportCached(item, runCache, opsTab);
+                    if (fields && fields.fromCache) stats.fromCache++;
+                    else if (fields && !fields.empty) stats.fetched++;
+
+                    if (!fields || fields.empty || !this._userStoryExportHasContent(fields)) {
+                        stats.skippedEmpty++;
+                        return;
+                    }
+
+                    const scenarioTitle = fields.scenarioTitle;
+                    const userStory = fields.userStory;
+                    const annotator = this._userStoryExportOmitAnnotator(
+                        userStory,
+                        fields.humanAnnotatorInstructions
+                    );
+                    const fp = this._userStoryExportFingerprint(scenarioTitle, userStory, annotator);
+                    let entry = byFingerprint.get(fp);
+                    if (!entry) {
+                        entry = {
+                            scenarioTitle: scenarioTitle,
+                            userStory: userStory,
+                            humanAnnotatorInstructions: annotator,
+                            taskIds: []
+                        };
+                        byFingerprint.set(fp, entry);
+                    }
+                    if (taskId && entry.taskIds.indexOf(taskId) === -1) {
+                        entry.taskIds.push(taskId);
+                    }
+                } catch (err) {
+                    stats.failed++;
+                    Logger.warn(
+                        'search-output-results-pane: user story export fetch failed — '
+                        + (taskId ? taskId.slice(0, 8) + '…' : '(no id)'),
+                        err
+                    );
+                } finally {
+                    done++;
+                    this._setUserStoryExportProgress(done, total);
+                }
+            });
+
+            const stories = Array.from(byFingerprint.values()).map((entry) => {
+                entry.taskIds.sort();
+                return entry;
+            });
+            stories.sort((a, b) => {
+                const ta = String(a.scenarioTitle || '');
+                const tb = String(b.scenarioTitle || '');
+                if (ta !== tb) return ta.localeCompare(tb);
+                return String(a.userStory || '').localeCompare(String(b.userStory || ''));
+            });
+
+            if (stories.length === 0) {
+                Logger.warn(
+                    'search-output-results-pane: user story export finished with no stories — '
+                    + 'empty ' + stats.skippedEmpty + ', failed ' + stats.failed
+                );
+                return;
+            }
+
+            const payload = this._buildUserStoriesExportPayload(items, stories, stats);
+            const filename = 'user-stories-' + this._taskCardsExportIdentity(payload) + '-'
+                + this._dashExportTimestampSlug(payload.exportedAt) + '.json';
+            const json = JSON.stringify(payload, null, 2);
+            if (typeof this._downloadTextFile === 'function') {
+                this._downloadTextFile(filename, json, 'application/json;charset=utf-8');
+            } else {
+                Logger.error('search-output-results-pane: user story export failed — download helper unavailable');
+                return;
+            }
+            const summary = stories.length + ' unique · ' + items.length + ' item(s)'
+                + (stats.failed ? ' · ' + stats.failed + ' failed' : '')
+                + ' · ' + filename;
+            Logger.log('search-output-results-pane: user stories exported — ' + summary);
+            if (stats.failed) {
+                Logger.warn(
+                    'search-output-results-pane: user story export partial failures — '
+                    + stats.failed + ' of ' + items.length
+                );
+            }
+        } finally {
+            this._state.userStoryExportRunning = false;
+            this._syncTaskExportUi();
+        }
     },
 
     _exportFilteredTasksJson() {
@@ -6456,7 +6738,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '5.19',
+    _version: '6.0',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -5388,6 +5388,11 @@ function attachSearchOutputListeners(modal, dash) {
                 dash._exportFilteredTasksJson();
                 return;
             }
+            const userStoriesExportBtn = e.target.closest('#wf-dash-export-user-stories');
+            if (userStoriesExportBtn && modal.contains(userStoriesExportBtn)) {
+                void dash._exportFilteredUserStories();
+                return;
+            }
             const stopSearchBtn = e.target.closest('[data-wf-dash-stop-search]');
             if (stopSearchBtn && modal.contains(stopSearchBtn)) {
                 dash._requestStopSearchFetches();
@@ -5890,7 +5895,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.24',
+    _version: '9.25',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -5176,7 +5176,7 @@ function attachSearchOutputListeners(modal, dash) {
                 dash._validateRangeUi();
             });
             retrieveInput.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') {
+                if (e.key === 'Enter' && !e.shiftKey) {
                     e.preventDefault();
                     void dash._submitRetrieveTask();
                 }
@@ -5890,7 +5890,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.23',
+    _version: '9.24',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/verifier-fetcher.js
+++ b/plugins/core/main/verifier-fetcher.js
@@ -324,7 +324,9 @@ async function sendVerifierChatMessage(modal, userText) {
     }
 
     ensureVerifierChatPaneOpen(modal);
-    if (typeof chat.ensureMounted === 'function') {
+    // Already inside Deep Chat connect: remounting/rebinding clears the viewport.
+    // Match ratings follow-ups — only ensureMounted on cold programmatic sends.
+    if (!modal._wfAiChatFromHandler && typeof chat.ensureMounted === 'function') {
         try {
             await chat.ensureMounted(modal, state, verifierChatOpts());
         } catch (err) {
@@ -972,7 +974,7 @@ const plugin = {
     id: 'verifier-fetcher',
     name: 'Verifier Fetcher',
     description: 'Verifier code fetch tab for the Ops dashboard (Verifier Output + optional AI Decode/chat)',
-    _version: '7.2',
+    _version: '7.3',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -1006,6 +1008,6 @@ const plugin = {
                 if (ops && typeof ops.captureVerifierTabState === 'function') ops.captureVerifierTabState(modal);
             }
         });
-        Logger.log('verifier-fetcher: tab registered v7.2');
+        Logger.log('verifier-fetcher: tab registered v7.3');
     }
 };

--- a/plugins/core/main/verifier-fetcher.js
+++ b/plugins/core/main/verifier-fetcher.js
@@ -5,7 +5,13 @@
 // Diagnose is disabled and Chat shows the shared no-key overlay until
 // Context.aiOpenRouter.hasStoredKey() is true. Actual OpenRouter calls still
 // require Ops unlock to decrypt the key.
-// Chat transcript UI / streaming uses Context.aiChat (plugins/libs/ai-chat.js → Deep Chat).
+//
+// Chat uses Context.aiChat (plugins/libs/ai-chat.js → Deep Chat):
+// - Diagnose / programmatic send: displayContent + optional displayAttachment chip;
+//   bulk verifier/output goes in userContent (ai-chat paints via addMessage, not
+//   submitUserMessage). Open the pane without remounting/syncing history mid-send.
+// - Typed follow-ups: composer onSend → sendTurn (fromHandler / signals).
+// - Toolbar layout sync must not remount AI chat (see syncVerifierOutputToolbar).
 
 const VERIFIER_SCRATCHPAD_WIDTH_KEY = 'fleet-ux:verifier-fetcher-scratchpad-width';
 const VERIFIER_SCRATCHPAD_OPEN_KEY = 'fleet-ux:verifier-fetcher-scratchpad-open';
@@ -966,7 +972,7 @@ const plugin = {
     id: 'verifier-fetcher',
     name: 'Verifier Fetcher',
     description: 'Verifier code fetch tab for the Ops dashboard (Verifier Output + optional AI Decode/chat)',
-    _version: '7.1',
+    _version: '7.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -1000,6 +1006,6 @@ const plugin = {
                 if (ops && typeof ops.captureVerifierTabState === 'function') ops.captureVerifierTabState(modal);
             }
         });
-        Logger.log('verifier-fetcher: tab registered v7.1');
+        Logger.log('verifier-fetcher: tab registered v7.2');
     }
 };

--- a/plugins/core/main/verifier-fetcher.js
+++ b/plugins/core/main/verifier-fetcher.js
@@ -318,6 +318,14 @@ async function sendVerifierChatMessage(modal, userText) {
     }
 
     ensureVerifierChatPaneOpen(modal);
+    if (typeof chat.ensureMounted === 'function') {
+        try {
+            await chat.ensureMounted(modal, state, verifierChatOpts());
+        } catch (err) {
+            Logger.error('verifier-fetcher: chat mount failed before send', err);
+            return;
+        }
+    }
 
     const attachment = takeVerifierAttachmentForTurn(modal, state);
     const userContent = attachment
@@ -371,6 +379,15 @@ async function decodeVerifierOutput(modal) {
     }
 
     ensureVerifierChatPaneOpen(modal);
+    if (typeof chat.ensureMounted === 'function') {
+        try {
+            await chat.ensureMounted(modal, state, verifierChatOpts());
+        } catch (err) {
+            Logger.error('verifier-fetcher: chat mount failed before Diagnose', err);
+            if (Context.buttonFeedback && decodeBtn) Context.buttonFeedback.flashFailure(decodeBtn);
+            return;
+        }
+    }
     if (Context.buttonFeedback && decodeBtn) Context.buttonFeedback.flashSuccess(decodeBtn);
 
     const attachment = takeVerifierAttachmentForTurn(modal, state);
@@ -564,8 +581,10 @@ function restoreVerifierScratchpadState(modal) {
 
 function syncVerifierOutputToolbar(modal) {
     if (!modal) return;
+    // Layout only — do not remount/sync AI chat here. Ops calls this after every
+    // content-search UI refresh (including late highlight after Fetch), which
+    // would race Diagnose/send and wipe the live Deep Chat turn.
     applyVerifierScratchpadLayout(modal);
-    syncVerifierAiUi(modal);
 }
 
 function captureVerifierScratchpadTabState(modal) {
@@ -947,7 +966,7 @@ const plugin = {
     id: 'verifier-fetcher',
     name: 'Verifier Fetcher',
     description: 'Verifier code fetch tab for the Ops dashboard (Verifier Output + optional AI Decode/chat)',
-    _version: '7.0',
+    _version: '7.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -981,6 +1000,6 @@ const plugin = {
                 if (ops && typeof ops.captureVerifierTabState === 'function') ops.captureVerifierTabState(modal);
             }
         });
-        Logger.log('verifier-fetcher: tab registered v7.0');
+        Logger.log('verifier-fetcher: tab registered v7.1');
     }
 };

--- a/plugins/libs/ai-chat.js
+++ b/plugins/libs/ai-chat.js
@@ -1,18 +1,42 @@
 // ============= ai-chat.js (library) =============
 // Shared OpenRouter chat transcript UI + streaming controller, backed by
 // Deep Chat (<deep-chat>). Used by verifier-fetcher Diagnose/Chat, rating-
-// explain cards, and the Ops dashboard Chats tab.
+// explain cards, Search Chat, and the Ops dashboard Chats tab.
 //
 // Consumers supply feature-specific system prompts, mount markup, and
 // turn callbacks. This module owns Deep Chat mounting, message sync, and
 // chatCompletionStream orchestration.
+//
+// ## Turn modes (Context.aiChat.sendTurn)
+//
+// 1. Composer — user typed; Deep Chat connect sets `_wfAiChatFromHandler` and
+//    streams via Deep Chat signals. Consumer `onSend` may wrap sendTurn.
+// 2. Programmatic hidden (`hideInUi: true`) — bulk context (ratings overview,
+//    tool intermediates). No user bubble; AI painted with addMessage/updateMessage.
+// 3. Programmatic visible — short `displayContent` (+ optional `displayAttachment`
+//    chip). Same direct paint path as hidden; never submitUserMessage / _pendingTurn.
+//
+// ## Attachments
+//
+// `displayAttachment` is UI metadata (chip + lazy-expanded source). Full verifier
+// text for the model belongs in `userContent` / message.content, not forced into
+// the shadow DOM on every row sync.
+//
+// ## Consumer rules
+//
+// - Wire the composer once; open the pane without remounting mid-send.
+// - Bulk context → userContent (`hideInUi` when no bubble is needed).
+// - Short label → displayContent; chips → displayAttachment.
+// - Do not call renderMessages / force history sync around sendTurn.
+// - Layout/toolbar helpers must not remount AI chat.
 
-const AI_CHAT_VERSION = '6.5';
+const AI_CHAT_VERSION = '7.0';
 const PLUGIN_ID = 'ai-chat';
 const AI_CHAT_MAX_WIDTH_PX = 900;
 const AI_CHAT_TOOL_ROUND_TIMEOUT_MS = 90000;
 const AI_CHAT_NO_KEY_OVERLAY_ATTR = 'data-wf-ai-chat-no-key-overlay';
 const AI_CHAT_KEY_GATED_ATTR = 'data-wf-ai-chat-key-gated';
+const AI_CHAT_ATTACH_SOURCE_ATTR = 'data-wf-chat-attach-source-ready';
 const AI_CHAT_CALLBACK_KEYS = [
     'onSend', 'onStop', 'onExport', 'onTurnDone', 'getTurnOpts',
     'onToolActivity', 'executeTool',
@@ -649,6 +673,7 @@ function aiChatReconcileAttachment(row, attachment) {
         body.setAttribute('data-wf-chat-attach-body', '1');
         body.className = 'wf-chat-attach-body';
         details.appendChild(body);
+        details.setAttribute(AI_CHAT_ATTACH_SOURCE_ATTR, '0');
     }
     const bodyEl = details.querySelector('[data-wf-chat-attach-body="1"]');
     if (idBtn) {
@@ -687,8 +712,26 @@ function aiChatReconcileAttachment(row, attachment) {
             if (!idBtn.disabled) idBtn.disabled = true;
         }
     }
-    if (bodyEl && bodyEl.textContent !== att.source) {
-        bodyEl.textContent = att.source;
+    // Keep full source off the critical path: chip-only until the operator expands.
+    details._wfAttachSource = att.source;
+    if (details.getAttribute(AI_CHAT_ATTACH_SOURCE_ATTR) !== '1') {
+        details.setAttribute(AI_CHAT_ATTACH_SOURCE_ATTR, '0');
+        if (bodyEl && bodyEl.textContent) bodyEl.textContent = '';
+        if (!details._wfAttachToggleWired) {
+            details._wfAttachToggleWired = true;
+            details.addEventListener('toggle', () => {
+                if (!details.open) return;
+                const body = details.querySelector('[data-wf-chat-attach-body="1"]');
+                const source = details._wfAttachSource != null
+                    ? String(details._wfAttachSource)
+                    : '';
+                if (body && body.textContent !== source) body.textContent = source;
+                details.setAttribute(AI_CHAT_ATTACH_SOURCE_ATTR, '1');
+            });
+        }
+    } else if (details.open && bodyEl) {
+        const source = String(att.source || '');
+        if (bodyEl.textContent !== source) bodyEl.textContent = source;
     }
 }
 
@@ -1467,9 +1510,121 @@ function aiChatExportConversation(state, opts) {
 }
 
 /**
+ * Programmatic turn via direct Deep Chat paint (ratings-style), not submitUserMessage.
+ * hideInUi skips the user bubble; otherwise paints display text + attachment chips.
+ */
+async function aiChatProgrammaticPaintAndStream(el, state, opts) {
+    const o = opts.wireOpts;
+    const userContent = opts.userContent;
+    const displayContent = opts.displayContent;
+    const displayAttachment = opts.displayAttachment;
+    const hideInUi = !!opts.hideInUi;
+    const systemContent = opts.systemContent;
+    const apiMessagesOverride = opts.apiMessagesOverride;
+    const display = opts.display;
+
+    if (userContent) {
+        const userMsg = aiChatApplyUserMessageExtras(
+            { role: 'user', content: userContent, hideInUi: hideInUi || undefined },
+            { displayContent, displayAttachment, hideInUi }
+        );
+        state.messages.push(userMsg);
+    }
+    state.messages.push({ role: 'assistant', content: '', streaming: true });
+
+    if (!hideInUi && display) {
+        try {
+            el.addMessage({ role: 'user', text: String(display) });
+        } catch (err) {
+            Logger.warn(o.logTag + ': programmatic user bubble failed', err);
+        }
+        try { aiChatSyncRowEnhancements(el, o); } catch (_e) { /* ignore */ }
+    }
+
+    const apiMessages = apiMessagesOverride
+        || aiChatBuildApiMessages(state, { systemContent });
+    let uiText = '';
+    let aiIndex = -1;
+    const signals = {
+        onOpen() {
+            try { el.disableSubmitButton(true); } catch (_e) { /* ignore */ }
+        },
+        onClose() {
+            try { el.disableSubmitButton(false); } catch (_e) { /* ignore */ }
+        },
+        onResponse(response) {
+            if (!response) return;
+            if (response.error) {
+                try { el.addMessage({ error: String(response.error) }); } catch (_e) { /* ignore */ }
+                return;
+            }
+            const text = response.text != null ? String(response.text) : '';
+            uiText = response.overwrite ? text : (uiText + text);
+            try {
+                if (aiIndex < 0) {
+                    el.addMessage({ role: 'ai', text: uiText });
+                    const all = typeof el.getMessages === 'function' ? el.getMessages() : [];
+                    aiIndex = Array.isArray(all) ? all.length - 1 : 0;
+                } else {
+                    el.updateMessage({ role: 'ai', text: uiText }, aiIndex);
+                }
+            } catch (_e) { /* ignore */ }
+        },
+        stopClicked: { listener: null },
+    };
+
+    try {
+        const result = await aiChatRunStreamWithSignals(state, apiMessages, signals, o);
+        const full = result && result.text != null ? String(result.text) : '';
+        const generationId = result && result.generationId ? result.generationId : null;
+        const model = result && result.model ? result.model : null;
+        state.lastGenerationId = generationId;
+        state.lastModel = model;
+        const last = state.messages[state.messages.length - 1];
+        if (last && last.role === 'assistant') {
+            last.content = full || '';
+            last.streaming = false;
+        }
+        Logger.log(o.logTag + ': chat reply done (' + (full || '').length + ' chars'
+            + (generationId ? ' · gen ' + generationId : '') + ')');
+        if (o.onTurnDone) {
+            let userPreview = '';
+            if (displayContent != null) {
+                userPreview = String(displayContent).trim();
+            } else {
+                for (let i = state.messages.length - 1; i >= 0; i--) {
+                    const m = state.messages[i];
+                    if (m && m.role === 'user') {
+                        userPreview = String(
+                            m.displayContent != null ? m.displayContent : (m.content || '')
+                        ).trim();
+                        break;
+                    }
+                }
+            }
+            try {
+                o.onTurnDone({ generationId, model, userPreview, fullText: full || '' });
+            } catch (cbErr) {
+                Logger.warn(o.logTag + ': onTurnDone failed', cbErr);
+            }
+        }
+        try { aiChatSyncRowEnhancements(el, o); } catch (_e) { /* ignore */ }
+        return full || '';
+    } catch (err) {
+        const last = state.messages[state.messages.length - 1];
+        if (last && last.role === 'assistant') {
+            last.content = 'Error: ' + ((err && err.message) || String(err));
+            last.streaming = false;
+        }
+        Logger.error(o.logTag + ': chat failed: ' + ((err && err.message) || err));
+        throw err;
+    }
+}
+
+/**
  * Push user + streaming assistant, run stream, finalize last bubble.
- * When invoked from Deep Chat's connect handler (via onSend), reuses the
- * active signals. Otherwise submits through Deep Chat or streams directly.
+ * Composer path reuses Deep Chat connect signals; programmatic paths paint
+ * via addMessage (ratings-style) and never submitUserMessage.
  */
 async function aiChatSendTurn(root, state, opts) {
     const o = aiChatResolveOpts(Object.assign({}, state && state._wireOpts, opts));
@@ -1542,122 +1697,39 @@ async function aiChatSendTurn(root, state, opts) {
         }
     }
 
-    // Programmatic send
+    // Programmatic send (hidden or visible): direct paint, no submitUserMessage.
     const el = await aiChatEnsureMounted(root, state, o);
     const systemContent = opts && opts.systemContent != null ? opts.systemContent : null;
     const apiMessagesOverride = opts && opts.apiMessages;
-
-    // Hidden machine payloads: stream without a visible user bubble (matches prior UX).
-    if (hideInUi) {
-        if (userContent) {
-            const userMsg = aiChatApplyUserMessageExtras(
-                { role: 'user', content: userContent, hideInUi: true },
-                { displayContent, displayAttachment, hideInUi: true }
-            );
-            state.messages.push(userMsg);
-        }
-        state.messages.push({ role: 'assistant', content: '', streaming: true });
-        const apiMessages = apiMessagesOverride
-            || aiChatBuildApiMessages(state, { systemContent });
-        let assembled = '';
-        let uiText = '';
-        let aiIndex = -1;
-        const signals = {
-            onOpen() {
-                try { el.disableSubmitButton(true); } catch (_e) { /* ignore */ }
-            },
-            onClose() {
-                try { el.disableSubmitButton(false); } catch (_e) { /* ignore */ }
-            },
-            onResponse(response) {
-                if (!response) return;
-                if (response.error) {
-                    try { el.addMessage({ error: String(response.error) }); } catch (_e) { /* ignore */ }
-                    return;
-                }
-                const text = response.text != null ? String(response.text) : '';
-                uiText = response.overwrite ? text : (uiText + text);
-                try {
-                    if (aiIndex < 0) {
-                        el.addMessage({ role: 'ai', text: uiText });
-                        const all = typeof el.getMessages === 'function' ? el.getMessages() : [];
-                        aiIndex = Array.isArray(all) ? all.length - 1 : 0;
-                    } else {
-                        el.updateMessage({ role: 'ai', text: uiText }, aiIndex);
-                    }
-                } catch (_e) { /* ignore */ }
-            },
-            stopClicked: { listener: null },
-        };
-        try {
-            const result = await aiChatRunStreamWithSignals(state, apiMessages, signals, o);
-            const full = result && result.text != null ? String(result.text) : '';
-            assembled = full;
-            const generationId = result && result.generationId ? result.generationId : null;
-            const model = result && result.model ? result.model : null;
-            state.lastGenerationId = generationId;
-            state.lastModel = model;
-            const last = state.messages[state.messages.length - 1];
-            if (last && last.role === 'assistant') {
-                last.content = full || '';
-                last.streaming = false;
-            }
-            Logger.log(o.logTag + ': chat reply done (' + (full || '').length + ' chars'
-                + (generationId ? ' · gen ' + generationId : '') + ')');
-            if (o.onTurnDone) {
-                const userPreview = displayContent != null
-                    ? String(displayContent).trim()
-                    : '';
-                try {
-                    o.onTurnDone({ generationId, model, userPreview, fullText: full || '' });
-                } catch (cbErr) {
-                    Logger.warn(o.logTag + ': onTurnDone failed', cbErr);
-                }
-            }
-            return assembled || '';
-        } catch (err) {
-            const last = state.messages[state.messages.length - 1];
-            if (last && last.role === 'assistant') {
-                last.content = 'Error: ' + ((err && err.message) || String(err));
-                last.streaming = false;
-            }
-            Logger.error(o.logTag + ': chat failed: ' + ((err && err.message) || err));
-            throw err;
-        }
-    }
-
     const display = displayContent != null
         ? String(displayContent)
         : (userText || userContent);
+
+    if (hideInUi) {
+        return aiChatProgrammaticPaintAndStream(el, state, {
+            wireOpts: o,
+            userContent,
+            displayContent,
+            displayAttachment,
+            hideInUi: true,
+            systemContent,
+            apiMessagesOverride,
+            display,
+        });
+    }
+
     if (!String(display || '').trim() && !apiMessagesOverride) return null;
 
-    let resolvePending;
-    let rejectPending;
-    const pendingResult = new Promise((resolve, reject) => {
-        resolvePending = resolve;
-        rejectPending = reject;
-    });
-    state._pendingTurn = {
-        userText,
+    return aiChatProgrammaticPaintAndStream(el, state, {
+        wireOpts: o,
         userContent,
         displayContent,
         displayAttachment,
         hideInUi: false,
         systemContent,
-        apiMessages: apiMessagesOverride,
-        onTurnDone: o.onTurnDone,
-        _resolve: resolvePending,
-        _reject: rejectPending,
-    };
-    try {
-        el.submitUserMessage({ text: String(display) });
-    } catch (err) {
-        state._pendingTurn = null;
-        Logger.error(o.logTag + ': submitUserMessage failed', err);
-        rejectPending(err instanceof Error ? err : new Error(String(err)));
-        throw err;
-    }
-    return pendingResult;
+        apiMessagesOverride,
+        display,
+    });
 }
 
 function aiChatRunStream(root, state, apiMessages, opts) {
@@ -2234,7 +2306,7 @@ const plugin = {
     id: 'aiChatLib',
     name: 'AI Chat (library)',
     description: 'Shared OpenRouter chat transcript UI (Deep Chat) and streaming controller',
-    _version: '6.5',
+    _version: '7.0',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/libs/ai-chat.js
+++ b/plugins/libs/ai-chat.js
@@ -7,7 +7,7 @@
 // turn callbacks. This module owns Deep Chat mounting, message sync, and
 // chatCompletionStream orchestration.
 
-const AI_CHAT_VERSION = '6.4';
+const AI_CHAT_VERSION = '6.5';
 const PLUGIN_ID = 'ai-chat';
 const AI_CHAT_MAX_WIDTH_PX = 900;
 const AI_CHAT_TOOL_ROUND_TIMEOUT_MS = 90000;
@@ -865,6 +865,19 @@ function aiChatSetupCopyButtons(el, opts) {
     setTimeout(poll, 0);
 }
 
+/**
+ * Whether it is safe to reset Deep Chat's `history` from state.
+ * Skip while a programmatic/connect turn is in flight — assigning history
+ * races the just-painted user bubble and can wipe the live stream UI.
+ */
+function aiChatShouldSyncHistory(root, state) {
+    if (!state) return false;
+    if (state.streaming) return false;
+    if (state._pendingTurn) return false;
+    if (root && root._wfAiChatFromHandler) return false;
+    return true;
+}
+
 function aiChatSyncHistory(el, state) {
     if (!el) return;
     try {
@@ -1320,9 +1333,7 @@ function aiChatRenderMessages(root, state, opts) {
     const run = async () => {
         try {
             const el = await aiChatEnsureMounted(root, state, o);
-            // Do not reset Deep Chat history while a live connect/stream turn is
-            // in flight — that races the just-painted user bubble and wipes it.
-            if (!state.streaming && !root._wfAiChatFromHandler) {
+            if (aiChatShouldSyncHistory(root, state)) {
                 aiChatSyncHistory(el, state);
             }
             aiChatSetKeyGate(root, {
@@ -1373,7 +1384,9 @@ function aiChatWireComposer(root, stateOrOpts, maybeOpts) {
     }
 
     void aiChatEnsureMounted(root, state, o).then((el) => {
-        if (el) aiChatSyncHistory(el, state);
+        if (el && aiChatShouldSyncHistory(root, state)) {
+            aiChatSyncHistory(el, state);
+        }
         aiChatSetKeyGate(root, {
             mountSelector: o.mountSelector,
             state,
@@ -2221,7 +2234,7 @@ const plugin = {
     id: 'aiChatLib',
     name: 'AI Chat (library)',
     description: 'Shared OpenRouter chat transcript UI (Deep Chat) and streaming controller',
-    _version: '6.4',
+    _version: '6.5',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/libs/ai-chat.js
+++ b/plugins/libs/ai-chat.js
@@ -30,7 +30,7 @@
 // - Do not call renderMessages / force history sync around sendTurn.
 // - Layout/toolbar helpers must not remount AI chat.
 
-const AI_CHAT_VERSION = '7.0';
+const AI_CHAT_VERSION = '7.1';
 const PLUGIN_ID = 'ai-chat';
 const AI_CHAT_MAX_WIDTH_PX = 900;
 const AI_CHAT_TOOL_ROUND_TIMEOUT_MS = 90000;
@@ -931,6 +931,40 @@ function aiChatSyncHistory(el, state) {
 }
 
 /**
+ * If Deep Chat's viewport is empty but state still has visible messages,
+ * restore the view from state (state is source of truth after programmatic turns).
+ */
+function aiChatHealEmptyView(el, state, opts) {
+    if (!el || !state) return false;
+    const visible = aiChatVisibleStateMessages(state);
+    if (!visible.length) return false;
+    let deepCount = -1;
+    try {
+        if (typeof el.getMessages === 'function') {
+            const msgs = el.getMessages();
+            deepCount = Array.isArray(msgs) ? msgs.length : -1;
+        }
+    } catch (_e) {
+        deepCount = -1;
+    }
+    if (deepCount < 0) {
+        try {
+            const rows = aiChatMessageRows(el.shadowRoot);
+            deepCount = rows.length;
+        } catch (_e2) {
+            deepCount = -1;
+        }
+    }
+    if (deepCount > 0) return false;
+    const o = aiChatResolveOpts(opts || (state && state._wireOpts) || {});
+    Logger.log(o.logTag + ': healing empty deep-chat view from state ('
+        + visible.length + ' message(s))');
+    aiChatSyncHistory(el, state);
+    try { aiChatSyncRowEnhancements(el, o); } catch (_e3) { /* ignore */ }
+    return true;
+}
+
+/**
  * Build OpenRouter message list from transcript state.
  * Supports tool_calls on assistant messages and role:'tool' results.
  * @param {object} state
@@ -1289,6 +1323,9 @@ function aiChatBindElement(el, root, state, opts) {
     const o = aiChatResolveOpts(opts);
     el._wfAiChatRoot = root;
     el._wfAiChatState = state;
+    // Re-applying theme/connect mid-turn clears Deep Chat's viewport while
+    // state.messages stay intact (follow-up wipe). Bind chrome once per element.
+    if (el._wfAiChatBound === true) return;
     aiChatApplyTheme(el, o);
     if (o.placeholder) {
         el.textInput = Object.assign({}, el.textInput || {}, {
@@ -1304,6 +1341,7 @@ function aiChatBindElement(el, root, state, opts) {
         }
     };
     aiChatSetupCopyButtons(el, o);
+    el._wfAiChatBound = true;
 }
 
 async function aiChatEnsureMounted(root, state, opts) {
@@ -1609,6 +1647,7 @@ async function aiChatProgrammaticPaintAndStream(el, state, opts) {
             }
         }
         try { aiChatSyncRowEnhancements(el, o); } catch (_e) { /* ignore */ }
+        aiChatHealEmptyView(el, state, o);
         return full || '';
     } catch (err) {
         const last = state.messages[state.messages.length - 1];
@@ -1617,6 +1656,7 @@ async function aiChatProgrammaticPaintAndStream(el, state, opts) {
             last.streaming = false;
         }
         Logger.error(o.logTag + ': chat failed: ' + ((err && err.message) || err));
+        try { aiChatHealEmptyView(el, state, o); } catch (_e2) { /* ignore */ }
         throw err;
     }
 }
@@ -1685,6 +1725,7 @@ async function aiChatSendTurn(root, state, opts) {
                 }
             }
             try { aiChatSyncRowEnhancements(state._deepChat, o); } catch (_e) { /* ignore */ }
+            aiChatHealEmptyView(state._deepChat, state, o);
             return full || '';
         } catch (err) {
             const last = state.messages[state.messages.length - 1];
@@ -1693,6 +1734,7 @@ async function aiChatSendTurn(root, state, opts) {
                 last.streaming = false;
             }
             Logger.error(o.logTag + ': chat failed: ' + ((err && err.message) || err));
+            try { aiChatHealEmptyView(state._deepChat, state, o); } catch (_e2) { /* ignore */ }
             throw err;
         }
     }
@@ -2306,7 +2348,7 @@ const plugin = {
     id: 'aiChatLib',
     name: 'AI Chat (library)',
     description: 'Shared OpenRouter chat transcript UI (Deep Chat) and streaming controller',
-    _version: '7.0',
+    _version: '7.1',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/libs/vnc-helper.js
+++ b/plugins/libs/vnc-helper.js
@@ -40,7 +40,7 @@ const VncHelperApi = {
     name: 'VNC Helper',
     description:
         'VNC Helper modal with prompt cache, scratchpad, and clipboard bridge for noVNC sessions',
-    _version: '2.3',
+    _version: '2.4',
     enabledByDefault: true,
     phase: 'mutation',
     subOptions: [SHOW_PANEL_SUBOPTION],
@@ -502,12 +502,14 @@ const VncHelperApi = {
             bExtract.addEventListener('click', () => {
                 clipQueue = clipQueue
                     .then(async () => {
-                        const ok = await extractVmTextToOs();
+                        const ok = await extractVmTextToOs({ deferFocus: true });
                         if (ok) flashClipBtnSuccess(bExtract);
                         else flashClipBtnFailure(bExtract);
+                        focusVncTarget();
                     })
                     .catch(() => {
                         flashClipBtnFailure(bExtract);
+                        focusVncTarget();
                     });
             });
             bOverwrite.addEventListener('click', () => {
@@ -515,17 +517,20 @@ const VncHelperApi = {
                     .then(async () => {
                         try {
                             const t = await readClipboardText();
-                            const ok = await pushOsTextToVmClipboard(typeof t === 'string' ? t : '');
+                            const ok = await pushOsTextToVmClipboard(typeof t === 'string' ? t : '', {
+                                deferFocus: true
+                            });
                             if (ok) flashClipBtnSuccess(bOverwrite);
                             else flashClipBtnFailure(bOverwrite);
                         } catch (_eOw) {
                             toast('Overwrite failed: could not read system clipboard.');
                             flashClipBtnFailure(bOverwrite);
-                            focusVncTarget();
                         }
+                        focusVncTarget();
                     })
                     .catch(() => {
                         flashClipBtnFailure(bOverwrite);
+                        focusVncTarget();
                     });
             });
 
@@ -718,7 +723,7 @@ const plugin = {
     id: 'vncHelperLib',
     name: 'VNC Helper (library)',
     description: 'Shared API for VNC helper panel and clipboard helpers',
-    _version: '2.3',
+    _version: '2.4',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -776,7 +781,7 @@ function flashClipBtnFailure(btn) {
     btn.style.color = '#ffffff';
     void btn.offsetHeight;
     btn.style.transition =
-        'background-color ' + CLIP_BTN_FLASH_MS + 'ms ease-out, color ' + CLIP_BTN_FLASH_MS + 'ms ease-out';
+        'background ' + CLIP_BTN_FLASH_MS + 'ms ease-out, color ' + CLIP_BTN_FLASH_MS + 'ms ease-out';
     btn.style.background = CLIP_BTN_BG;
     btn.style.color = '#f2f2f2';
     btn._fleetClipFlashTimeout = setTimeout(() => {
@@ -1018,11 +1023,12 @@ async function runCopyVmToHost() {
 }
 
 /** Push plain text to the virtual machine via noVNC (no Ctrl+V — updates remote clipboard only). */
-async function pushOsTextToVmClipboard(text) {
+async function pushOsTextToVmClipboard(text, opts) {
+    const deferFocus = !!(opts && opts.deferFocus);
     const el = clipEl();
     if (!el) {
         toast('Overwrite failed: noVNC clipboard field (#noVNC_clipboard_text) not found.');
-        focusVncTarget();
+        if (!deferFocus) focusVncTarget();
         return false;
     }
     const merged = text;
@@ -1041,32 +1047,33 @@ async function pushOsTextToVmClipboard(text) {
         el.dispatchEvent(new Event('change', { bubbles: true }));
         el.dispatchEvent(new Event('input', { bubbles: true }));
     }
-    focusVncTarget();
     toast(`Virtual machine clipboard updated from this computer.\n\u2192 ${truncPreview(merged)}`);
+    if (!deferFocus) focusVncTarget();
     return true;
 }
 
-async function extractVmTextToOs() {
+async function extractVmTextToOs(opts) {
+    const deferFocus = !!(opts && opts.deferFocus);
     const el = clipEl();
     if (!el) {
         toast('Extract failed: noVNC clipboard field not found.');
-        focusVncTarget();
+        if (!deferFocus) focusVncTarget();
         return false;
     }
     const v = el.value || '';
     if (!v) {
         toast('Nothing to extract yet. Copy inside the virtual machine first, then try again.');
-        focusVncTarget();
+        if (!deferFocus) focusVncTarget();
         return false;
     }
     try {
         await navigator.clipboard.writeText(v);
         toast(`Copied virtual machine clipboard to this computer.\n\u2192 ${truncPreview(v)}`);
-        focusVncTarget();
+        if (!deferFocus) focusVncTarget();
         return true;
     } catch (e3) {
         toast('Extract failed: could not write to system clipboard.');
-        focusVncTarget();
+        if (!deferFocus) focusVncTarget();
         return false;
     }
 }


### PR DESCRIPTION
## Summary

Fixes Ops dashboard reliability around Verifier Fetcher / shared AI chat (Diagnose and follow-ups no longer wipe the transcript) and improves Worker Output Search Retrieve Task multi-item input handling, plus restores VNC clipboard success flash feedback.

## Changes

- **Shared AI chat (`ai-chat`)**: Programmatic turns (visible or hidden) now use the same direct Deep Chat paint path as Ratings Explain instead of `submitUserMessage`, skip history sync while a turn is in flight, heal an empty Deep Chat viewport from state when needed, and load attachment source text only when the chip is expanded.
- **Verifier Fetcher**: Diagnose mounts chat before sending; typed follow-ups skip remount/rebind while Deep Chat’s connect handler is active; toolbar layout sync no longer remounts AI chat on every Ops content-search refresh (which raced live turns and cleared the pane).
- **Retrieve Task**: Accepts newline- and `task_`-delimited lists (plus existing comma/URL/JSON chrome stripping), uses a compact multi-line textarea, and shortens the input hint. Also fixes a syntax error from the hint cleanup that prevented `search-output-left-pane` from parsing on load.
- **VNC clipboard**: Embedded fos iframe Extract/Overwrite flashes use a solid inline background (Context/ui-lib is not available in that bootstrap), and the external VNC Helper flashes before focus moves to the canvas so the pulse stays visible.
