### PR TITLE
Fix embedded FOS Overwrite via parent-hosted VM Clipboard

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "12.4.16",
+  "version": "12.4.17",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.231",
+  "archetypesVersion": "14.232",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -40,8 +40,8 @@
     },
     {
       "name": "fos-embedded-watcher.js",
-      "version": "1.2",
-      "hash": "sha256-ee7de3814c8be4f1e9625d6c5e48d84b90e4083ae800366c7695bc1c85b2cfd4",
+      "version": "1.3",
+      "hash": "sha256-30cc4df04e5ecb86fd332b656bd3b4ad14d7ed645f4e4efb88e92a78aabf59ce",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "12.4.15",
+  "version": "12.4.16",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.230",
+  "archetypesVersion": "14.231",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -40,8 +40,8 @@
     },
     {
       "name": "fos-embedded-watcher.js",
-      "version": "1.1",
-      "hash": "sha256-e4ea8afe3bf982acd2a5393e9bdfc0682e891e046dc205b7d3b2a9554dfa3aac",
+      "version": "1.2",
+      "hash": "sha256-ee7de3814c8be4f1e9625d6c5e48d84b90e4083ae800366c7695bc1c85b2cfd4",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "12.4.16",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.231",
+  "archetypesVersion": "14.232",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -156,8 +156,8 @@
     },
     {
       "name": "env-helper.js",
-      "version": "1.4",
-      "hash": "sha256-2d0be39619f5d5cf7549d94c8d001ecc9ab26b3e46083d8d4ad0a4d4fb85fce5",
+      "version": "1.5",
+      "hash": "sha256-04632a0df4356fa48ce7852cadb176189facca889a2b5097fe25c58556df1b05",
       "log": false
     }
   ],

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/fix-overwrite] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/fix-overwrite';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/fix-overwrite] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'feat/fix-overwrite';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/utils/test.sh
+++ b/dev/utils/test.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 #
-# test.sh — Create a test branch to simulate the main userscript update experience
+# test.sh — Create a test branch to simulate the main userscript update experience,
+#           or fork the current branch faithfully with --from-head / -f
 #
 # Usage:
-#   ./utils/test.sh [--dry-run] <new_branch_name>
+#   ./utils/test.sh [--dry-run] [--from-head|-f] <new_branch_name>
 #
 # Options:
-#   --dry-run  Print every change that would be made (fleet.user.js and git steps); do not modify anything.
+#   --dry-run       Print every change that would be made (fleet.user.js and git
+#                   steps); do not modify anything.
+#   --from-head, -f Keep the current branch's fleet.user.js (version and host
+#                   logic); only remap branch-bound fields via sync-branch-config.sh.
+#                   Default (without this flag) replaces fleet.user.js with main's.
 #
 # Arguments:
 #   new_branch_name   Name for the new branch. Must not already exist locally or
 #                     on origin, and cannot be "main".
 #
-# Effects:
+# Effects (default):
 #   1. Validates branch name (non-empty, not "main", valid ref format) and ensures
 #      it does not exist locally or on origin. Requires a clean working tree.
 #   2. Fetches origin/main. Creates the new branch from the current branch (so
@@ -26,8 +31,13 @@
 #      testing how users on the current main script would experience an update before
 #      releasing; install from the printed URL to find script-breaking issues.
 #
-# Use this to validate an upcoming main release: install the test-branch script,
-# use it as normal, then merge to main with publish.sh when satisfied.
+# Effects (--from-head / -f):
+#   Same as default except fleet.user.js is not replaced with main's copy; only
+#   branch-bound fields are remapped. Also prints the DEV-ID install URL.
+#
+# Use default mode to validate an upcoming main release: install the test-branch
+# script, use it as normal, then merge to main with publish.sh when satisfied.
+# Use --from-head / -f for a temporary copy of the current feature branch.
 #
 # Prerequisites: run from anywhere inside the repo; sync-branch-config.sh must exist
 # in the same directory (utils/). Working tree must be clean.
@@ -46,26 +56,52 @@ fi
 
 usage() {
   cat <<'EOF'
-Usage: test.sh [--dry-run] NEW_BRANCH_NAME
+Usage: test.sh [--dry-run] [--from-head|-f] NEW_BRANCH_NAME
 
   --dry-run       Print every change that would be made; do not modify anything.
+  --from-head, -f Keep current fleet.user.js; only remap branch config (no main replace).
   NEW_BRANCH_NAME Name for the new branch (must not already exist locally or on origin).
 
-Creates the branch from the current branch (modules from current branch), replaces
-fleet.user.js with main's version, syncs fleet.user.js for the new branch via
-sync-branch-config.sh, commits any changes, and pushes to origin. Install the script
-from the printed URL to test the update experience before publishing to main.
+Default: create branch from current HEAD, replace fleet.user.js with main's version,
+sync for the new branch name, commit, and push. Use to test the update experience
+before publishing to main.
+
+With --from-head / -f: create branch from current HEAD, preserve fleet.user.js
+content/version, sync branch-bound fields only, commit, and push.
 EOF
 }
 
 dry_run=false
+from_head=false
 branch=""
-if [[ "${1:-}" == "--dry-run" ]]; then
-  dry_run=true
-  branch="${2:-}"
-else
-  branch="${1:-}"
-fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    --from-head|-f)
+      from_head=true
+      shift
+      ;;
+    -*)
+      echo "[error] Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -n "$branch" ]]; then
+        echo "[error] Unexpected argument: $1" >&2
+        usage
+        exit 1
+      fi
+      branch="$1"
+      shift
+      ;;
+  esac
+done
+
 if [[ -z "${branch// }" ]]; then
   echo "[error] Branch name required (cannot be empty)"
   usage
@@ -97,44 +133,65 @@ if ! git -C "$root" diff --quiet || ! git -C "$root" diff --cached --quiet; then
   exit 1
 fi
 
+current_branch="$(git -C "$root" branch --show-current)"
+
 if [[ "$dry_run" == true ]]; then
-  echo "[info] Fetching main for dry-run..."
-  git -C "$root" fetch origin main
-  if ! git -C "$root" show origin/main:fleet.user.js >/dev/null 2>&1; then
-    echo "[error] fleet.user.js not found on origin/main"
-    exit 1
+  if [[ "$from_head" == true ]]; then
+    echo "[dry-run] Would create branch: $branch from current branch ($current_branch); keep fleet.user.js, then update branch config:"
+    "$sync_script" --dry-run --branch "$branch"
+    echo "[dry-run] Would run: git checkout -b $branch"
+    echo "[dry-run] Would run: $sync_script"
+    echo "[dry-run] Would run: git add ."
+    echo "[dry-run] Would run: git commit -m \"Sync branch config for $branch\""
+    echo "[dry-run] Would run: git push -u origin $branch"
+    url="$(cd "$root" && gh browse --no-browser)"
+    ghuser=$(echo "$url" | perl -nE 'say $1 if m{github\.com/([^/]+)}')
+    ghrepo=$(echo "$url" | perl -nE 'say $1 if m{'"$ghuser"'/([^/]+)(?:/|$)}')
+    echo "[dry-run] Would print DEV-ID install URL: https://raw.githubusercontent.com/$ghuser/$ghrepo/$branch/dev/fleet-dev-id.user.js"
+    echo "[dry-run] Would print install URL: https://raw.githubusercontent.com/$ghuser/$ghrepo/$branch/fleet.user.js"
+  else
+    echo "[info] Fetching main for dry-run..."
+    git -C "$root" fetch origin main
+    if ! git -C "$root" show origin/main:fleet.user.js >/dev/null 2>&1; then
+      echo "[error] fleet.user.js not found on origin/main"
+      exit 1
+    fi
+    tmp_fleet="$(mktemp)"
+    trap 'rm -f "$tmp_fleet"' EXIT
+    git -C "$root" show origin/main:fleet.user.js >"$tmp_fleet"
+    echo "[dry-run] Would create branch: $branch from current branch ($current_branch); would replace fleet.user.js with main's, then update fleet.user.js:"
+    "$sync_script" --dry-run --fleet "$tmp_fleet" --branch "$branch"
+    echo "[dry-run] Would run: git fetch origin main"
+    echo "[dry-run] Would run: git checkout -b $branch"
+    echo "[dry-run] Would run: git checkout origin/main -- fleet.user.js"
+    echo "[dry-run] Would run: $sync_script"
+    echo "[dry-run] Would run: git add ."
+    echo "[dry-run] Would run: git commit -m \"Sync branch config for $branch\""
+    echo "[dry-run] Would run: git push -u origin $branch"
+    url="$(cd "$root" && gh browse --no-browser)"
+    ghuser=$(echo "$url" | perl -nE 'say $1 if m{github\.com/([^/]+)}')
+    ghrepo=$(echo "$url" | perl -nE 'say $1 if m{'"$ghuser"'/([^/]+)(?:/|$)}')
+    echo "[dry-run] Would print install URL: https://raw.githubusercontent.com/$ghuser/$ghrepo/$branch/fleet.user.js"
   fi
