### PR TITLE
Fix FOS embedded clipboard auth timeouts

### DIFF
--- a/.github/workflows/verify-main-branch-config-pr.yml
+++ b/.github/workflows/verify-main-branch-config-pr.yml
@@ -18,9 +18,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Fetch main for sync baseline
-        run: git fetch origin main
-
+      # Uses PR-head working-tree @name base; -m remaps branch prefix + GitHub URLs for main.
       - name: Sync fleet.user.js for main
         run: |
           ./dev/utils/sync-branch-config.sh -m

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "13.2",
+  "version": "13.3",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.252",
+  "archetypesVersion": "14.253",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -40,8 +40,8 @@
     },
     {
       "name": "fos-embedded-watcher.js",
-      "version": "3.1",
-      "hash": "sha256-832cd5db214e952e7ec2e024e18e11b9b3ead71dc3fc773935e5ec94a71fd0ce",
+      "version": "3.2",
+      "hash": "sha256-c34444b2922cd3d59517f4221db73467937ac4cfb408cb14e28b0eec3b91b5c2",
       "log": false
     }
   ],
@@ -102,8 +102,8 @@
     },
     {
       "name": "fos-vm-clipboard-bar.js",
-      "version": "1.4",
-      "hash": "sha256-eb9daefd6d99697b9fe30fcc7a236d76ca7d743a1e8c839b9aa7b73c2ec17e95",
+      "version": "1.5",
+      "hash": "sha256-4cace907dd80d027562709e795353dfcafc5df8d1aa3e8826b3af2bec5f5b803",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.3",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.253",
+  "archetypesVersion": "14.254",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -281,8 +281,8 @@
   "devPlugins": [
     {
       "name": "logger-panel.js",
-      "version": "2.17",
-      "hash": "sha256-42fa1154f42b165651f49d06290ba29fc17634183aa450bb5e32f5e992721113",
+      "version": "2.18",
+      "hash": "sha256-84c3520b7a3fa8791b1b93ed6a1d8e6922e1cff442060e2a3c95173a83cd866a",
       "log": false
     }
   ],

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "13.3",
+  "version": "13.4",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.254",
+  "archetypesVersion": "14.255",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -40,8 +40,8 @@
     },
     {
       "name": "fos-embedded-watcher.js",
-      "version": "3.2",
-      "hash": "sha256-c34444b2922cd3d59517f4221db73467937ac4cfb408cb14e28b0eec3b91b5c2",
+      "version": "4.0",
+      "hash": "sha256-adda6ba2614032dcd197ab33f0b510d4047a99491596e270562cbaf114c283d1",
       "log": false
     }
   ],

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/utils/sync-branch-config.sh
+++ b/dev/utils/sync-branch-config.sh
@@ -11,16 +11,16 @@
 #   ./sync-branch-config.sh --fleet PATH # read/write this file instead of <root>/fleet.user.js
 #   ./sync-branch-config.sh --branch NAME # use NAME instead of git HEAD (ignored if -m)
 #
-# Run from repo root (or anywhere; uses git to find root). Owner, repo, and @name base
-# always come from git (origin remote + origin/main:fleet.user.js), never from existing
-# script contents. Updates:
+# Run from repo root (or anywhere; uses git to find root). Owner/repo come from the
+# origin remote; @name base comes from the userscript files being synced (branch
+# working tree). Updates:
 #   - fleet.user.js
-#   - @name: base from origin/main; "[branch] " prefix when not main
+#   - @name: base from current file (strip any existing "[…]" prefix); "[branch] " when not main
 #   - @downloadURL / @updateURL: full raw URL from origin owner/repo + target branch
 #   - GITHUB_CONFIG.owner / .repo / .branch: from origin remote + target branch
 #   - const VERSION: set from header @version in the file being synced
 #   - dev/fleet-dev-id.user.js
-#   - @name: base from origin/main dev script; "[branch] " prefix when not main
+#   - @name: base from current file (strip any existing "[…]" prefix); "[branch] " when not main
 #   - @downloadURL / @updateURL: full raw URL from origin owner/repo + target branch
 #   - const BRANCH_NAME: set to target branch
 #