-  tmp_fleet="$(mktemp)"
-  trap 'rm -f "$tmp_fleet"' EXIT
-  git -C "$root" show origin/main:fleet.user.js >"$tmp_fleet"
-  current_branch="$(git -C "$root" branch --show-current)"
-  echo "[dry-run] Would create branch: $branch from current branch ($current_branch); would replace fleet.user.js with main's, then update fleet.user.js:"
-  "$sync_script" --dry-run --fleet "$tmp_fleet" --branch "$branch"
-  echo "[dry-run] Would run: git fetch origin main"
-  echo "[dry-run] Would run: git checkout -b $branch"
-  echo "[dry-run] Would run: git checkout origin/main -- fleet.user.js"
-  echo "[dry-run] Would run: $sync_script"
-  echo "[dry-run] Would run: git add ."
-  echo "[dry-run] Would run: git commit -m \"Sync branch config for $branch\""
-  echo "[dry-run] Would run: git push -u origin $branch"
-  url="$(cd "$root" && gh browse --no-browser)"
-  ghuser=$(echo "$url" | perl -nE 'say $1 if m{github\.com/([^/]+)}')
-  ghrepo=$(echo "$url" | perl -nE 'say $1 if m{'"$ghuser"'/([^/]+)(?:/|$)}')
-  echo "[dry-run] Would print install URL: https://raw.githubusercontent.com/$ghuser/$ghrepo/$branch/fleet.user.js"
   exit 0
 fi
 
-echo "[info] Fetching main..."
-git -C "$root" fetch origin main
+if [[ "$from_head" != true ]]; then
+  echo "[info] Fetching main..."
+  git -C "$root" fetch origin main
+fi
 
-current_branch="$(git -C "$root" branch --show-current)"
 echo "[info] Creating branch: $branch from current branch ($current_branch)"
 git -C "$root" checkout -b "$branch"
 
-echo "[info] Replacing fleet.user.js with main's version..."
-git -C "$root" checkout origin/main -- fleet.user.js
+if [[ "$from_head" == true ]]; then
+  echo "[info] Keeping fleet.user.js from $current_branch (from-head); syncing branch config only..."
+else
+  echo "[info] Replacing fleet.user.js with main's version..."
+  git -C "$root" checkout origin/main -- fleet.user.js
+  echo "[info] Syncing branch config in fleet.user.js..."
+fi
 
-echo "[info] Syncing branch config in fleet.user.js..."
 (cd "$root" && "$sync_script")
 
 git -C "$root" add .
@@ -151,8 +208,17 @@ url="$(cd "$root" && gh browse --no-browser)"
 ghuser=$(echo "$url" | perl -nE 'say $1 if m{github\.com/([^/]+)}')
 ghrepo=$(echo "$url" | perl -nE 'say $1 if m{'"$ghuser"'/([^/]+)(?:/|$)}')
 MAIN_INSTALL_URL="https://raw.githubusercontent.com/$ghuser/$ghrepo/$branch/fleet.user.js"
+DEV_ID_INSTALL_URL="https://raw.githubusercontent.com/$ghuser/$ghrepo/$branch/dev/fleet-dev-id.user.js"
 
-echo "The purpose of this step is to test how users on the current main userscript would experience the changes before updating their script to the current version."
-echo "If the incoming update introduces script breaking errors, this is where those would be identified."
-echo "Install the test userscript from:"
-echo "$MAIN_INSTALL_URL"
+if [[ "$from_head" == true ]]; then
+  echo "Branch $branch was created from $current_branch with fleet.user.js preserved (branch config remapped)."
+  echo "Install DEV-ID userscript (raw):"
+  echo "$DEV_ID_INSTALL_URL"
+  echo "Install branch userscript (raw):"
+  echo "$MAIN_INSTALL_URL"
+else
+  echo "The purpose of this step is to test how users on the current main userscript would experience the changes before updating their script to the current version."
+  echo "If the incoming update introduces script breaking errors, this is where those would be identified."
+  echo "Install the test userscript from:"
+  echo "$MAIN_INSTALL_URL"
+fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -196,7 +196,7 @@ Scripts in `dev/utils/` automate branch creation, `fleet.user.js` sync, version 
 |--------|---------|
 | **checkout.sh** | Create a feature branch and sync `fleet.user.js` for that branch. Use when **starting** work on a feature. |
 | **push.sh** | Version-aware commit and push: bump versions for changed files if needed, run `update-versions.sh` and `compute-hashes.sh`, then commit and push. Use for **committing** on a branch. |
-| **test.sh** | Create a test branch and sync `fleet.user.js` for that branch. Use to **simulate** how main userscript users would experience an update before releasing. |
+| **test.sh** | Create a test branch and sync `fleet.user.js`. Default: simulate a main userscript update. `--from-head` / `-f`: faithful copy of the current branch (preserve `fleet.user.js`). |
 | **update-versions.sh** | Sync `archetypes.json` and `fleet.user.js` with plugin `_version` values; normalize fleet `@version`/const `VERSION`; bump `archetypesVersion`. Used by `push.sh`; can be run standalone. |
 | **compute-hashes.sh** | Compute SHA-256 hashes for all plugin files listed in `archetypes.json` and write them back. Run after `update-versions.sh`. |
 | **sync-branch-config.sh** | Align `fleet.user.js` with the current git branch. Used by `checkout.sh` and `test.sh`; safe to run by hand after switching branches. |
@@ -241,11 +241,12 @@ Scripts that touch `fleet.user.js` (checkout, test, sync-branch-config) ensure:
 - Runs `./dev/utils/update-versions.sh` and `./dev/utils/compute-hashes.sh` to sync archetypes and fleet, then `git add -A`, `git commit`, `git push` (only if there is something to commit). Default message: "push.sh auto commit at <date/time>".
 - Requires `jq`. Use for normal commits on a branch to keep versions in sync automatically.
 
-**test.sh** — `./dev/utils/test.sh [--dry-run] <new_branch_name>`
+**test.sh** — `./dev/utils/test.sh [--dry-run] [--from-head|-f] <new_branch_name>`
 
 - Requires clean working tree. Branch name must not be `main` and must not exist. Depends on `sync-branch-config.sh` in the same directory. `--dry-run` prints planned changes without modifying anything.
-- Fetches `origin/main`, creates a new branch from the **current** branch (so non-fleet files stay as on your branch), replaces `fleet.user.js` with `origin/main`'s copy, runs `sync-branch-config.sh` to update `fleet.user.js` for the new branch name, commits and pushes.
-- `test-update` is a **main-like branch**: hash verification is enforced, dev plugins are not loaded, and non-dev redirect is not shown. Use to validate an upcoming main release: install the test-branch script, use it as normal, then merge to main when satisfied.
+- **Default:** Fetches `origin/main`, creates a new branch from the **current** branch (so non-fleet files stay as on your branch), replaces `fleet.user.js` with `origin/main`'s copy, runs `sync-branch-config.sh` to update `fleet.user.js` for the new branch name, commits and pushes.
+- **`--from-head` / `-f`:** Creates a new branch from the current branch and keeps the current `fleet.user.js` (version and host logic). Only remaps branch-bound fields via `sync-branch-config.sh`, then commits and pushes. Prints both DEV-ID and branch install URLs. Use for a temporary copy of a feature branch.
+- `test-update` is a **main-like branch**: hash verification is enforced, dev plugins are not loaded, and non-dev redirect is not shown. Use (default mode) to validate an upcoming main release: install the test-branch script, use it as normal, then merge to main when satisfied.
 
 **update-versions.sh** — `./dev/utils/update-versions.sh [--dry-run] [options]`
 

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         [feat/fix-overwrite] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.4.16
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'feat/fix-overwrite',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.4.17
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      12.4.15
+// @version      12.4.16
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '12.4.15';
+    const VERSION = '12.4.16';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -694,9 +694,9 @@
             }
         }
 