@@ -111,16 +111,11 @@ if ! origin_repo="$(printf '%s' "$origin_url" | perl -ne 'if (m{github\.com[:/](
   exit 1
 fi
 
-if ! git -C "$root" rev-parse --verify origin/main >/dev/null 2>&1; then
-  echo "[error] origin/main is required (run: git fetch origin main)" >&2
-  exit 1
-fi
-
-fleet_base_name="$(git -C "$root" show origin/main:fleet.user.js | perl -ne '
+fleet_base_name="$(perl -ne '
   if (/^\/\/ \@name\s+(?:\[[^\]]+\]\s+)?(.+?)\s*$/) { print $1; exit }
-' || true)"
+' "$file_path" || true)"
 if [[ -z "$fleet_base_name" ]]; then
-  echo "[error] Could not read @name base from origin/main:fleet.user.js" >&2
+  echo "[error] Could not read @name base from $file_path" >&2
   exit 1
 fi
 
@@ -130,19 +125,11 @@ else
   fleet_display_name="[${branch}] ${fleet_base_name}"
 fi
 
-if git -C "$root" cat-file -e "origin/main:dev/fleet-dev-id.user.js" 2>/dev/null; then
-  dev_id_base_name="$(git -C "$root" show origin/main:dev/fleet-dev-id.user.js | perl -ne '
-    if (/^\/\/ \@name\s+(?:\[[^\]]+\]\s+)?(.+?)\s*$/) { print $1; exit }
-  ' || true)"
-elif git -C "$root" cat-file -e "origin/main:dev/fleet-godmode.user.js" 2>/dev/null; then
-  # Main still has legacy godmode file; use canonical DEV-ID title until main is updated.
-  dev_id_base_name="DEV-ID - Fleet UX Enhancer - (dev identifier)"
-else
-  echo "[error] Could not read dev ID @name base from origin/main (dev/fleet-dev-id.user.js or dev/fleet-godmode.user.js)" >&2
-  exit 1
-fi
+dev_id_base_name="$(perl -ne '
+  if (/^\/\/ \@name\s+(?:\[[^\]]+\]\s+)?(.+?)\s*$/) { print $1; exit }
+' "$dev_id_path" || true)"
 if [[ -z "$dev_id_base_name" ]]; then
-  echo "[error] Could not read @name base from origin/main:dev/fleet-dev-id.user.js" >&2
+  echo "[error] Could not read @name base from $dev_id_path" >&2
   exit 1
 fi
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -209,7 +209,7 @@ Scripts in `dev/utils/` automate branch creation, `fleet.user.js` sync, version 
 
 Scripts that touch `fleet.user.js` (checkout, test, sync-branch-config) ensure:
 
-- `@name`: branch prefix (e.g. `[my-feature] Fleet`) or no prefix on `main`
+- `@name`: keeps the base title from the branch’s current userscript file; remaps only the branch prefix (e.g. `[my-feature] Fleet`) or drops the prefix on `main`
 - `@downloadURL` / `@updateURL`: branch segment in the raw GitHub URL
 - `GITHUB_CONFIG.branch`: current branch name
 - `VERSION`: kept in sync with header `@version`
@@ -222,7 +222,7 @@ Scripts that touch `fleet.user.js` (checkout, test, sync-branch-config) ensure:
 
 **sync-branch-config.sh** — `./dev/utils/sync-branch-config.sh [-m] [-c] [--dry-run] [--fleet PATH] [--branch NAME]`
 