-        async function runOverwrite(btn) {
+        async function runOverwrite(btn, readPromise) {
             try {
-                const t = await navigator.clipboard.readText();
+                const t = await (readPromise || navigator.clipboard.readText());
                 const ok = await pushOsTextToVmClipboard(typeof t === 'string' ? t : '');
                 if (ok) {
                     flashSuccess(btn);
@@ -706,7 +706,18 @@
                 }
             } catch (e) {
                 flashFailure(btn);
-                console.warn(EMBED_LOG + ': overwrite failed — could not read system clipboard', e);
+                const name = e && e.name ? String(e.name) : '';
+                if (name === 'NotAllowedError') {
+                    console.warn(
+                        EMBED_LOG +
+                            ': overwrite failed — clipboard read blocked (NotAllowedError). ' +
+                            'Cross-origin env iframes need clipboard-read on the iframe allow attribute, ' +
+                            'and the click must keep user activation.',
+                        e
+                    );
+                } else {
+                    console.warn(EMBED_LOG + ': overwrite failed — could not read system clipboard', e);
+                }
             }
         }
 
@@ -836,7 +847,16 @@
                 clipQueue = clipQueue.then(() => runExtract(bExtract)).catch(() => {});
             });
             bOverwrite.addEventListener('click', () => {
-                clipQueue = clipQueue.then(() => runOverwrite(bOverwrite)).catch(() => {});
+                // Start read under the user gesture; only serialize the VM push via clipQueue.
+                let readPromise;
+                try {
+                    readPromise = navigator.clipboard.readText();
+                } catch (eSync) {
+                    readPromise = Promise.reject(eSync);
+                }
+                clipQueue = clipQueue
+                    .then(() => runOverwrite(bOverwrite, readPromise))
+                    .catch(() => {});
             });
 
             btnRow.appendChild(bExtract);

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/fix-overwrite] Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.4.17
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/fix-overwrite/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/fix-overwrite',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      12.4.15
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/fix-overwrite] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      12.4.16
+// @version      12.4.17
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '12.4.16';
+    const VERSION = '12.4.17';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -569,19 +569,21 @@
 
     /**
      * Minimal bootstrap for FOS env iframes embedded on www.fleetai.com.
-     * Parent fos-embedded-watcher authorizes via postMessage; this injects a neutered clipboard panel only.
+     * Parent fos-embedded-watcher owns the VM Clipboard UI and system clipboard I/O;
+     * this child only pushes/pulls the noVNC buffer over postMessage.
      */
     function initFosEmbeddedMode() {
         const EMBED_LOG = '[Fleet UX Enhancer] fos-embedded';
-        const ROOT_ID = 'fleet-fos-embedded-clipboard';
         const NOVNC_CLIPBOARD_ID = 'noVNC_clipboard_text';
-        const COPY_SUCCESS_MS = 600;
-        const COPY_FAIL_MS = 600;
         const FLEET_PARENT_HOSTS = new Set(['www.fleetai.com', 'fleetai.com']);
+        const MSG_PUSH = 'fleet-fos-push-clipboard';
+        const MSG_PUSH_RESULT = 'fleet-fos-push-result';
+        const MSG_EXTRACT_REQ = 'fleet-fos-extract-request';
+        const MSG_EXTRACT_RESULT = 'fleet-fos-extract-result';
+        const MSG_EMBEDDED_READY = 'fleet-fos-embedded-ready';
 
         let fosAuthorized = false;
-        let bridgeStarted = false;
-        let bridgeDismissed = false;
+        let bridgeReady = false;
         let waitObserver = null;
         let clipQueue = Promise.resolve();
 
@@ -591,41 +593,6 @@
             } catch (_e) {
                 return false;
             }
-        }
-
-        // Solid inline flash only — this iframe bootstrap returns before Context/ui-lib
-        // exist, and these buttons use the `background` shorthand (not background-color).
-        const CLIP_BTN_BG = 'rgba(255,255,255,0.08)';
-
-        function flashSuccess(btn) {
-            if (!btn) return;
-            if (btn._fosClipResetTimeout) clearTimeout(btn._fosClipResetTimeout);
-            btn.style.transition = '';
-            btn.style.background = 'rgb(34, 197, 94)';
-            btn.style.color = '#ffffff';
-            btn._fosClipResetTimeout = setTimeout(() => {
-                btn._fosClipResetTimeout = null;
-                btn.style.background = CLIP_BTN_BG;
-                btn.style.color = '#f2f2f2';
-            }, COPY_SUCCESS_MS);
-        }
-
-        function flashFailure(btn) {
-            if (!btn) return;
-            if (btn._fosClipResetTimeout) clearTimeout(btn._fosClipResetTimeout);
-            const prevT = btn.style.transition;
-            btn.style.transition = 'none';
-            btn.style.background = 'rgb(239, 68, 68)';
-            btn.style.color = '#ffffff';
-            void btn.offsetHeight;
-            btn.style.transition =
-                'background ' + COPY_FAIL_MS + 'ms ease-out, color ' + COPY_FAIL_MS + 'ms ease-out';
-            btn.style.background = CLIP_BTN_BG;
-            btn.style.color = '#f2f2f2';
-            btn._fosClipResetTimeout = setTimeout(() => {
-                btn.style.transition = prevT || '';
-                btn._fosClipResetTimeout = null;
-            }, COPY_FAIL_MS);
         }
 
         function clipEl() {
@@ -649,13 +616,23 @@
             });
         }
 