-- Aligns `fleet.user.js` with the current git branch (`-m` treats the branch as `main`). `-c` commits the file if it changed. `--dry-run` prints the planned field updates without writing. `--fleet` uses a specific file path (default: `<repo>/fleet.user.js`). `--branch` uses a branch name instead of `git` HEAD (ignored when `-m` is set). Used by `checkout.sh` and `test.sh`; safe to run by hand after switching branches.
+- Aligns `fleet.user.js` and `dev/fleet-dev-id.user.js` with the target git branch (`-m` treats the branch as `main`). `@name` base text is taken from the files being synced (so branch-local renames are preserved); only the `[branch]` prefix and GitHub URL / `GITHUB_CONFIG` fields are remapped from `origin` + target branch. `-c` commits the files if they changed. `--dry-run` prints the planned field updates without writing. `--fleet` uses a specific fleet file path (default: `<repo>/fleet.user.js`). `--branch` uses a branch name instead of `git` HEAD (ignored when `-m` is set). Used by `checkout.sh` and `test.sh`; safe to run by hand after switching branches.
 
 **apply-archetypes-boolean-patch.sh** — `./dev/utils/apply-archetypes-boolean-patch.sh <archetypes.json> <patch.json>`
 

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      13.3
+// @version      13.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '13.3';
+    const VERSION = '13.4';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -581,6 +581,7 @@
         const MSG_EXTRACT_REQ = 'fleet-fos-extract-request';
         const MSG_EXTRACT_RESULT = 'fleet-fos-extract-result';
         const MSG_EMBEDDED_READY = 'fleet-fos-embedded-ready';
+        const MSG_EMBEDDED_ACK = 'fleet-fos-embedded-ack';
 
         let fosAuthorized = false;
         let bridgeReady = false;
@@ -710,26 +711,33 @@
                 return;
             }
 
+            // Parent already decided desktop+latch; authorize any embedded-ready (no env_key substring gate).
             if (event.data.type === MSG_EMBEDDED_READY) {
                 const envKey = String(event.data.envKey || '');
-                if (!envKey.includes('fos')) {
-                    return;
-                }
-                if (fosAuthorized) {
-                    return;
-                }
+                const wasAuthorized = fosAuthorized;
                 fosAuthorized = true;
-                console.log(EMBED_LOG + ': authorized for env ' + envKey);
-                installWaitObserver();
-                return;
-            }
-
-            if (!fosAuthorized) {
+                if (!wasAuthorized) {
+                    console.log(EMBED_LOG + ': authorized for env ' + (envKey || '(none)'));
+                    installWaitObserver();
+                } else {
+                    console.log(EMBED_LOG + ': re-ack for env ' + (envKey || '(none)'));
+                }
+                reply(event, { type: MSG_EMBEDDED_ACK, envKey, ok: true });
                 return;
             }
 
             if (event.data.type === MSG_PUSH) {
                 const requestId = event.data.requestId;
+                if (!fosAuthorized) {
+                    console.warn(EMBED_LOG + ': push ignored — not authorized');
+                    reply(event, {
+                        type: MSG_PUSH_RESULT,
+                        requestId,
+                        ok: false,
+                        reason: 'not-authorized'
+                    });
+                    return;
+                }
                 clipQueue = clipQueue
                     .then(async () => {
                         const ok = await pushOsTextToVmClipboard(event.data.text);
@@ -761,6 +769,16 @@
 
             if (event.data.type === MSG_EXTRACT_REQ) {
                 const requestId = event.data.requestId;
+                if (!fosAuthorized) {
+                    console.warn(EMBED_LOG + ': extract ignored — not authorized');
+                    reply(event, {
+                        type: MSG_EXTRACT_RESULT,
+                        requestId,
+                        ok: false,
+                        reason: 'not-authorized'
+                    });
+                    return;
+                }
                 clipQueue = clipQueue
                     .then(async () => {
                         const text = readVmClipboardText();

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      13.4
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      13.2
+// @version      13.3
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '13.2';
+    const VERSION = '13.3';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -733,14 +733,28 @@
                 clipQueue = clipQueue
                     .then(async () => {
                         const ok = await pushOsTextToVmClipboard(event.data.text);
-                        reply(event, { type: MSG_PUSH_RESULT, requestId, ok: !!ok });
                         if (ok) {
+                            reply(event, { type: MSG_PUSH_RESULT, requestId, ok: true });
                             console.log(EMBED_LOG + ': push ok');
+                        } else {
+                            reply(event, {
+                                type: MSG_PUSH_RESULT,
+                                requestId,
+                                ok: false,
+                                reason: 'missing-clipboard-field'
+                            });
                         }
                     })
                     .catch((e) => {
+                        const error = String((e && e.message) || e);
                         console.warn(EMBED_LOG + ': push failed', e);
-                        reply(event, { type: MSG_PUSH_RESULT, requestId, ok: false });
+                        reply(event, {
+                            type: MSG_PUSH_RESULT,
+                            requestId,
+                            ok: false,
+                            reason: 'exception',
+                            error
+                        });
                     });
                 return;
             }
@@ -751,19 +765,37 @@
                     .then(async () => {
                         const text = readVmClipboardText();
                         if (text == null) {
-                            reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: false });
+                            reply(event, {
+                                type: MSG_EXTRACT_RESULT,
+                                requestId,
+                                ok: false,
+                                reason: 'missing-clipboard-field'
+                            });
                             return;
                         }
                         if (!text) {
-                            reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: false, text: '' });
+                            reply(event, {
+                                type: MSG_EXTRACT_RESULT,
+                                requestId,
+                                ok: false,
+                                text: '',
+                                reason: 'empty'
+                            });
                             return;
                         }
                         reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: true, text });
                         console.log(EMBED_LOG + ': extract ok');
                     })
                     .catch((e) => {
+                        const error = String((e && e.message) || e);
                         console.warn(EMBED_LOG + ': extract failed', e);
-                        reply(event, { type: MSG_EXTRACT_RESULT, requestId, ok: false });
+                        reply(event, {
+                            type: MSG_EXTRACT_RESULT,
+                            requestId,
+                            ok: false,
+                            reason: 'exception',
+                            error
+                        });
                     });
             }
         });

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      13.2
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/dev/logger-panel.js
+++ b/plugins/core/dev/logger-panel.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'dev-logger-panel',
     name: 'Dev Logger Panel',
     description: 'Floating panel to view Fleet UX Enhancer logs',
-    _version: '2.17',
+    _version: '2.18',
     enabledByDefault: true,
     phase: 'core',
 
@@ -400,13 +400,13 @@ const plugin = {
                     const rect = ui.root.getBoundingClientRect();
                     Storage.set(self.storageKeys.positionLeft, rect.left);
                     Storage.set(self.storageKeys.positionTop, rect.top);
-                    Logger.log(`Dev logger position saved: left=${rect.left}, top=${rect.top}`);
+                    Logger.debug(`Dev logger position saved: left=${rect.left}, top=${rect.top}`);
                 }
                 if (state.isResizing && ui) {
                     const rect = ui.root.getBoundingClientRect();
                     Storage.set(self.storageKeys.width, rect.width);
                     Storage.set(self.storageKeys.height, rect.height);
-                    Logger.log(`Dev logger size saved: width=${rect.width}, height=${rect.height}`);
+                    Logger.debug(`Dev logger size saved: width=${rect.width}, height=${rect.height}`);
                 }
                 state.isDragging = false;
                 state.isResizing = false;

--- a/plugins/core/main/fos-embedded-watcher.js
+++ b/plugins/core/main/fos-embedded-watcher.js
@@ -192,7 +192,7 @@ const plugin = {
     name: 'FOS Embedded Watcher',
     description:
         'Detects embedded FOS desktop envs (noVNC/child shape), signals the iframe child, and hosts parent-side VM Clipboard controls',
-    _version: '3.1',
+    _version: '3.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: {
@@ -372,6 +372,26 @@ const plugin = {
         return null;
     },
 
+    _childFailureDetail(result, emptyFallback) {
+        if (!result) {
+            return 'no result';
+        }
+        if (result.timedOut) {
+            return 'timed out';
+        }
+        if (result.reason) {
+            const err =
+                result.error != null && String(result.error)
+                    ? String(result.error)
+                    : '';
+            return err ? result.reason + ': ' + err : String(result.reason);
+        }
+        if (emptyFallback && result.text === '') {
+            return 'VM clipboard empty';
+        }
+        return 'unknown';
+    },
+
     async _overwriteInstance(state, instanceId) {
         const id = String(instanceId || '');
         const child = this._resolveChild(state, id);
@@ -406,7 +426,7 @@ const plugin = {
             Logger.log('overwrite ok for ' + id);
             return true;
         }
-        Logger.warn('overwrite failed for ' + id);
+        Logger.warn('overwrite failed for ' + id + ' — ' + this._childFailureDetail(result, false));
         return false;
     },
 
@@ -431,7 +451,7 @@ const plugin = {
         }
         const result = await resultPromise;
         if (!result || !result.ok || typeof result.text !== 'string' || !result.text) {
-            Logger.warn('extract failed for ' + id);
+            Logger.warn('extract failed for ' + id + ' — ' + this._childFailureDetail(result, true));
             return false;
         }
         try {

--- a/plugins/core/main/fos-embedded-watcher.js
+++ b/plugins/core/main/fos-embedded-watcher.js
@@ -8,6 +8,7 @@ const FOS_ENV_HOST_PATTERN = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
 const FOS_ORCHESTRATOR_INSTANCES_URL = 'https://orchestrator.fleetai.com/v1/env/instances';
 const FOS_CHILD_READY_TYPE = 'fleet-fos-child-ready';
 const FOS_EMBEDDED_READY_TYPE = 'fleet-fos-embedded-ready';
+const FOS_EMBEDDED_ACK_TYPE = 'fleet-fos-embedded-ack';
 const FOS_PUSH_TYPE = 'fleet-fos-push-clipboard';
 const FOS_PUSH_RESULT_TYPE = 'fleet-fos-push-result';
 const FOS_EXTRACT_REQ_TYPE = 'fleet-fos-extract-request';
@@ -192,7 +193,7 @@ const plugin = {
     name: 'FOS Embedded Watcher',
     description:
         'Detects embedded FOS desktop envs (noVNC/child shape), signals the iframe child, and hosts parent-side VM Clipboard controls',
-    _version: '3.2',
+    _version: '4.0',
     phase: 'core',
     enabledByDefault: true,
     initialState: {
@@ -205,6 +206,7 @@ const plugin = {
         readinessListeners: null,
         messageListenerInstalled: false,
         resultListenerInstalled: false,
+        ackListenerInstalled: false,
         iframeObserverInstalled: false,
         layoutListenersInstalled: false,
         activationLogged: false,
@@ -241,6 +243,7 @@ const plugin = {
         this._subscribeDesktopShape(state);
         this._subscribeLatch(state);
         this._listenChildReady(state);
+        this._listenEmbeddedAck(state);
         this._listenClipboardResults(state);
         this._watchEnvIframes(state);
         this._installLayoutListeners(state);
@@ -898,9 +901,8 @@ const plugin = {
                 (hostname ? fosFindEnvIframeByHostname(hostname) : null);
             if (iframe) {
                 this._patchIframeClipboardAllow(state, iframe);
-                this._markInstanceReady(state, instanceId, child, iframe);
-                this._mountClipboardPanel(state, instanceId, child, iframe);
             }
+            // Ready UI waits for fleet-fos-embedded-ack so push/extract are not offered before auth.
             if (!state.activationLogged) {
                 state.activationLogged = true;
                 Logger.log('signaled embedded FOS iframe for instance ' +
@@ -917,6 +919,58 @@ const plugin = {
             Logger.warn('postMessage to child failed for ' + instanceId, e);
             return false;
         }
+    },
+
+    _onEmbeddedAck(state, event) {
+        let originHostname = '';
+        try {
+            originHostname = new URL(event.origin).hostname;
+        } catch (_e) {
+            return;
+        }
+        if (!FOS_ENV_HOST_PATTERN.test(originHostname)) {
+            return;
+        }
+        if (!event.data || event.data.ok !== true) {
+            Logger.warn('embedded ack rejected from ' + originHostname);
+            return;
+        }
+        const instanceId = fosInstanceIdFromHostname(originHostname);
+        if (!instanceId) {
+            return;
+        }
+        const rec = state.fosInstances.get(instanceId);
+        const child =
+            (rec && rec.child && rec.child.source === event.source && rec.child) ||
+            { source: event.source, origin: event.origin };
+        if (rec) {
+            rec.child = child;
+        }
+        const iframe =
+            fosFindIframeForSource(event.source) ||
+            fosFindEnvIframeByHostname(originHostname);
+        if (!iframe) {
+            Logger.warn('embedded ack for ' + instanceId + ' — iframe not found');
+            return;
+        }
+        this._patchIframeClipboardAllow(state, iframe);
+        this._markInstanceReady(state, instanceId, child, iframe);
+        this._mountClipboardPanel(state, instanceId, child, iframe);
+        Logger.log('embedded bridge authorized for ' + instanceId);
+    },
+
+    _listenEmbeddedAck(state) {
+        if (state.ackListenerInstalled) {
+            return;
+        }
+        state.ackListenerInstalled = true;
+        const self = this;
+        window.addEventListener('message', (event) => {
+            if (!event.data || event.data.type !== FOS_EMBEDDED_ACK_TYPE) {
+                return;
+            }
+            self._onEmbeddedAck(state, event);
+        });
     },
 
     _flushPendingChild(state, instanceId) {
@@ -1100,6 +1154,9 @@ const plugin = {
             self._patchIframeForChild(state, child, hostname);
             self._markFosDesktop(state, instanceId, 'child-ready');
             Logger.debug('child-ready from ' + instanceId);
+            // Iframe navigated/reloaded: clear prior ready until the new document acks.
+            self._teardownPanel(state, instanceId);
+            self._unmarkInstanceReady(state, instanceId);
             if (!self._tryNotifyChild(state, instanceId, child)) {
                 state.pendingChildren.set(instanceId, child);
                 Logger.debug('child queued pending latch for ' + instanceId);

--- a/plugins/libs/fos-vm-clipboard-bar.js
+++ b/plugins/libs/fos-vm-clipboard-bar.js
@@ -181,8 +181,6 @@ const FosVmClipboardBarApi = {
                 this._flash(bExtract, !!ok);
                 if (ok) {
                     Logger.log(`extract ok`);
-                } else {
-                    Logger.warn(`extract failed`);
                 }
             }).catch((err) => {
                 this._flash(bExtract, false);
@@ -202,8 +200,6 @@ const FosVmClipboardBarApi = {
                 this._flash(bOverwrite, !!ok);
                 if (ok) {
                     Logger.log(`overwrite ok`);
-                } else {
-                    Logger.warn(`overwrite failed`);
                 }
             }).catch((err) => {
                 this._flash(bOverwrite, false);
@@ -222,7 +218,7 @@ const plugin = {
     name: 'FOS VM Clipboard Bar (library)',
     description:
         'Shared VM Clipboard Extract/Overwrite bar chrome (archetype modules supply find/mount)',
-    _version: '1.4',
+    _version: '1.5',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },


### PR DESCRIPTION
## Summary

Hardens the embedded FOS VM clipboard bridge so Extract/Overwrite wait for a real parent↔iframe auth handshake (fixing silent timeouts), and surfaces concrete failure reasons when those operations fail. Also stops `sync-branch-config` from resetting `@name` bases from `origin/main`, so branch-local display names survive remaps.

## Changes

- **FOS embedded bridge**: Parent now ACKs `fleet-fos-embedded-ready`; the watcher mounts VM Clipboard UI only after `fleet-fos-embedded-ack`, and tears down readiness on child reload so push/extract are not offered before auth.
- **Clipboard failure detail**: Push/extract replies include `reason` / `error`; parent overwrite and extract warnings log that detail instead of a bare failure.
- **sync-branch-config**: `@name` base is taken from the files being synced (strip existing `[branch]` prefix) rather than from `origin/main`, with docs updated to match.