+        function reply(event, payload) {
+            try {
+                if (event.source && typeof event.source.postMessage === 'function') {
+                    event.source.postMessage(payload, event.origin);
+                }
+            } catch (e) {
+                console.warn(EMBED_LOG + ': reply postMessage failed', e);
+            }
+        }
+
         async function pushOsTextToVmClipboard(text) {
             const el = clipEl();
             if (!el) {
-                console.warn(EMBED_LOG + ': overwrite failed — noVNC clipboard field missing');
+                console.warn(EMBED_LOG + ': push failed — noVNC clipboard field missing');
                 return false;
             }
-            const merged = text;
+            const merged = typeof text === 'string' ? text : '';
             const rfb = getRfb();
             el.value = merged;
             if (rfb && typeof rfb.clipboardPasteFrom === 'function') {
@@ -674,281 +651,22 @@
             return true;
         }
 
-        async function extractVmTextToOs() {
+        function readVmClipboardText() {
             const el = clipEl();
             if (!el) {
                 console.warn(EMBED_LOG + ': extract failed — noVNC clipboard field missing');
-                return false;
+                return null;
             }
             const v = el.value || '';
             if (!v) {
                 console.warn(EMBED_LOG + ': extract skipped — VM clipboard empty');
-                return false;
+                return '';
             }
-            try {
-                await navigator.clipboard.writeText(v);
-                return true;
-            } catch (e) {
-                console.warn(EMBED_LOG + ': extract failed — could not write system clipboard', e);
-                return false;
-            }
+            return v;
         }
 
-        async function runOverwrite(btn, readPromise) {
-            try {
-                const t = await (readPromise || navigator.clipboard.readText());
-                const ok = await pushOsTextToVmClipboard(typeof t === 'string' ? t : '');
-                if (ok) {
-                    flashSuccess(btn);
-                    console.log(EMBED_LOG + ': overwrite ok');
-                } else {
-                    flashFailure(btn);
-                }
-            } catch (e) {
-                flashFailure(btn);
-                const name = e && e.name ? String(e.name) : '';
-                if (name === 'NotAllowedError') {
-                    console.warn(
-                        EMBED_LOG +
-                            ': overwrite failed — clipboard read blocked (NotAllowedError). ' +
-                            'Cross-origin env iframes need clipboard-read on the iframe allow attribute, ' +
-                            'and the click must keep user activation.',
-                        e
-                    );
-                } else {
-                    console.warn(EMBED_LOG + ': overwrite failed — could not read system clipboard', e);
-                }
-            }
-        }
-
-        async function runExtract(btn) {
-            const ok = await extractVmTextToOs();
-            if (ok) {
-                flashSuccess(btn);
-                console.log(EMBED_LOG + ': extract ok');
-            } else {
-                flashFailure(btn);
-            }
-        }
-
-        function injectPanel() {
-            if (bridgeDismissed) {
-                return;
-            }
-            const old = document.getElementById(ROOT_ID);
-            if (old) {
-                old.remove();
-            }
-
-            const root = document.createElement('div');
-            root.id = ROOT_ID;
-            root.style.cssText =
-                'position:fixed;left:16px;bottom:16px;z-index:2147483646;' +
-                'min-width:220px;max-width:280px;padding:0;' +
-                'border-radius:10px;border:1px solid rgba(255,255,255,0.14);' +
-                'background:rgba(28,28,32,0.96);color:#f2f2f2;' +
-                'font:500 12px/1.4 system-ui,-apple-system,sans-serif;' +
-                'box-shadow:0 8px 32px rgba(0,0,0,0.45);user-select:none;';
-
-            const clipHeader = document.createElement('div');
-            clipHeader.style.cssText =
-                'display:flex;align-items:center;justify-content:space-between;' +
-                'padding:6px 8px 4px 12px;cursor:grab;';
-
-            const clipTitle = document.createElement('div');
-            clipTitle.textContent = 'VM Clipboard';
-            clipTitle.style.cssText =
-                'font-size:11px;font-weight:600;color:#b0b0b8;' +
-                'letter-spacing:0.03em;text-transform:uppercase;flex:1;min-width:0;';
-
-            const closeActions = document.createElement('div');
-            closeActions.style.cssText =
-                'display:flex;align-items:center;gap:4px;flex-shrink:0;';
-
-            const closeBtn = document.createElement('button');
-            closeBtn.type = 'button';
-            closeBtn.setAttribute('aria-label', 'Close VM Clipboard');
-            closeBtn.textContent = '\u00d7';
-            closeBtn.style.cssText =
-                'margin:0;padding:0 4px;border:none;background:transparent;' +
-                'color:#a5a5ad;font:inherit;font-size:16px;line-height:1;cursor:pointer;border-radius:4px;';
-            closeBtn.onmouseenter = () => {
-                closeBtn.style.color = '#f2f2f2';
-            };
-            closeBtn.onmouseleave = () => {
-                closeBtn.style.color = '#a5a5ad';
-            };
-
-            const closeConfirm = document.createElement('div');
-            closeConfirm.style.cssText = 'display:none;align-items:center;gap:4px;';
-
-            function makeHeaderActionBtn(label, destructive) {
-                const b = document.createElement('button');
-                b.type = 'button';
-                b.textContent = label;
-                b.style.cssText =
-                    'margin:0;padding:2px 6px;border-radius:4px;font:inherit;font-size:10px;' +
-                    'font-weight:600;line-height:1.3;cursor:pointer;white-space:nowrap;';
-                if (destructive) {
-                    b.style.border = '1px solid rgba(239,68,68,0.45)';
-                    b.style.background = 'rgba(239,68,68,0.18)';
-                    b.style.color = '#fecaca';
-                } else {
-                    b.style.border = '1px solid rgba(255,255,255,0.18)';
-                    b.style.background = 'rgba(255,255,255,0.06)';
-                    b.style.color = '#c8c8d0';
-                }
-                return b;
-            }
-
-            const cancelCloseBtn = makeHeaderActionBtn('Cancel', false);
-            cancelCloseBtn.setAttribute('aria-label', 'Cancel closing VM Clipboard');
-            const confirmCloseBtn = makeHeaderActionBtn('Confirm', true);
-            confirmCloseBtn.setAttribute('aria-label', 'Confirm close VM Clipboard');
-
-            closeConfirm.appendChild(cancelCloseBtn);
-            closeConfirm.appendChild(confirmCloseBtn);
-            closeActions.appendChild(closeBtn);
-            closeActions.appendChild(closeConfirm);
-
-            clipHeader.appendChild(clipTitle);
-            clipHeader.appendChild(closeActions);
-
-            const clipBody = document.createElement('div');
-            clipBody.style.cssText = 'padding:0 12px 10px 12px;';
-
-            const btnRow = document.createElement('div');
-            btnRow.style.cssText = 'display:flex;gap:8px;';
-
-            function makeBtn(label) {
-                const b = document.createElement('button');
-                b.type = 'button';
-                b.textContent = label;
-                b.style.cssText =
-                    'flex:1;margin:0;padding:6px 8px;border-radius:6px;' +
-                    'border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);' +
-                    'color:#f2f2f2;font:inherit;font-size:11px;font-weight:500;cursor:pointer;';
-                b.onmouseenter = () => {
-                    if (!b._fosClipResetTimeout) {
-                        b.style.background = 'rgba(255,255,255,0.14)';
-                    }
-                };
-                b.onmouseleave = () => {
-                    if (!b._fosClipResetTimeout) {
-                        b.style.background = 'rgba(255,255,255,0.08)';
-                    }
-                };
-                return b;
-            }
-
-            const bExtract = makeBtn('Extract');
-            const bOverwrite = makeBtn('Overwrite');
-            bExtract.addEventListener('click', () => {
-                clipQueue = clipQueue.then(() => runExtract(bExtract)).catch(() => {});
-            });
-            bOverwrite.addEventListener('click', () => {
-                // Start read under the user gesture; only serialize the VM push via clipQueue.
-                let readPromise;
-                try {
-                    readPromise = navigator.clipboard.readText();
-                } catch (eSync) {
-                    readPromise = Promise.reject(eSync);
-                }
-                clipQueue = clipQueue
-                    .then(() => runOverwrite(bOverwrite, readPromise))
-                    .catch(() => {});
-            });
-
-            btnRow.appendChild(bExtract);
-            btnRow.appendChild(bOverwrite);
-            clipBody.appendChild(btnRow);
-            root.appendChild(clipHeader);
-            root.appendChild(clipBody);
-            document.body.appendChild(root);
-
-            let dragging = false;
-            let dragOx = 0;
-            let dragOy = 0;
-
-            function onDragMove(ev) {
-                if (!dragging) {
-                    return;
-                }
-                root.style.left = Math.max(0, ev.clientX - dragOx) + 'px';
-                root.style.top = Math.max(0, ev.clientY - dragOy) + 'px';
-            }
-
-            function onDragUp() {
-                if (!dragging) {
-                    return;
-                }
-                dragging = false;
-                clipHeader.style.cursor = 'grab';
-                document.removeEventListener('mousemove', onDragMove, true);
-                document.removeEventListener('mouseup', onDragUp, true);
-            }
-
-            function dismissBridge() {
-                bridgeDismissed = true;
-                bridgeStarted = true;
-                onDragUp();
-                if (waitObserver) {
-                    try {
-                        waitObserver.disconnect();
-                    } catch (_e) { /* ignore */ }
-                    waitObserver = null;
-                }
-                if (root.parentNode) {
-                    root.parentNode.removeChild(root);
-                }
-                console.log(EMBED_LOG + ': clipboard panel dismissed');
-            }
-
-            function showCloseConfirm() {
-                closeBtn.style.display = 'none';
-                closeConfirm.style.display = 'flex';
-            }
-
-            function hideCloseConfirm() {
-                closeConfirm.style.display = 'none';
-                closeBtn.style.display = '';
-            }
-
-            closeBtn.addEventListener('click', (ev) => {
-                ev.stopPropagation();
-                showCloseConfirm();
-            });
-            cancelCloseBtn.addEventListener('click', (ev) => {
-                ev.stopPropagation();
-                hideCloseConfirm();
-            });
-            confirmCloseBtn.addEventListener('click', (ev) => {
-                ev.stopPropagation();
-                dismissBridge();
-            });
-
-            clipHeader.addEventListener('mousedown', (ev) => {
-                if (ev.button !== 0 || closeActions.contains(ev.target)) {
-                    return;
-                }
-                ev.preventDefault();
-                const r = root.getBoundingClientRect();
-                root.style.bottom = 'auto';
-                root.style.left = r.left + 'px';
-                root.style.top = r.top + 'px';
-                dragging = true;
-                dragOx = ev.clientX - r.left;
-                dragOy = ev.clientY - r.top;
-                clipHeader.style.cursor = 'grabbing';
-                document.addEventListener('mousemove', onDragMove, true);
-                document.addEventListener('mouseup', onDragUp, true);
-            });
-
-            console.log(EMBED_LOG + ': clipboard panel injected');
-        }
-
-        function startBridge() {
-            if (bridgeStarted || bridgeDismissed) {
+        function markBridgeReady() {
+            if (bridgeReady) {
                 return;
             }
             if (waitObserver) {
@@ -957,35 +675,24 @@
                 } catch (_e) { /* ignore */ }
                 waitObserver = null;
             }
-            bridgeStarted = true;
-
-            const attach = () => {
-                if (!document.body) {
-                    return;
-                }
-                injectPanel();
-            };
-            if (document.body) {
-                attach();
-            } else {
-                document.addEventListener('DOMContentLoaded', attach, { once: true });
-            }
+            bridgeReady = true;
+            console.log(EMBED_LOG + ': noVNC clipboard ready (parent hosts UI)');
         }
 
         function installWaitObserver() {
-            if (bridgeStarted || bridgeDismissed || waitObserver) {
+            if (bridgeReady || waitObserver) {
                 return;
             }
             const check = () => {
-                if (!fosAuthorized || bridgeStarted || bridgeDismissed) {
+                if (!fosAuthorized || bridgeReady) {
                     return;
                 }
                 if (document.getElementById(NOVNC_CLIPBOARD_ID)) {
-                    startBridge();
+                    markBridgeReady();
                 }
             };
             check();
-            if (bridgeStarted) {
+            if (bridgeReady) {
                 return;
             }
             waitObserver = new MutationObserver(check);
@@ -996,22 +703,69 @@
         }
 
         window.addEventListener('message', (event) => {
-            if (!event.data || event.data.type !== 'fleet-fos-embedded-ready') {
+            if (!event.data || typeof event.data.type !== 'string') {
                 return;
             }
             if (!isFleetParentOrigin(event.origin)) {
                 return;
             }
-            const envKey = String(event.data.envKey || '');
-            if (!envKey.includes('fos')) {
+
+            if (event.data.type === MSG_EMBEDDED_READY) {
+                const envKey = String(event.data.envKey || '');
+                if (!envKey.includes('fos')) {
+                    return;
+                }
+                if (fosAuthorized) {
+                    return;
+                }
+                fosAuthorized = true;
+                console.log(EMBED_LOG + ': authorized for env ' + envKey);
+                installWaitObserver();
                 return;
             }
-            if (fosAuthorized) {
+
+            if (!fosAuthorized) {
                 return;
             }
-            fosAuthorized = true;
-            console.log(EMBED_LOG + ': authorized for env ' + envKey);
-            installWaitObserver();
+
+            if (event.data.type === MSG_PUSH) {
+                const requestId = event.data.requestId;
+                clipQueue = clipQueue
+                    .then(async () => {
+                        const ok = await pushOsTextToVmClipboard(event.data.text);
+                        reply(event, { type: MSG_PUSH_RESULT, requestId, ok: !!ok });
+                        if (ok) {
+                            console.log(EMBED_LOG + ': push ok');
+                        }
+                    })
+                    .catch((e) => {
+                        console.warn(EMBED_LOG + ': push failed', e);
+                        reply(event, { type: MSG_PUSH_RESULT, requestId, ok: false });
+                    });
+                return;
+            }
+
+            if (event.data.type === MSG_EXTRACT_REQ) {
+                const requestId = event.data.requestId;
+                clipQueue = clipQueue
+                    .then(async () => {
+                        const text = readVmClipboardText();
+                        if (text == null) {
+                            reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: false });
+                            return;
+                        }
+                        if (!text) {
+                            reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: false, text: '' });
+                            return;
+                        }
+                        reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: true, text });
+                        console.log(EMBED_LOG + ': extract ok');
+                    })
+                    .catch((e) => {
+                        console.warn(EMBED_LOG + ': extract failed', e);
+                        reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: false });
+                    });
+            }
         });
 
         try {
@@ -1024,6 +778,7 @@
             console.warn(EMBED_LOG + ': child-ready postMessage failed', e);
         }
     }
+
 
     function showNonDevRedirectModal() {
         const root = document.body || document.documentElement;

--- a/plugins/core/main/fos-embedded-watcher.js
+++ b/plugins/core/main/fos-embedded-watcher.js
@@ -1,11 +1,19 @@
 // fos-embedded-watcher.js
-// Parent-page watcher: detects FOS env instances via orchestrator + latch, authorizes embedded iframe clipboard bridge.
+// Parent-page watcher: detects FOS env instances via orchestrator + latch, authorizes embedded
+// iframe clipboard bridge, and hosts VM Clipboard UI (system clipboard I/O stays on the parent).
 
 const FOS_ENV_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
 const FOS_ORCHESTRATOR_INSTANCES_URL = 'https://orchestrator.fleetai.com/v1/env/instances';
 const FOS_CHILD_READY_TYPE = 'fleet-fos-child-ready';
 const FOS_EMBEDDED_READY_TYPE = 'fleet-fos-embedded-ready';
+const FOS_PUSH_TYPE = 'fleet-fos-push-clipboard';
+const FOS_PUSH_RESULT_TYPE = 'fleet-fos-push-result';
+const FOS_EXTRACT_REQ_TYPE = 'fleet-fos-extract-request';
+const FOS_EXTRACT_RESULT_TYPE = 'fleet-fos-extract-result';
 const FOS_CLIPBOARD_ALLOW_TOKENS = ['clipboard-read *', 'clipboard-write *'];
+const FOS_PANEL_ATTR = 'data-fleet-fos-vm-clipboard';
+const FOS_CLIP_FLASH_MS = 600;
+const FOS_CLIP_BTN_BG = 'rgba(255,255,255,0.08)';
 
 function fosInstanceIdFromHostname(hostname) {
     return String(hostname || '').split('.')[0] || '';
@@ -58,7 +66,7 @@ function fosAllowHasClipboardFeature(allowValue, feature) {
 
 /**
  * Ensure cross-origin clipboard Permissions Policy is delegated on the iframe.
- * Returns true when the allow attribute was changed.
+ * Returns true when the allow attribute was changed. (Does not unlock read without reload.)
  */
 function fosEnsureClipboardAllow(iframe) {
     if (!iframe || iframe.tagName !== 'IFRAME') {
@@ -115,21 +123,63 @@ function fosFindEnvIframeByHostname(hostname) {
     return null;
 }
 
+function fosNextRequestId() {
+    return 'fos-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 8);
+}
+
+function fosFlashBtn(btn, ok) {
+    if (!btn) {
+        return;
+    }
+    if (btn._fosClipResetTimeout) {
+        clearTimeout(btn._fosClipResetTimeout);
+    }
+    if (ok) {
+        btn.style.transition = '';
+        btn.style.background = 'rgb(34, 197, 94)';
+        btn.style.color = '#ffffff';
+        btn._fosClipResetTimeout = setTimeout(() => {
+            btn._fosClipResetTimeout = null;
+            btn.style.background = FOS_CLIP_BTN_BG;
+            btn.style.color = '#f2f2f2';
+        }, FOS_CLIP_FLASH_MS);
+        return;
+    }
+    const prevT = btn.style.transition;
+    btn.style.transition = 'none';
+    btn.style.background = 'rgb(239, 68, 68)';
+    btn.style.color = '#ffffff';
+    void btn.offsetHeight;
+    btn.style.transition =
+        'background ' + FOS_CLIP_FLASH_MS + 'ms ease-out, color ' + FOS_CLIP_FLASH_MS + 'ms ease-out';
+    btn.style.background = FOS_CLIP_BTN_BG;
+    btn.style.color = '#f2f2f2';
+    btn._fosClipResetTimeout = setTimeout(() => {
+        btn.style.transition = prevT || '';
+        btn._fosClipResetTimeout = null;
+    }, FOS_CLIP_FLASH_MS);
+}
+
 const plugin = {
     id: 'fosEmbeddedWatcher',
     name: 'FOS Embedded Watcher',
     description:
-        'Detects embedded FOS env instances on the parent page and signals the iframe child when the env timestamp probe succeeds',
-    _version: '1.2',
+        'Detects embedded FOS env instances, signals the iframe child, and hosts parent-side VM Clipboard controls',
+    _version: '1.3',
     phase: 'core',
     enabledByDefault: true,
     initialState: {
         fosInstances: null,
         pendingChildren: null,
+        clipboardPanels: null,
+        pendingRequests: null,
         messageListenerInstalled: false,
+        resultListenerInstalled: false,
         iframeObserverInstalled: false,
+        layoutListenersInstalled: false,
         activationLogged: false,
-        clipboardPatchedLogged: false
+        clipboardPatchedLogged: false,
+        panelMountedLogged: false
     },
 
     init(state, _context) {
@@ -139,16 +189,28 @@ const plugin = {
         if (!state.pendingChildren) {
             state.pendingChildren = new Map();
         }
+        if (!state.clipboardPanels) {
+            state.clipboardPanels = new Map();
+        }
+        if (!state.pendingRequests) {
+            state.pendingRequests = new Map();
+        }
         this._subscribeOrchestrator(state);
         this._subscribeLatch(state);
         this._listenChildReady(state);
+        this._listenClipboardResults(state);
         this._watchEnvIframes(state);
+        this._installLayoutListeners(state);
         Logger.debug('fosEmbeddedWatcher: parent watchers registered');
     },
 
     _ensureInstance(state, instanceId) {
         if (!state.fosInstances.has(instanceId)) {
-            state.fosInstances.set(instanceId, { envKey: null, latchReady: false });
+            state.fosInstances.set(instanceId, {
+                envKey: null,
+                latchReady: false,
+                child: null
+            });
         }
         return state.fosInstances.get(instanceId);
     },
@@ -182,6 +244,7 @@ const plugin = {
         if (iframe) {
             this._patchIframeClipboardAllow(state, iframe);
         }
+        return iframe;
     },
 
     _scanEnvIframes(state) {
@@ -189,6 +252,8 @@ const plugin = {
         for (let i = 0; i < frames.length; i++) {
             this._patchIframeClipboardAllow(state, frames[i]);
         }
+        this._repositionAllPanels(state);
+        this._pruneMissingPanels(state);
     },
 
     _watchEnvIframes(state) {
@@ -231,6 +296,8 @@ const plugin = {
                     }
                 }
             }
+            self._repositionAllPanels(state);
+            self._pruneMissingPanels(state);
         });
         observer.observe(target, {
             childList: true,
@@ -240,6 +307,345 @@ const plugin = {
         });
         if (typeof CleanupRegistry !== 'undefined' && CleanupRegistry.registerObserver) {
             CleanupRegistry.registerObserver(observer);
+        }
+    },
+
+    _installLayoutListeners(state) {
+        if (state.layoutListenersInstalled) {
+            return;
+        }
+        state.layoutListenersInstalled = true;
+        const self = this;
+        const onLayout = () => {
+            self._repositionAllPanels(state);
+        };
+        window.addEventListener('resize', onLayout, true);
+        window.addEventListener('scroll', onLayout, true);
+        if (typeof CleanupRegistry !== 'undefined' && CleanupRegistry.registerEventListener) {
+            CleanupRegistry.registerEventListener(window, 'resize', onLayout, true);
+            CleanupRegistry.registerEventListener(window, 'scroll', onLayout, true);
+        }
+    },
+
+    _positionPanel(panel, iframe) {
+        if (!panel || !iframe || !iframe.isConnected) {
+            return;
+        }
+        const rect = iframe.getBoundingClientRect();
+        const left = Math.max(8, Math.round(rect.left + 16));
+        const top = Math.max(8, Math.round(rect.bottom - 16 - panel.offsetHeight));
+        panel.style.left = left + 'px';
+        panel.style.top = top + 'px';
+        panel.style.bottom = 'auto';
+    },
+
+    _repositionAllPanels(state) {
+        state.clipboardPanels.forEach((entry) => {
+            if (!entry || !entry.root || !entry.iframe) {
+                return;
+            }
+            if (entry.userMoved) {
+                return;
+            }
+            this._positionPanel(entry.root, entry.iframe);
+        });
+    },
+
+    _pruneMissingPanels(state) {
+        const toRemove = [];
+        state.clipboardPanels.forEach((entry, instanceId) => {
+            if (!entry || !entry.iframe || !entry.iframe.isConnected) {
+                toRemove.push(instanceId);
+            }
+        });
+        toRemove.forEach((id) => {
+            this._teardownPanel(state, id);
+        });
+    },
+
+    _teardownPanel(state, instanceId) {
+        const entry = state.clipboardPanels.get(instanceId);
+        if (!entry) {
+            return;
+        }
+        if (entry.root && entry.root.parentNode) {
+            entry.root.parentNode.removeChild(entry.root);
+        }
+        state.clipboardPanels.delete(instanceId);
+        Logger.debug('fosEmbeddedWatcher: VM Clipboard panel removed for ' + instanceId);
+    },
+
+    _waitForChildResult(state, requestId, timeoutMs) {
+        return new Promise((resolve) => {
+            const timer = setTimeout(() => {
+                state.pendingRequests.delete(requestId);
+                resolve({ ok: false, timedOut: true });
+            }, timeoutMs || 8000);
+            state.pendingRequests.set(requestId, {
+                resolve: (payload) => {
+                    clearTimeout(timer);
+                    resolve(payload);
+                }
+            });
+        });
+    },
+
+    _mountClipboardPanel(state, instanceId, child, iframe) {
+        if (!iframe || !child || !child.source) {
+            return;
+        }
+        const existing = state.clipboardPanels.get(instanceId);
+        if (existing && existing.root && existing.root.isConnected) {
+            existing.child = child;
+            existing.iframe = iframe;
+            this._positionPanel(existing.root, iframe);
+            return;
+        }
+        if (existing) {
+            this._teardownPanel(state, instanceId);
+        }
+
+        if (!document.body) {
+            return;
+        }
+
+        const self = this;
+        const root = document.createElement('div');
+        root.setAttribute(FOS_PANEL_ATTR, instanceId);
+        root.style.cssText =
+            'position:fixed;z-index:2147483646;min-width:220px;max-width:280px;padding:0;' +
+            'border-radius:10px;border:1px solid rgba(255,255,255,0.14);' +
+            'background:rgba(28,28,32,0.96);color:#f2f2f2;' +
+            'font:500 12px/1.4 system-ui,-apple-system,sans-serif;' +
+            'box-shadow:0 8px 32px rgba(0,0,0,0.45);user-select:none;';
+
+        const clipHeader = document.createElement('div');
+        clipHeader.style.cssText =
+            'display:flex;align-items:center;justify-content:space-between;' +
+            'padding:6px 8px 4px 12px;cursor:grab;';
+
+        const clipTitle = document.createElement('div');
+        clipTitle.textContent = 'VM Clipboard';
+        clipTitle.style.cssText =
+            'font-size:11px;font-weight:600;color:#b0b0b8;' +
+            'letter-spacing:0.03em;text-transform:uppercase;flex:1;min-width:0;';
+
+        const closeBtn = document.createElement('button');
+        closeBtn.type = 'button';
+        closeBtn.setAttribute('aria-label', 'Close VM Clipboard');
+        closeBtn.textContent = '\u00d7';
+        closeBtn.style.cssText =
+            'margin:0;padding:0 4px;border:none;background:transparent;' +
+            'color:#a5a5ad;font:inherit;font-size:16px;line-height:1;cursor:pointer;border-radius:4px;';
+        closeBtn.onmouseenter = () => {
+            closeBtn.style.color = '#f2f2f2';
+        };
+        closeBtn.onmouseleave = () => {
+            closeBtn.style.color = '#a5a5ad';
+        };
+
+        clipHeader.appendChild(clipTitle);
+        clipHeader.appendChild(closeBtn);
+
+        const clipBody = document.createElement('div');
+        clipBody.style.cssText = 'padding:0 12px 10px 12px;';
+
+        const btnRow = document.createElement('div');
+        btnRow.style.cssText = 'display:flex;gap:8px;';
+
+        function makeBtn(label) {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = label;
+            b.style.cssText =
+                'flex:1;margin:0;padding:6px 8px;border-radius:6px;' +
+                'border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);' +
+                'color:#f2f2f2;font:inherit;font-size:11px;font-weight:500;cursor:pointer;';
+            b.onmouseenter = () => {
+                if (!b._fosClipResetTimeout) {
+                    b.style.background = 'rgba(255,255,255,0.14)';
+                }
+            };
+            b.onmouseleave = () => {
+                if (!b._fosClipResetTimeout) {
+                    b.style.background = FOS_CLIP_BTN_BG;
+                }
+            };
+            return b;
+        }
+
+        const bExtract = makeBtn('Extract');
+        const bOverwrite = makeBtn('Overwrite');
+
+        bOverwrite.addEventListener('click', () => {
+            const entry = state.clipboardPanels.get(instanceId);
+            if (!entry || !entry.child || !entry.child.source) {
+                fosFlashBtn(bOverwrite, false);
+                Logger.warn('fosEmbeddedWatcher: overwrite failed — child missing for ' + instanceId);
+                return;
+            }
+            const requestId = fosNextRequestId();
+            const readPromise = (async () => {
+                try {
+                    return await navigator.clipboard.readText();
+                } catch (e) {
+                    Logger.warn('fosEmbeddedWatcher: overwrite failed — could not read system clipboard', e);
+                    return null;
+                }
+            })();
+            readPromise
+                .then(async (text) => {
+                    if (text == null) {
+                        fosFlashBtn(bOverwrite, false);
+                        return;
+                    }
+                    const resultPromise = self._waitForChildResult(state, requestId, 8000);
+                    try {
+                        entry.child.source.postMessage(
+                            { type: FOS_PUSH_TYPE, text: String(text), requestId },
+                            entry.child.origin || '*'
+                        );
+                    } catch (ePost) {
+                        state.pendingRequests.delete(requestId);
+                        fosFlashBtn(bOverwrite, false);
+                        Logger.warn('fosEmbeddedWatcher: push postMessage failed', ePost);
+                        return;
+                    }
+                    const result = await resultPromise;
+                    fosFlashBtn(bOverwrite, !!(result && result.ok));
+                    if (result && result.ok) {
+                        Logger.log('fosEmbeddedWatcher: overwrite ok for ' + instanceId);
+                    } else {
+                        Logger.warn('fosEmbeddedWatcher: overwrite failed for ' + instanceId);
+                    }
+                })
+                .catch(() => {
+                    fosFlashBtn(bOverwrite, false);
+                });
+        });
+
+        bExtract.addEventListener('click', () => {
+            const entry = state.clipboardPanels.get(instanceId);
+            if (!entry || !entry.child || !entry.child.source) {
+                fosFlashBtn(bExtract, false);
+                Logger.warn('fosEmbeddedWatcher: extract failed — child missing for ' + instanceId);
+                return;
+            }
+            const requestId = fosNextRequestId();
+            const resultPromise = self._waitForChildResult(state, requestId, 8000);
+            try {
+                entry.child.source.postMessage(
+                    { type: FOS_EXTRACT_REQ_TYPE, requestId },
+                    entry.child.origin || '*'
+                );
+            } catch (ePost) {
+                state.pendingRequests.delete(requestId);
+                fosFlashBtn(bExtract, false);
+                Logger.warn('fosEmbeddedWatcher: extract postMessage failed', ePost);
+                return;
+            }
+            resultPromise
+                .then(async (result) => {
+                    if (!result || !result.ok || typeof result.text !== 'string' || !result.text) {
+                        fosFlashBtn(bExtract, false);
+                        Logger.warn('fosEmbeddedWatcher: extract failed for ' + instanceId);
+                        return;
+                    }
+                    try {
+                        await navigator.clipboard.writeText(result.text);
+                        fosFlashBtn(bExtract, true);
+                        Logger.log('fosEmbeddedWatcher: extract ok for ' + instanceId);
+                    } catch (eWrite) {
+                        fosFlashBtn(bExtract, false);
+                        Logger.warn(
+                            'fosEmbeddedWatcher: extract failed — could not write system clipboard',
+                            eWrite
+                        );
+                    }
+                })
+                .catch(() => {
+                    fosFlashBtn(bExtract, false);
+                });
+        });
+
+        closeBtn.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            self._teardownPanel(state, instanceId);
+            Logger.log('fosEmbeddedWatcher: VM Clipboard panel dismissed for ' + instanceId);
+        });
+
+        btnRow.appendChild(bExtract);
+        btnRow.appendChild(bOverwrite);
+        clipBody.appendChild(btnRow);
+        root.appendChild(clipHeader);
+        root.appendChild(clipBody);
+        document.body.appendChild(root);
+
+        let dragging = false;
+        let dragOx = 0;
+        let dragOy = 0;
+        let userMoved = false;
+
+        function onDragMove(ev) {
+            if (!dragging) {
+                return;
+            }
+            root.style.left = Math.max(0, ev.clientX - dragOx) + 'px';
+            root.style.top = Math.max(0, ev.clientY - dragOy) + 'px';
+            userMoved = true;
+        }
+
+        function onDragUp() {
+            if (!dragging) {
+                return;
+            }
+            dragging = false;
+            clipHeader.style.cursor = 'grab';
+            document.removeEventListener('mousemove', onDragMove, true);
+            document.removeEventListener('mouseup', onDragUp, true);
+        }
+
+        clipHeader.addEventListener('mousedown', (ev) => {
+            if (ev.button !== 0 || closeBtn.contains(ev.target)) {
+                return;
+            }
+            ev.preventDefault();
+            const r = root.getBoundingClientRect();
+            dragging = true;
+            dragOx = ev.clientX - r.left;
+            dragOy = ev.clientY - r.top;
+            clipHeader.style.cursor = 'grabbing';
+            document.addEventListener('mousemove', onDragMove, true);
+            document.addEventListener('mouseup', onDragUp, true);
+        });
+
+        const entry = {
+            root,
+            iframe,
+            child,
+            userMoved: false,
+            get moved() {
+                return userMoved;
+            }
+        };
+        // Keep userMoved in sync for reposition skip
+        Object.defineProperty(entry, 'userMoved', {
+            get() {
+                return userMoved;
+            },
+            set(v) {
+                userMoved = !!v;
+            }
+        });
+
+        state.clipboardPanels.set(instanceId, entry);
+        this._positionPanel(root, iframe);
+
+        if (!state.panelMountedLogged) {
+            state.panelMountedLogged = true;
+            Logger.log('fosEmbeddedWatcher: mounted parent VM Clipboard for ' + instanceId);
+        } else {
+            Logger.debug('fosEmbeddedWatcher: mounted VM Clipboard for ' + instanceId);
         }
     },
 
@@ -256,6 +662,23 @@ const plugin = {
                 { type: FOS_EMBEDDED_READY_TYPE, envKey: rec.envKey },
                 child.origin || '*'
             );
+            rec.child = child;
+            const hostname =
+                (child.origin && (() => {
+                    try {
+                        return new URL(child.origin).hostname;
+                    } catch (_e) {
+                        return '';
+                    }
+                })()) ||
+                '';
+            const iframe =
+                fosFindIframeForSource(child.source) ||
+                (hostname ? fosFindEnvIframeByHostname(hostname) : null);
+            if (iframe) {
+                this._patchIframeClipboardAllow(state, iframe);
+                this._mountClipboardPanel(state, instanceId, child, iframe);
+            }
             if (!state.activationLogged) {
                 state.activationLogged = true;
                 Logger.log(
@@ -361,6 +784,40 @@ const plugin = {
                     );
                 }
                 self._onInstanceProgress(state, instanceId);
+            }
+        });
+    },
+
+    _listenClipboardResults(state) {
+        if (state.resultListenerInstalled) {
+            return;
+        }
+        state.resultListenerInstalled = true;
+        window.addEventListener('message', (event) => {
+            if (!event.data || typeof event.data.type !== 'string') {
+                return;
+            }
+            const type = event.data.type;
+            if (type !== FOS_PUSH_RESULT_TYPE && type !== FOS_EXTRACT_RESULT_TYPE) {
+                return;
+            }
+            let originHostname = '';
+            try {
+                originHostname = new URL(event.origin).hostname;
+            } catch (_e) {
+                return;
+            }
+            if (!FOS_ENV_HOST_PATTERN.test(originHostname)) {
+                return;
+            }
+            const requestId = event.data.requestId;
+            if (!requestId || !state.pendingRequests.has(requestId)) {
+                return;
+            }
+            const pending = state.pendingRequests.get(requestId);
+            state.pendingRequests.delete(requestId);
+            if (pending && typeof pending.resolve === 'function') {
+                pending.resolve(event.data);
             }
         });
     },

--- a/plugins/core/main/fos-embedded-watcher.js
+++ b/plugins/core/main/fos-embedded-watcher.js
@@ -5,6 +5,7 @@ const FOS_ENV_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
 const FOS_ORCHESTRATOR_INSTANCES_URL = 'https://orchestrator.fleetai.com/v1/env/instances';
 const FOS_CHILD_READY_TYPE = 'fleet-fos-child-ready';
 const FOS_EMBEDDED_READY_TYPE = 'fleet-fos-embedded-ready';
+const FOS_CLIPBOARD_ALLOW_TOKENS = ['clipboard-read *', 'clipboard-write *'];
 
 function fosInstanceIdFromHostname(hostname) {
     return String(hostname || '').split('.')[0] || '';
@@ -24,19 +25,111 @@ function fosIsEnvTimestampProbe(meta) {
     );
 }
 
+function fosHostnameFromIframe(iframe) {
+    if (!iframe) {
+        return '';
+    }
+    const candidates = [iframe.src, iframe.getAttribute('src')];
+    for (let i = 0; i < candidates.length; i++) {
+        const raw = candidates[i];
+        if (!raw) {
+            continue;
+        }
+        try {
+            return new URL(raw, window.location.href).hostname;
+        } catch (_e) {
+            /* ignore */
+        }
+    }
+    return '';
+}
+
+function fosIsEnvIframe(iframe) {
+    return FOS_ENV_HOST_PATTERN.test(fosHostnameFromIframe(iframe));
+}
+
+function fosAllowHasClipboardFeature(allowValue, feature) {
+    const tokens = String(allowValue || '')
+        .split(';')
+        .map((t) => t.trim().toLowerCase())
+        .filter(Boolean);
+    return tokens.some((t) => t === feature || t.startsWith(feature + ' '));
+}
+
+/**
+ * Ensure cross-origin clipboard Permissions Policy is delegated on the iframe.
+ * Returns true when the allow attribute was changed.
+ */
+function fosEnsureClipboardAllow(iframe) {
+    if (!iframe || iframe.tagName !== 'IFRAME') {
+        return false;
+    }
+    const current = iframe.getAttribute('allow') || iframe.allow || '';
+    const missing = FOS_CLIPBOARD_ALLOW_TOKENS.filter((token) => {
+        const feature = token.split(/\s+/)[0].toLowerCase();
+        return !fosAllowHasClipboardFeature(current, feature);
+    });
+    if (missing.length === 0) {
+        return false;
+    }
+    const next = [current.trim(), ...missing].filter(Boolean).join('; ');
+    iframe.setAttribute('allow', next);
+    try {
+        iframe.allow = next;
+    } catch (_e) {
+        /* ignore */
+    }
+    return true;
+}
+
+function fosFindIframeForSource(source) {
+    if (!source) {
+        return null;
+    }
+    const frames = document.querySelectorAll('iframe');
+    for (let i = 0; i < frames.length; i++) {
+        const frame = frames[i];
+        try {
+            if (frame.contentWindow === source) {
+                return frame;
+            }
+        } catch (_e) {
+            /* cross-origin access to contentWindow identity still works for === */
+        }
+    }
+    return null;
+}
+
+function fosFindEnvIframeByHostname(hostname) {
+    const want = String(hostname || '');
+    if (!want) {
+        return null;
+    }
+    const frames = document.querySelectorAll('iframe');
+    for (let i = 0; i < frames.length; i++) {
+        const frame = frames[i];
+        if (fosHostnameFromIframe(frame) === want) {
+            return frame;
+        }
+    }
+    return null;
+}
+
 const plugin = {
     id: 'fosEmbeddedWatcher',
     name: 'FOS Embedded Watcher',
     description:
         'Detects embedded FOS env instances on the parent page and signals the iframe child when the env timestamp probe succeeds',
-    _version: '1.1',
+    _version: '1.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: {
         fosInstances: null,
         pendingChildren: null,
         messageListenerInstalled: false,
-        activationLogged: false
+        iframeObserverInstalled: false,
+        activationLogged: false,
+        clipboardPatchedLogged: false
     },
 
     init(state, _context) {
@@ -49,6 +142,7 @@ const plugin = {
         this._subscribeOrchestrator(state);
         this._subscribeLatch(state);
         this._listenChildReady(state);
+        this._watchEnvIframes(state);
         Logger.debug('fosEmbeddedWatcher: parent watchers registered');
     },
 
@@ -57,6 +151,96 @@ const plugin = {
             state.fosInstances.set(instanceId, { envKey: null, latchReady: false });
         }
         return state.fosInstances.get(instanceId);
+    },
+
+    _logClipboardPatched(state, iframe) {
+        const host = fosHostnameFromIframe(iframe) || 'unknown';
+        if (!state.clipboardPatchedLogged) {
+            state.clipboardPatchedLogged = true;
+            Logger.log('fosEmbeddedWatcher: enabled clipboard permissions on env iframe ' + host);
+        } else {
+            Logger.debug('fosEmbeddedWatcher: clipboard permissions patched on ' + host);
+        }
+    },
+
+    _patchIframeClipboardAllow(state, iframe) {
+        if (!iframe || !fosIsEnvIframe(iframe)) {
+            return false;
+        }
+        if (!fosEnsureClipboardAllow(iframe)) {
+            return false;
+        }
+        this._logClipboardPatched(state, iframe);
+        return true;
+    },
+
+    _patchIframeForChild(state, child, hostname) {
+        let iframe = fosFindIframeForSource(child && child.source);
+        if (!iframe && hostname) {
+            iframe = fosFindEnvIframeByHostname(hostname);
+        }
+        if (iframe) {
+            this._patchIframeClipboardAllow(state, iframe);
+        }
+    },
+
+    _scanEnvIframes(state) {
+        const frames = document.querySelectorAll('iframe');
+        for (let i = 0; i < frames.length; i++) {
+            this._patchIframeClipboardAllow(state, frames[i]);
+        }
+    },
+
+    _watchEnvIframes(state) {
+        if (state.iframeObserverInstalled) {
+            return;
+        }
+        state.iframeObserverInstalled = true;
+        const self = this;
+        const scan = () => {
+            self._scanEnvIframes(state);
+        };
+        scan();
+        const target = document.documentElement || document.body;
+        if (!target) {
+            return;
+        }
+        const observer = new MutationObserver((mutations) => {
+            for (let i = 0; i < mutations.length; i++) {
+                const m = mutations[i];
+                if (m.type === 'attributes' && m.target && m.target.tagName === 'IFRAME') {
+                    self._patchIframeClipboardAllow(state, m.target);
+                    continue;
+                }
+                if (m.type !== 'childList') {
+                    continue;
+                }
+                const nodes = m.addedNodes;
+                for (let j = 0; j < nodes.length; j++) {
+                    const node = nodes[j];
+                    if (!node || node.nodeType !== 1) {
+                        continue;
+                    }
+                    if (node.tagName === 'IFRAME') {
+                        self._patchIframeClipboardAllow(state, node);
+                    } else if (typeof node.querySelectorAll === 'function') {
+                        const nested = node.querySelectorAll('iframe');
+                        for (let k = 0; k < nested.length; k++) {
+                            self._patchIframeClipboardAllow(state, nested[k]);
+                        }
+                    }
+                }
+            }
+        });
+        observer.observe(target, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['src', 'allow']
+        });
+        if (typeof CleanupRegistry !== 'undefined' && CleanupRegistry.registerObserver) {
+            CleanupRegistry.registerObserver(observer);
+        }
     },
 
     _tryNotifyChild(state, instanceId, child) {
@@ -209,6 +393,7 @@ const plugin = {
                 return;
             }
             const child = { source: event.source, origin: event.origin };
+            self._patchIframeForChild(state, child, hostname);
             Logger.debug('fosEmbeddedWatcher: child-ready from ' + instanceId);
             if (!self._tryNotifyChild(state, instanceId, child)) {
                 state.pendingChildren.set(instanceId, child);

--- a/plugins/libs/env-helper.js
+++ b/plugins/libs/env-helper.js
@@ -41,7 +41,7 @@ const EnvHelperApi = {
     id: 'envHelper',
     name: 'Env Helper',
     description: 'Env Helper modal with prompt cache and scratchpad for non-VNC env pages',
-    _version: '1.4',
+    _version: '1.5',
     enabledByDefault: true,
     phase: 'mutation',
     subOptions: [SHOW_PANEL_SUBOPTION],
@@ -325,8 +325,6 @@ const EnvHelperApi = {
         let onUp = () => {};
         let onResizeMove = () => {};
         let onResizeUp = () => {};
-
-        const self = this;
 
         /** Persistent tab: stays mounted while the modal is open or minimized. */
         const ensureRestoreTab = () => {
@@ -628,7 +626,7 @@ const plugin = {
     id: 'envHelperLib',
     name: 'Env Helper (library)',
     description: 'Shared API for Env Helper panel on non-VNC env pages',
-    _version: '1.4',
+    _version: '1.5',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },


### PR DESCRIPTION
## Summary

Fix embedded FOS VM Clipboard Overwrite failing with `NotAllowedError` by moving Extract/Overwrite onto the parent Fleet page, where system clipboard access is allowed, and having the env iframe only push/pull the noVNC buffer over postMessage. Also fix Env Helper failing to load on external env pages from a duplicate `const self` declaration.

## Changes

- Host the VM Clipboard panel on the parent (`www.fleetai.com`) over the env iframe; Overwrite reads the system clipboard in the parent click gesture, then postMessages text into the child to update the noVNC/RFB buffer.
- Extract asks the child for the VM clipboard text and writes it on the parent; the child no longer calls `navigator.clipboard` for these controls.
- Keep FOS authorize/latch signaling and optional iframe `allow` patching, but do not rely on in-iframe `clipboard-read` for Overwrite (Permissions Policy cannot be applied by patching `allow` after load without reloading the session).
- Fix Env Helper `startPanel` so a duplicate `const self` no longer throws and blocks the library on non-VNC env pages.
- Add `test.sh --from-head` / `-f` for faithful forks of the current branch during local testing.
