### PR TITLE
Stabilize Search Output overlays and add plugin CDN failover

### DIFF
--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.379",
+  "archetypesVersion": "14.380",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -206,8 +206,8 @@
     },
     {
       "name": "dashboard.js",
-      "version": "12.12",
-      "hash": "sha256-68e3c74df9bf25cd742fbc5c5429df95e24c04966547bdc070ca9a7176ba7d65",
+      "version": "12.13",
+      "hash": "sha256-b863cffbaf6042e53e352099d2789ddd4163b7a1dbe028dc5a91e53c001c6dea",
       "log": false
     },
     {
@@ -254,8 +254,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.52",
-      "hash": "sha256-b12c3c65342c2d2f2d0626732d281d415c986f3f3876dcde2090c307d9ae6fbe",
+      "version": "9.53",
+      "hash": "sha256-9bf75c2b42f3d445b1217db8af91e274e5219908a2c81e56750be666c9697338",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.383",
+  "archetypesVersion": "14.384",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -254,8 +254,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.54",
-      "hash": "sha256-fe2e86ee3682309beffcba274577af40137cec057de55e24c72e14ac83586df8",
+      "version": "9.55",
+      "hash": "sha256-0c20574caa46aafbb09f335ecd8f463b9e8dd027ed793a5c1d445790a3766008",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.380",
+  "archetypesVersion": "14.381",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -224,8 +224,8 @@
     },
     {
       "name": "search-output-left-pane.js",
-      "version": "5.17",
-      "hash": "sha256-ec2fddcfeb9061d9c21cd3c865d4df6f484f7f6b3c79fbcd6bd9a484595e3f49",
+      "version": "5.18",
+      "hash": "sha256-6fd082777f63fb9a863ec67835893539cb3a5cd18a4ea0ea7beaf7d8575419a9",
       "log": false
     },
     {
@@ -254,8 +254,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.53",
-      "hash": "sha256-9bf75c2b42f3d445b1217db8af91e274e5219908a2c81e56750be666c9697338",
+      "version": "9.54",
+      "hash": "sha256-fe2e86ee3682309beffcba274577af40137cec057de55e24c72e14ac83586df8",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.386",
+  "archetypesVersion": "14.387",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -230,8 +230,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "10.5",
-      "hash": "sha256-f670ce0cb0624d18d08c6dc7803fbbd081655d90f1895caffbf34ad3e1d1c258",
+      "version": "10.6",
+      "hash": "sha256-1cc2a6b71ed08f7a3fc7306628807c23aaf02243f2cc07ae29147ba0ceb47f5c",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.376",
+  "archetypesVersion": "14.378",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -16,8 +16,8 @@
   "corePlugins": [
     {
       "name": "ui-lib.js",
-      "version": "3.18",
-      "hash": "sha256-f4fbf27932e0dbb682a34f2fb64c29af0c77967e4d06ca2e4f392b65be558aca",
+      "version": "3.19",
+      "hash": "sha256-c7143dc5532bc1702a879af9ec7671e5037b275eaf0d53f110d53229749f6181",
       "log": false
     },
     {
@@ -34,8 +34,8 @@
     },
     {
       "name": "settings-ui.js",
-      "version": "11.15",
-      "hash": "sha256-5fd229b563e2772a2d640b91128ad79dfc7aba28bd2e6d95baaff749c2b08bdb",
+      "version": "11.17",
+      "hash": "sha256-269476c101a539f10e227ddff8b191f0eb7733077f83948101fb91db73082052",
       "log": false
     },
     {
@@ -272,8 +272,8 @@
     },
     {
       "name": "team-members.js",
-      "version": "5.0",
-      "hash": "sha256-afce04a5e4e5294d69dcdc138fe14c30ca6b07338c64e0aae426a5b1156befd6",
+      "version": "5.2",
+      "hash": "sha256-bff727b2bb0d0342ab4a464ab1c834302a857dc05e3dd1aec1d52e01b0ee185e",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.381",
+  "archetypesVersion": "14.382",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -230,8 +230,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "10.2",
-      "hash": "sha256-a04b7391757d1b04ee10275125ed0a7d1cdf15e0745b183ad80ae2ae96abc60c",
+      "version": "10.3",
+      "hash": "sha256-3ddc0485eb4ce7317aa5f4ff98809f9dc969ab8e3de334d303bd5ac4cb013a72",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.384",
+  "archetypesVersion": "14.385",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -230,8 +230,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "10.4",
-      "hash": "sha256-918ac5a75cb5065150220fb1163b59d214b4d4d35c409d27b4dfc915dec3cf14",
+      "version": "10.5",
+      "hash": "sha256-f670ce0cb0624d18d08c6dc7803fbbd081655d90f1895caffbf34ad3e1d1c258",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.387",
+  "archetypesVersion": "14.388",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -230,8 +230,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "10.6",
-      "hash": "sha256-1cc2a6b71ed08f7a3fc7306628807c23aaf02243f2cc07ae29147ba0ceb47f5c",
+      "version": "10.7",
+      "hash": "sha256-ce7246ad809d501bb14283e8ec3e6850c1e04d27b3e0143ed49baff2c13efb1e",
       "log": false
     },
     {
@@ -254,8 +254,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.56",
-      "hash": "sha256-4d190e6cfdbcddaad2ae5db082eb4cb64fe621bfec0b18a05603b66bcd00bf06",
+      "version": "9.57",
+      "hash": "sha256-af4b495e5df588b173f6b578994163783c8d3df6d4f7e7b16eb0dfa3fe8a857a",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "13.10",
+  "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.375",
+  "archetypesVersion": "14.376",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -34,8 +34,8 @@
     },
     {
       "name": "settings-ui.js",
-      "version": "11.14",
-      "hash": "sha256-e0bf8a28ae58094257c4527153ae59147bcb3c835643e20989c60f3fe94d2b81",
+      "version": "11.15",
+      "hash": "sha256-5fd229b563e2772a2d640b91128ad79dfc7aba28bd2e6d95baaff749c2b08bdb",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.378",
+  "archetypesVersion": "14.379",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -272,8 +272,8 @@
     },
     {
       "name": "team-members.js",
-      "version": "5.2",
-      "hash": "sha256-bff727b2bb0d0342ab4a464ab1c834302a857dc05e3dd1aec1d52e01b0ee185e",
+      "version": "5.3",
+      "hash": "sha256-e1cda0e6d30f05971c0db4a3de6604390dea3f5385b8d9c4a1651436884a7ea4",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "13.9",
+  "version": "13.10",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.374",
+  "archetypesVersion": "14.375",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.382",
+  "archetypesVersion": "14.383",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -230,8 +230,8 @@
     },
     {
       "name": "search-output-results-pane.js",
-      "version": "10.3",
-      "hash": "sha256-3ddc0485eb4ce7317aa5f4ff98809f9dc969ab8e3de334d303bd5ac4cb013a72",
+      "version": "10.4",
+      "hash": "sha256-918ac5a75cb5065150220fb1163b59d214b4d4d35c409d27b4dfc915dec3cf14",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.385",
+  "archetypesVersion": "14.386",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -254,8 +254,8 @@
     },
     {
       "name": "search-output.js",
-      "version": "9.55",
-      "hash": "sha256-0c20574caa46aafbb09f335ecd8f463b9e8dd027ed793a5c1d445790a3766008",
+      "version": "9.56",
+      "hash": "sha256-4d190e6cfdbcddaad2ae5db082eb4cb64fe621bfec0b18a05603b66bcd00bf06",
       "log": false
     },
     {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
-  "version": "13.8",
+  "version": "13.9",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.373",
+  "archetypesVersion": "14.374",
   "logs": {
     "debug": false,
     "verbose": false,

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      13.10
+// @version      13.11
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '13.10';
+    const VERSION = '13.11';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -945,6 +945,89 @@
         getPluginKey(filename, sourcePath) {
             // Create a unique key for the plugin based on its path
             return sourcePath || filename;
+        },
+        /**
+         * Resolve GM plugin-cache sourcePath for a registered plugin.
+         * Prefers plugin._sourcePath; otherwise reconstructs from flags + current archetype.
+         */
+        resolvePluginSourcePath(plugin) {
+            if (!plugin || typeof plugin !== 'object') return null;
+            if (typeof plugin._sourcePath === 'string' && plugin._sourcePath) {
+                return plugin._sourcePath;
+            }
+            const filename = plugin._sourceFile || null;
+            if (!filename || typeof filename !== 'string') return null;
+            if (plugin._isLib) return `libs/${filename}`;
+            if (plugin._isCore && plugin._isDev) return `core/dev/${filename}`;
+            if (plugin._isCore) return `core/main/${filename}`;
+            const am = Context.archetypeManager;
+            if (plugin._isDev) {
+                const devId = (am && am.currentDevArchetype && am.currentDevArchetype.id)
+                    || (Context.currentDevArchetype && Context.currentDevArchetype.id)
+                    || null;
+                if (devId) return `archetypes/${devId}/dev/${filename}`;
+                return null;
+            }
+            const archId = (am && am.currentArchetype && am.currentArchetype.id)
+                || (Context.currentArchetype && Context.currentArchetype.id)
+                || null;
+            if (archId) return `archetypes/${archId}/main/${filename}`;
+            return null;
+        },
+        /**
+         * Clear GM code cache and module-associated settings for a plugin.
+         * Keeps plugin-{id}-enabled. Does not unregister from PluginManager.
+         * @returns {{ clearedKeys: number, sourcePath: string|null }}
+         */
+        clearModuleLocalData(plugin) {
+            if (!plugin || !plugin.id) {
+                return { clearedKeys: 0, sourcePath: null };
+            }
+            let clearedKeys = 0;
+            const sourcePath = this.resolvePluginSourcePath(plugin);
+            const filename = plugin._sourceFile || (sourcePath ? sourcePath.split('/').pop() : null);
+
+            if (sourcePath) {
+                const pluginKey = this.getPluginKey(filename || sourcePath, sourcePath);
+                this.clearCachedPlugin(pluginKey);
+                clearedKeys++;
+                if (sourcePath.startsWith('archetypes/')) {
+                    const parts = sourcePath.split('/');
+                    if (parts.length >= 3 && parts[1] && filename) {
+                        this.unregisterCachedPlugin(parts[1], filename);
+                    }
+                }
+            }
+
+            this.delete(`module-logging-${plugin.id}`);
+            clearedKeys++;
+            if (Context.logger && Context.logger._moduleLogEnabled
+                && Object.prototype.hasOwnProperty.call(Context.logger._moduleLogEnabled, plugin.id)) {
+                delete Context.logger._moduleLogEnabled[plugin.id];
+            }
+
+            if (plugin.subOptions && Array.isArray(plugin.subOptions)) {
+                plugin.subOptions.forEach((subOption) => {
+                    if (!subOption || !subOption.id) return;
+                    this.delete(`suboption-${plugin.id}-${subOption.id}`);
+                    clearedKeys++;
+                });
+            }
+
+            this.delete(`${plugin.id}-ignored`);
+            clearedKeys++;
+
+            if (plugin.storageKeys && typeof plugin.storageKeys === 'object' && !Array.isArray(plugin.storageKeys)) {
+                Object.keys(plugin.storageKeys).forEach((k) => {
+                    const key = plugin.storageKeys[k];
+                    if (typeof key === 'string' && key) {
+                        this.delete(key);
+                        clearedKeys++;
+                    }
+                });
+            }
+
+            return { clearedKeys, sourcePath };
         },
         // Settings modal doc cache (versioned, same pattern as plugin cache)
         getCachedSettingsDoc(name) {
@@ -3387,6 +3470,7 @@
             
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
+            plugin._sourcePath = sourcePath;
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded core plugin ${filename} v${version}`);
             return plugin;
@@ -3412,6 +3496,7 @@
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
+            plugin._sourcePath = sourcePath;
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded library ${filename} v${version}`);
             return plugin;
@@ -3430,6 +3515,7 @@
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
+            plugin._sourcePath = sourcePath;
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded dev plugin ${filename} v${version}`);
             return plugin;
@@ -3455,6 +3541,7 @@
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
+            plugin._sourcePath = sourcePath;
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded ${filename} v${version} from ${sourcePath}`);
             return plugin;
@@ -3481,6 +3568,7 @@
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
+            plugin._sourcePath = sourcePath;
             this._loadedPluginFiles.add(sourcePath);
             Logger.debug(`Loaded dev archetype plugin ${filename} v${version} from ${sourcePath}`);
             return plugin;

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      13.8
+// @version      13.9
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '13.8';
+    const VERSION = '13.9';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -964,6 +964,39 @@
             const cacheData = { raw, version, cachedAt: Date.now() };
             this.set(`settings-doc-cache-${name}`, JSON.stringify(cacheData));
         },
+        // Last-known-good archetypes.json (branch-scoped fallback when GitHub fetch fails)
+        getCachedArchetypesJson(branch) {
+            const cached = this.get('archetypes-json-cache', null);
+            if (!cached) return null;
+            try {
+                const parsed = typeof cached === 'string' ? JSON.parse(cached) : cached;
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+                if (!parsed.raw || typeof parsed.raw !== 'string') return null;
+                if (branch && parsed.branch !== branch) return null;
+                return {
+                    raw: parsed.raw,
+                    branch: parsed.branch || null,
+                    archetypesVersion: parsed.archetypesVersion != null ? parsed.archetypesVersion : null,
+                    cachedAt: typeof parsed.cachedAt === 'number' ? parsed.cachedAt : null
+                };
+            } catch (e) {
+                Logger.error('Failed to parse cached archetypes.json:', e);
+                return null;
+            }
+        },
+        setCachedArchetypesJson(raw, branch, archetypesVersion) {
+            if (!raw || typeof raw !== 'string' || !branch) return;
+            const cacheData = {
+                raw,
+                branch,
+                archetypesVersion: archetypesVersion != null ? archetypesVersion : null,
+                cachedAt: Date.now()
+            };
+            this.set('archetypes-json-cache', JSON.stringify(cacheData));
+        },
+        clearCachedArchetypesJson() {
+            this.delete('archetypes-json-cache');
+        },
         getSubmoduleLoggingEnabled() {
             return this.get('submodule-logging', DEFAULT_STORAGE_SUBMODULE_LOGGING);
         },
@@ -1095,7 +1128,8 @@
                 'debug',
                 'verbose',
                 'submodule-logging',
-                'disputes-cache'
+                'disputes-cache',
+                'archetypes-json-cache'
             ];
             globalKeys.forEach(key => {
                 this.delete(key);
@@ -2381,6 +2415,51 @@
             const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.archetypesPath}?t=${timestamp}`;
             
             Logger.debug(`Fetching archetypes from branch: ${GITHUB_CONFIG.branch} (${url})`);
+
+            const isTransientArchetypesFailure = (status) => {
+                if (status === 0 || status === 408 || status === 429) return true;
+                if (typeof status === 'number' && status >= 500 && status <= 599) return true;
+                return false;
+            };
+
+            const formatCacheAge = (cachedAt) => {
+                if (typeof cachedAt !== 'number' || !cachedAt) return 'unknown age';
+                const ms = Math.max(0, Date.now() - cachedAt);
+                const sec = Math.floor(ms / 1000);
+                if (sec < 60) return `${sec}s old`;
+                const min = Math.floor(sec / 60);
+                if (min < 60) return `${min}m old`;
+                const hr = Math.floor(min / 60);
+                if (hr < 48) return `${hr}h old`;
+                const days = Math.floor(hr / 24);
+                return `${days}d old`;
+            };
+
+            const tryFallback = (reason, resolve, reject) => {
+                const cached = Storage.getCachedArchetypesJson(GITHUB_CONFIG.branch);
+                if (!cached) {
+                    reject(reason instanceof Error ? reason : new Error(String(reason)));
+                    return;
+                }
+                try {
+                    const config = JSON.parse(cached.raw);
+                    if (!config || typeof config !== 'object' || Array.isArray(config)) {
+                        reject(reason instanceof Error ? reason : new Error(String(reason)));
+                        return;
+                    }
+                    this._applyArchetypesConfig(config);
+                    const ver = cached.archetypesVersion != null
+                        ? cached.archetypesVersion
+                        : (config.archetypesVersion || 'unknown');
+                    Logger.warn(
+                        `GitHub fetch failed (${reason instanceof Error ? reason.message : reason}); using cached archetypes v${ver} (${formatCacheAge(cached.cachedAt)})`
+                    );
+                    resolve(config);
+                } catch (e) {
+                    Logger.error('Failed to apply cached archetypes.json:', e);
+                    reject(reason instanceof Error ? reason : new Error(String(reason)));
+                }
+            };
             
             return new Promise((resolve, reject) => {
                 GM_xmlhttpRequest({
@@ -2392,81 +2471,110 @@
                         'Expires': '0'
                     },
                     onload: (response) => {
-                        if (response.status === 200) {
+                        const status = typeof response.status === 'number' ? response.status : 0;
+                        if (status === 200) {
+                            const raw = response.responseText || '';
+                            if (!raw.trim()) {
+                                Logger.error('Failed to load archetypes: empty response body');
+                                tryFallback(new Error('empty archetypes.json body'), resolve, reject);
+                                return;
+                            }
                             try {
-                                const config = JSON.parse(response.responseText);
-                                this.archetypes = config.archetypes || [];
-                                this.devArchetypes = config.devArchetypes || [];
-                                this.corePlugins = config.corePlugins || [];
-                                this.libraries = config.libraries || [];
-                                this.opsDashboardPlugins = config.opsDashboardPlugins || [];
-                                this.opsDashboardLibraries = Array.isArray(config.opsDashboardLibraries)
-                                    ? config.opsDashboardLibraries
-                                    : [];
-                                this.devPlugins = config.devPlugins || [];
-                                this.settingsModalDocs = config.settingsModalDocs || [];
-                                
-                                // Check if script version is outdated
-                                if (config.version) {
-                                    const latestVersion = config.version;
-                                    Context.latestVersion = latestVersion;
-                                    // Simple version comparison: if versions don't match, consider outdated
-                                    // This handles semantic versioning (e.g., "3.4.0" vs "3.4.1")
-                                    Context.isOutdated = compareVersions(VERSION, latestVersion) < 0;
-                                    if (Context.isOutdated) {
-                                        Logger.warn(`Script version ${VERSION} is outdated. Latest version is ${latestVersion}`);
-                                    }
-                                } else {
-                                    // No version in config, assume up to date
-                                    Context.isOutdated = false;
-                                    Context.latestVersion = VERSION;
+                                const config = JSON.parse(raw);
+                                if (!config || typeof config !== 'object' || Array.isArray(config)) {
+                                    Logger.error('Failed to parse archetypes config: not a JSON object');
+                                    tryFallback(new Error('archetypes.json is not a JSON object'), resolve, reject);
+                                    return;
                                 }
-                                if (Context.settingsUi && typeof Context.settingsUi.refreshUpdateIndicator === 'function') {
-                                    try {
-                                        Context.settingsUi.refreshUpdateIndicator();
-                                    } catch (refreshErr) {
-                                        Logger.debug('Settings UI update indicator refresh failed', refreshErr);
-                                    }
-                                }
-                                
-                                // Always log archetypes version (cannot be disabled)
-                                Context.archetypesVersion = config.archetypesVersion || null;
-                                Context.coreOnlyMode = config.coreOnlyMode === true;
-                                Context.opsAccess = config.opsAccess && typeof config.opsAccess === 'object'
-                                    ? config.opsAccess
-                                    : null;
-                                Context.opsSecrets = config.opsSecrets && typeof config.opsSecrets === 'object'
-                                    ? config.opsSecrets
-                                    : null;
-                                applyArchetypeRemoteLoggingConfig(config);
-                                console.log(`${LOG_PREFIX} archetypes v${config.archetypesVersion || 'unknown'}`);
-                                if (Context.coreOnlyMode) {
-                                    Logger.log('coreOnlyMode is enabled: archetype UX plugins and SPA auto-reload are off; core plugins remain active.');
-                                }
-                                
-                                Logger.log(`Loaded ${this.archetypes.length} archetypes from branch: ${GITHUB_CONFIG.branch}`);
-                                if (DEV_SCRIPTS_ENABLED) {
-                                    clearOrphanMarkerForCurrentBranch();
-                                }
+                                this._applyArchetypesConfig(config);
+                                Storage.setCachedArchetypesJson(
+                                    raw,
+                                    GITHUB_CONFIG.branch,
+                                    config.archetypesVersion != null ? config.archetypesVersion : null
+                                );
                                 resolve(config);
                             } catch (e) {
                                 Logger.error('Failed to parse archetypes config:', e);
-                                reject(e);
+                                tryFallback(e, resolve, reject);
                             }
                         } else {
-                            Logger.error(`Failed to load archetypes: ${response.status}`);
-                            if (response.status === 404 && DEV_SCRIPTS_ENABLED) {
+                            Logger.error(`Failed to load archetypes: ${status}`);
+                            if (status === 404 && DEV_SCRIPTS_ENABLED) {
                                 yieldToMainForOrphanedBranch('archetypes.json HTTP 404');
                             }
-                            reject(new Error(`HTTP ${response.status}`));
+                            if (status === 404 || !isTransientArchetypesFailure(status)) {
+                                reject(new Error(`HTTP ${status}`));
+                                return;
+                            }
+                            tryFallback(new Error(`HTTP ${status}`), resolve, reject);
                         }
                     },
                     onerror: (error) => {
                         Logger.error('Network error loading archetypes:', error);
-                        reject(error);
+                        tryFallback(error instanceof Error ? error : new Error('network error loading archetypes'), resolve, reject);
+                    },
+                    ontimeout: () => {
+                        Logger.error('Timeout loading archetypes');
+                        tryFallback(new Error('timeout loading archetypes'), resolve, reject);
                     }
                 });
             });
+        },
+
+        _applyArchetypesConfig(config) {
+            this.archetypes = config.archetypes || [];
+            this.devArchetypes = config.devArchetypes || [];
+            this.corePlugins = config.corePlugins || [];
+            this.libraries = config.libraries || [];
+            this.opsDashboardPlugins = config.opsDashboardPlugins || [];
+            this.opsDashboardLibraries = Array.isArray(config.opsDashboardLibraries)
+                ? config.opsDashboardLibraries
+                : [];
+            this.devPlugins = config.devPlugins || [];
+            this.settingsModalDocs = config.settingsModalDocs || [];
+
+            // Check if script version is outdated
+            if (config.version) {
+                const latestVersion = config.version;
+                Context.latestVersion = latestVersion;
+                // Simple version comparison: if versions don't match, consider outdated
+                // This handles semantic versioning (e.g., "3.4.0" vs "3.4.1")
+                Context.isOutdated = compareVersions(VERSION, latestVersion) < 0;
+                if (Context.isOutdated) {
+                    Logger.warn(`Script version ${VERSION} is outdated. Latest version is ${latestVersion}`);
+                }
+            } else {
+                // No version in config, assume up to date
+                Context.isOutdated = false;
+                Context.latestVersion = VERSION;
+            }
+            if (Context.settingsUi && typeof Context.settingsUi.refreshUpdateIndicator === 'function') {
+                try {
+                    Context.settingsUi.refreshUpdateIndicator();
+                } catch (refreshErr) {
+                    Logger.debug('Settings UI update indicator refresh failed', refreshErr);
+                }
+            }
+
+            // Always log archetypes version (cannot be disabled)
+            Context.archetypesVersion = config.archetypesVersion || null;
+            Context.coreOnlyMode = config.coreOnlyMode === true;
+            Context.opsAccess = config.opsAccess && typeof config.opsAccess === 'object'
+                ? config.opsAccess
+                : null;
+            Context.opsSecrets = config.opsSecrets && typeof config.opsSecrets === 'object'
+                ? config.opsSecrets
+                : null;
+            applyArchetypeRemoteLoggingConfig(config);
+            console.log(`${LOG_PREFIX} archetypes v${config.archetypesVersion || 'unknown'}`);
+            if (Context.coreOnlyMode) {
+                Logger.log('coreOnlyMode is enabled: archetype UX plugins and SPA auto-reload are off; core plugins remain active.');
+            }
+
+            Logger.log(`Loaded ${this.archetypes.length} archetypes from branch: ${GITHUB_CONFIG.branch}`);
+            if (DEV_SCRIPTS_ENABLED) {
+                clearOrphanMarkerForCurrentBranch();
+            }
         },
 
         getCorePlugins() {

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -2,7 +2,7 @@
 // ==UserScript==
 // @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      13.9
+// @version      13.10
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
 // @author       Nicholas Doherty
 // @match        https://www.fleetai.com/*
@@ -38,7 +38,7 @@
     }
 
     // ============= CORE CONFIGURATION =============
-    const VERSION = '13.9';
+    const VERSION = '13.10';
     const STORAGE_PREFIX = 'wf-enhancer-';
     const SHARED_STORAGE_KEYS = {
         favoriteTools: 'favorite-tools'
@@ -1472,6 +1472,160 @@
 
     Context.logger = Logger;
 
+    // ============= REPO CDN (session failover) =============
+    // Probe GitHub then jsDelivr for archetypes.json once; lock that host for all
+    // further repo fetches. If both miss → cache-only (GM storage only, no CDN).
+    const RepoCdn = {
+        /** @type {null|'github'|'jsdelivr'|'cache-only'} */
+        mode: null,
+        /** HTTP status from the GitHub archetypes probe (0 if network/other). */
+        lastGithubStatus: 0,
+
+        isCacheOnly() {
+            return this.mode === 'cache-only';
+        },
+
+        isNetworkLocked() {
+            return this.mode === 'github' || this.mode === 'jsdelivr';
+        },
+
+        setMode(mode) {
+            if (this.mode === mode) return;
+            this.mode = mode;
+            Logger.log(`Repo CDN: ${mode}`);
+        },
+
+        /**
+         * @param {string} repoPath - Path relative to repo root (e.g. archetypes.json, plugins/core/main/x.js)
+         * @param {'github'|'jsdelivr'} [modeOverride]
+         */
+        buildUrl(repoPath, modeOverride) {
+            const mode = modeOverride || this.mode;
+            const path = String(repoPath || '').replace(/^\//, '');
+            if (mode === 'jsdelivr') {
+                return `https://cdn.jsdelivr.net/gh/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}@${GITHUB_CONFIG.branch}/${path}`;
+            }
+            return `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${path}`;
+        },
+
+        _gmGet(url) {
+            return new Promise((resolve, reject) => {
+                GM_xmlhttpRequest({
+                    method: 'GET',
+                    url: url,
+                    headers: {
+                        'Cache-Control': 'no-cache, no-store, must-revalidate',
+                        'Pragma': 'no-cache',
+                        'Expires': '0'
+                    },
+                    onload: (response) => {
+                        const status = typeof response.status === 'number' ? response.status : 0;
+                        if (status === 200) {
+                            resolve({ status: status, text: response.responseText || '' });
+                            return;
+                        }
+                        const err = new Error(`HTTP ${status}`);
+                        err.status = status;
+                        reject(err);
+                    },
+                    onerror: (error) => {
+                        const err = error instanceof Error ? error : new Error('network error');
+                        err.status = 0;
+                        reject(err);
+                    },
+                    ontimeout: () => {
+                        const err = new Error('timeout');
+                        err.status = 0;
+                        reject(err);
+                    }
+                });
+            });
+        },
+
+        parseArchetypesRaw(raw) {
+            if (!raw || !String(raw).trim()) {
+                throw new Error('empty archetypes.json body');
+            }
+            let config;
+            try {
+                config = JSON.parse(raw);
+            } catch (e) {
+                const err = new Error('Failed to parse archetypes config');
+                err.cause = e;
+                throw err;
+            }
+            if (!config || typeof config !== 'object' || Array.isArray(config)) {
+                throw new Error('archetypes.json is not a JSON object');
+            }
+            return config;
+        },
+
+        /**
+         * Fetch from the locked CDN only. Rejects if cache-only or unset.
+         * @param {string} repoPath
+         * @param {{ cacheBust?: boolean }} [options]
+         * @returns {Promise<{ status: number, text: string }>}
+         */
+        fetchText(repoPath, options) {
+            const opts = options || {};
+            if (!this.isNetworkLocked()) {
+                return Promise.reject(new Error('Repo CDN: no network fetch (cache-only or unset)'));
+            }
+            let url = this.buildUrl(repoPath);
+            if (opts.cacheBust) {
+                url += (url.indexOf('?') >= 0 ? '&' : '?') + 't=' + Date.now();
+            }
+            return this._gmGet(url);
+        },
+
+        /**
+         * First archetypes probe: GitHub → jsDelivr. Locks mode. Returns hit or null.
+         * @returns {Promise<{ raw: string, config: object, source: string }|null>}
+         */
+        async probeAndLockFromArchetypes() {
+            const path = GITHUB_CONFIG.archetypesPath;
+            this.lastGithubStatus = 0;
+
+            try {
+                const url = this.buildUrl(path, 'github') + '?t=' + Date.now();
+                Logger.debug(`Fetching archetypes from github (${url})`);
+                const res = await this._gmGet(url);
+                const config = this.parseArchetypesRaw(res.text);
+                this.setMode('github');
+                return { raw: res.text, config: config, source: 'github' };
+            } catch (e) {
+                this.lastGithubStatus = e && typeof e.status === 'number' ? e.status : 0;
+                Logger.error('Failed to load archetypes from github:', e);
+            }
+
+            try {
+                const url = this.buildUrl(path, 'jsdelivr') + '?t=' + Date.now();
+                Logger.debug(`Fetching archetypes from jsdelivr (${url})`);
+                const res = await this._gmGet(url);
+                const config = this.parseArchetypesRaw(res.text);
+                this.setMode('jsdelivr');
+                return { raw: res.text, config: config, source: 'jsdelivr' };
+            } catch (e) {
+                Logger.error('Failed to load archetypes from jsdelivr:', e);
+            }
+
+            this.setMode('cache-only');
+            return null;
+        },
+
+        /**
+         * Re-fetch archetypes from the already-locked CDN.
+         * @returns {Promise<{ raw: string, config: object, source: string }>}
+         */
+        async fetchArchetypesLocked() {
+            const res = await this.fetchText(GITHUB_CONFIG.archetypesPath, { cacheBust: true });
+            const config = this.parseArchetypesRaw(res.text);
+            return { raw: res.text, config: config, source: this.mode };
+        }
+    };
+
+    Context.repoCdn = RepoCdn;
+
     // ============= NETWORK OBSERVER =============
     /**
      * Stable extension-owned keys for runtime access values stored in script GM storage.
@@ -2411,17 +2565,6 @@
         },
 
         async _doFetchArchetypes() {
-            const timestamp = Date.now();
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.archetypesPath}?t=${timestamp}`;
-            
-            Logger.debug(`Fetching archetypes from branch: ${GITHUB_CONFIG.branch} (${url})`);
-
-            const isTransientArchetypesFailure = (status) => {
-                if (status === 0 || status === 408 || status === 429) return true;
-                if (typeof status === 'number' && status >= 500 && status <= 599) return true;
-                return false;
-            };
-
             const formatCacheAge = (cachedAt) => {
                 if (typeof cachedAt !== 'number' || !cachedAt) return 'unknown age';
                 const ms = Math.max(0, Date.now() - cachedAt);
@@ -2435,90 +2578,76 @@
                 return `${days}d old`;
             };
 
-            const tryFallback = (reason, resolve, reject) => {
+            const applyFromGmCache = (reason) => {
                 const cached = Storage.getCachedArchetypesJson(GITHUB_CONFIG.branch);
                 if (!cached) {
-                    reject(reason instanceof Error ? reason : new Error(String(reason)));
-                    return;
+                    return null;
                 }
                 try {
-                    const config = JSON.parse(cached.raw);
-                    if (!config || typeof config !== 'object' || Array.isArray(config)) {
-                        reject(reason instanceof Error ? reason : new Error(String(reason)));
-                        return;
-                    }
+                    const config = RepoCdn.parseArchetypesRaw(cached.raw);
                     this._applyArchetypesConfig(config);
                     const ver = cached.archetypesVersion != null
                         ? cached.archetypesVersion
                         : (config.archetypesVersion || 'unknown');
                     Logger.warn(
-                        `GitHub fetch failed (${reason instanceof Error ? reason.message : reason}); using cached archetypes v${ver} (${formatCacheAge(cached.cachedAt)})`
+                        `Using cached archetypes v${ver} (${formatCacheAge(cached.cachedAt)}); ${reason}`
                     );
-                    resolve(config);
+                    return config;
                 } catch (e) {
                     Logger.error('Failed to apply cached archetypes.json:', e);
-                    reject(reason instanceof Error ? reason : new Error(String(reason)));
+                    return null;
                 }
             };
-            
-            return new Promise((resolve, reject) => {
-                GM_xmlhttpRequest({
-                    method: 'GET',
-                    url: url,
-                    headers: {
-                        'Cache-Control': 'no-cache, no-store, must-revalidate',
-                        'Pragma': 'no-cache',
-                        'Expires': '0'
-                    },
-                    onload: (response) => {
-                        const status = typeof response.status === 'number' ? response.status : 0;
-                        if (status === 200) {
-                            const raw = response.responseText || '';
-                            if (!raw.trim()) {
-                                Logger.error('Failed to load archetypes: empty response body');
-                                tryFallback(new Error('empty archetypes.json body'), resolve, reject);
-                                return;
-                            }
-                            try {
-                                const config = JSON.parse(raw);
-                                if (!config || typeof config !== 'object' || Array.isArray(config)) {
-                                    Logger.error('Failed to parse archetypes config: not a JSON object');
-                                    tryFallback(new Error('archetypes.json is not a JSON object'), resolve, reject);
-                                    return;
-                                }
-                                this._applyArchetypesConfig(config);
-                                Storage.setCachedArchetypesJson(
-                                    raw,
-                                    GITHUB_CONFIG.branch,
-                                    config.archetypesVersion != null ? config.archetypesVersion : null
-                                );
-                                resolve(config);
-                            } catch (e) {
-                                Logger.error('Failed to parse archetypes config:', e);
-                                tryFallback(e, resolve, reject);
-                            }
-                        } else {
-                            Logger.error(`Failed to load archetypes: ${status}`);
-                            if (status === 404 && DEV_SCRIPTS_ENABLED) {
-                                yieldToMainForOrphanedBranch('archetypes.json HTTP 404');
-                            }
-                            if (status === 404 || !isTransientArchetypesFailure(status)) {
-                                reject(new Error(`HTTP ${status}`));
-                                return;
-                            }
-                            tryFallback(new Error(`HTTP ${status}`), resolve, reject);
-                        }
-                    },
-                    onerror: (error) => {
-                        Logger.error('Network error loading archetypes:', error);
-                        tryFallback(error instanceof Error ? error : new Error('network error loading archetypes'), resolve, reject);
-                    },
-                    ontimeout: () => {
-                        Logger.error('Timeout loading archetypes');
-                        tryFallback(new Error('timeout loading archetypes'), resolve, reject);
-                    }
-                });
-            });
+
+            const persistAndApply = (hit) => {
+                this._applyArchetypesConfig(hit.config);
+                Storage.setCachedArchetypesJson(
+                    hit.raw,
+                    GITHUB_CONFIG.branch,
+                    hit.config.archetypesVersion != null ? hit.config.archetypesVersion : null
+                );
+                return hit.config;
+            };
+
+            // Already cache-only: GM only, no network.
+            if (RepoCdn.isCacheOnly()) {
+                const config = applyFromGmCache('session is cache-only');
+                if (config) return config;
+                throw new Error('archetypes.json unavailable (cache-only, no GM cache)');
+            }
+
+            // First probe of the page session: GitHub → jsDelivr → cache-only.
+            if (!RepoCdn.mode) {
+                Logger.debug(`Probing archetypes CDN for branch: ${GITHUB_CONFIG.branch}`);
+                const hit = await RepoCdn.probeAndLockFromArchetypes();
+                if (hit) {
+                    return persistAndApply(hit);
+                }
+                const cachedConfig = applyFromGmCache('GitHub and jsDelivr both failed');
+                if (cachedConfig) return cachedConfig;
+                if (DEV_SCRIPTS_ENABLED && RepoCdn.lastGithubStatus === 404) {
+                    yieldToMainForOrphanedBranch('archetypes.json HTTP 404');
+                }
+                throw new Error(
+                    RepoCdn.lastGithubStatus === 404
+                        ? 'HTTP 404'
+                        : 'Failed to load archetypes from GitHub, jsDelivr, and GM cache'
+                );
+            }
+
+            // Locked to github or jsdelivr: fetch only from that host; on failure use GM cache.
+            try {
+                Logger.debug(`Fetching archetypes via locked CDN ${RepoCdn.mode}`);
+                const hit = await RepoCdn.fetchArchetypesLocked();
+                return persistAndApply(hit);
+            } catch (e) {
+                Logger.error(`Failed to load archetypes from locked CDN (${RepoCdn.mode}):`, e);
+                const cachedConfig = applyFromGmCache(
+                    `locked CDN ${RepoCdn.mode} failed (${e && e.message ? e.message : e})`
+                );
+                if (cachedConfig) return cachedConfig;
+                throw e instanceof Error ? e : new Error(String(e));
+            }
         },
 
         _applyArchetypesConfig(config) {
@@ -3081,8 +3210,14 @@
                             this._registerCacheForArchetype(sourcePath, filename);
                             return cached.code;
                         }
+                        if (RepoCdn.isCacheOnly()) {
+                            throw new Error(`Plugin ${filename} unavailable (cache-only, cached hash mismatch)`);
+                        }
                         Logger.warn(`Cached ${filename} v${version} failed hash check. Re-fetching.`);
                     } catch (hashError) {
+                        if (RepoCdn.isCacheOnly() && hashError && /cache-only/.test(hashError.message || '')) {
+                            throw hashError;
+                        }
                         Logger.error(`Hash verification failed for ${filename}:`, hashError);
                         throw new Error(`Plugin ${filename} blocked: hash verification error — ${hashError.message || hashError}`);
                     }
@@ -3091,6 +3226,14 @@
                     this._registerCacheForArchetype(sourcePath, filename);
                     return cached.code;
                 }
+            }
+
+            // Session is cache-only: never hit CDN; missing/mismatched cache means skip.
+            if (RepoCdn.isCacheOnly()) {
+                throw new Error(`Plugin ${filename} unavailable (cache-only, no matching cache for v${version})`);
+            }
+            if (!RepoCdn.isNetworkLocked()) {
+                throw new Error(`Plugin ${filename} unavailable (Repo CDN unset)`);
             }
 
             // --- FETCH PATH ---
@@ -3240,7 +3383,7 @@
          */
         async loadCorePlugin(filename, version, hash) {
             const sourcePath = `core/main/${filename}`;
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
+            const url = RepoCdn.buildUrl(`${GITHUB_CONFIG.pluginsPath}/${sourcePath}`);
             
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
@@ -3265,7 +3408,7 @@
                 );
             }
             const sourcePath = `libs/${filename}`;
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
+            const url = RepoCdn.buildUrl(`${GITHUB_CONFIG.pluginsPath}/${sourcePath}`);
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
@@ -3283,7 +3426,7 @@
          */
         async loadDevPlugin(filename, version, hash) {
             const sourcePath = `core/dev/${filename}`;
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
+            const url = RepoCdn.buildUrl(`${GITHUB_CONFIG.pluginsPath}/${sourcePath}`);
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
@@ -3308,7 +3451,7 @@
             }
 
             const sourcePath = `archetypes/${archetypeId}/main/${filename}`;
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
+            const url = RepoCdn.buildUrl(`${GITHUB_CONFIG.pluginsPath}/${sourcePath}`);
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
@@ -3334,7 +3477,7 @@
             }
 
             const sourcePath = `archetypes/${archetypeId}/dev/${filename}`;
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/${GITHUB_CONFIG.pluginsPath}/${sourcePath}`;
+            const url = RepoCdn.buildUrl(`${GITHUB_CONFIG.pluginsPath}/${sourcePath}`);
 
             const code = await this.loadPluginCode(filename, sourcePath, version, url, hash);
             const plugin = this.parsePluginCode(code, filename, { useModuleLogger: true });
@@ -3357,7 +3500,15 @@
                 Context.settingsModalDocs[filename] = { raw: cached.raw, version };
                 return;
             }
-            const url = `https://raw.githubusercontent.com/${GITHUB_CONFIG.owner}/${GITHUB_CONFIG.repo}/${GITHUB_CONFIG.branch}/docs/settings-modal/${filename}`;
+            if (RepoCdn.isCacheOnly()) {
+                Logger.warn(`Settings doc ${filename} unavailable (cache-only, no matching cache for v${version})`);
+                return;
+            }
+            if (!RepoCdn.isNetworkLocked()) {
+                Logger.warn(`Settings doc ${filename} skipped (Repo CDN unset)`);
+                return;
+            }
+            const url = RepoCdn.buildUrl(`docs/settings-modal/${filename}`);
             Logger.debug(`Fetching settings doc ${filename} v${version}${cached ? ` (cached: v${cached.version})` : ''}`);
             return new Promise((resolve) => {
                 GM_xmlhttpRequest({

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      13.8
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      13.11
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/core/main/dashboard.js
+++ b/plugins/core/main/dashboard.js
@@ -209,7 +209,7 @@ const plugin = {
     id: 'dashboard',
     name: 'Dashboard',
     description: 'Ops dashboard loader: modal shell, tab registry, shared UI primitives',
-    _version: '12.12',
+    _version: '12.13',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -220,6 +220,7 @@ const plugin = {
     _state: null,
     _workspaces: null,
     _wsOverride: null,
+    _wsOverrideStack: null,
     _lastOutputWsId: 'search-output',
     _tabs: null,
     _tabsById: null,
@@ -239,6 +240,7 @@ const plugin = {
         }
         this._workspaces = {};
         this._wsOverride = null;
+        this._wsOverrideStack = [];
         this._lastOutputWsId = 'search-output';
         this._state = this._createInitialState();
         this._initOutputWorkspaces();
@@ -612,23 +614,37 @@ const plugin = {
         return this._workspaces[wsId];
     },
 
+    _pushOutputWs(wsId) {
+        if (!this._wsOverrideStack) this._wsOverrideStack = [];
+        const next = wsId || this._resolveActiveOutputWsId();
+        this._wsOverrideStack.push(next);
+        this._wsOverride = next;
+        return next;
+    },
+
+    _popOutputWs() {
+        if (!this._wsOverrideStack) this._wsOverrideStack = [];
+        this._wsOverrideStack.pop();
+        this._wsOverride = this._wsOverrideStack.length
+            ? this._wsOverrideStack[this._wsOverrideStack.length - 1]
+            : null;
+    },
+
     _withOutputWs(wsId, fn) {
-        const prev = this._wsOverride;
-        this._wsOverride = wsId || this._resolveActiveOutputWsId();
+        this._pushOutputWs(wsId);
         try {
             return fn();
         } finally {
-            this._wsOverride = prev;
+            this._popOutputWs();
         }
     },
 
     async _withOutputWsAsync(wsId, fn) {
-        const prev = this._wsOverride;
-        this._wsOverride = wsId || this._resolveActiveOutputWsId();
+        this._pushOutputWs(wsId);
         try {
             return await fn();
         } finally {
-            this._wsOverride = prev;
+            this._popOutputWs();
         }
     },
 
@@ -2871,7 +2887,14 @@ const plugin = {
             const scoped = this._queryWithinOutputPanel(outPanel, selector);
             if (scoped) return scoped;
         }
-        return this._modal.querySelector(selector);
+        const el = this._modal.querySelector(selector);
+        if (!el) return null;
+        // Modal chrome (close, settings, …) is fine. Never steal nodes from another
+        // output panel — inventory tabs omit search controls and would otherwise hit
+        // Search Output via modal-wide fallback.
+        const elPanel = el.closest && el.closest('[data-wf-dash-panel]');
+        if (elPanel && outPanel && elPanel !== outPanel) return null;
+        return el;
     },
 
     // ── Listener wiring ──,

--- a/plugins/core/main/search-output-left-pane.js
+++ b/plugins/core/main/search-output-left-pane.js
@@ -1099,18 +1099,26 @@ const searchOutputLeftPaneMethods = {
     },
 
     _addAuthorToken(person) {
-        if (this._isEveryoneAuthorToken(person)) return;
-        if (this._hasEveryoneAuthorToken()) {
-            this._state.draftTokens = this._state.draftTokens.filter((t) => !this._isEveryoneAuthorToken(t));
+        try {
+            if (this._isEveryoneAuthorToken(person)) return;
+            if (this._hasEveryoneAuthorToken()) {
+                this._state.draftTokens = this._state.draftTokens.filter((t) => !this._isEveryoneAuthorToken(t));
+            }
+            if (this._state.draftTokens.some((t) => t.id === person.id)) return;
+            this._state.draftTokens.push(person);
+            this._hideAuthorCandidates();
+            this._setAuthorError('');
+            this._renderAuthorTokens();
+            this._validateRangeUi();
+            this._maybeSwitchToAllTimeForContributor();
+            Logger.log('dashboard: author token added (' + this._personDisplayLabel(person) + ')');
+        } finally {
+            const input = this._q('#wf-dash-author-input');
+            if (input) {
+                input.value = '';
+                input.focus();
+            }
         }
-        if (this._state.draftTokens.some((t) => t.id === person.id)) return;
-        this._state.draftTokens.push(person);
-        this._hideAuthorCandidates();
-        this._setAuthorError('');
-        this._renderAuthorTokens();
-        this._validateRangeUi();
-        this._maybeSwitchToAllTimeForContributor();
-        Logger.log('dashboard: author token added (' + this._personDisplayLabel(person) + ')');
     },
 
     _ensureSearchOutputTabForUserSearch() {
@@ -1221,8 +1229,50 @@ const searchOutputLeftPaneMethods = {
         el.style.display = text ? 'block' : 'none';
     },
 
+    _authorCandidateBtnBaseStyle() {
+        return 'display: block; width: 100%; text-align: left; padding: 6px 8px; font-size: 11px;'
+            + ' border: none; border-radius: 4px; cursor: pointer; color: var(--foreground, #0f172a);';
+    },
+
+    _authorCandidateBtnStyle(active) {
+        const bg = active
+            ? 'background: var(--muted, #f1f5f9);'
+            : 'background: transparent;';
+        return this._authorCandidateBtnBaseStyle() + ' ' + bg;
+    },
+
+    _syncAuthorCandidateHighlight() {
+        const wrap = this._q('#wf-dash-author-candidates');
+        if (!wrap) return;
+        const buttons = wrap.querySelectorAll('[data-wf-dash-candidate]');
+        const idx = Number(this._state._candidateIndex);
+        buttons.forEach((btn, i) => {
+            const active = i === idx;
+            btn.style.cssText = this._authorCandidateBtnStyle(active);
+            if (active) {
+                btn.setAttribute('aria-selected', 'true');
+                btn.scrollIntoView({ block: 'nearest' });
+            } else {
+                btn.removeAttribute('aria-selected');
+            }
+        });
+    },
+
+    _moveAuthorCandidateHighlight(delta) {
+        const candidates = this._state._candidates || [];
+        if (candidates.length === 0) return;
+        const len = candidates.length;
+        let idx = Number(this._state._candidateIndex);
+        if (!Number.isFinite(idx) || idx < 0) idx = 0;
+        idx = (idx + delta) % len;
+        if (idx < 0) idx += len;
+        this._state._candidateIndex = idx;
+        this._syncAuthorCandidateHighlight();
+    },
+
     _showAuthorCandidates(results) {
         this._state._candidates = results;
+        this._state._candidateIndex = results.length > 0 ? 0 : -1;
         const wrap = this._q('#wf-dash-author-candidates');
         if (!wrap) return;
         wrap.innerHTML = `
@@ -1232,19 +1282,21 @@ const searchOutputLeftPaneMethods = {
                     const label = this._personDisplayLabel(c);
                     const showEmail = c.email && label !== c.email;
                     return `
-                    <button type="button" data-wf-dash-candidate="${dashEscHtml(c.id)}" style="display: block; width: 100%; text-align: left; padding: 6px 8px; font-size: 11px; background: transparent; border: none; border-radius: 4px; cursor: pointer; color: var(--foreground, #0f172a);">
+                    <button type="button" data-wf-dash-candidate="${dashEscHtml(c.id)}" style="${this._authorCandidateBtnStyle(false)}">
                         <span style="font-weight: 600;">${dashEscHtml(label)}</span>
                         ${showEmail ? `<span style="margin-left: 8px; color: var(--muted-foreground, #64748b);">${dashEscHtml(c.email)}</span>` : ''}
                     </button>`;
                 }).join('')}
             </div>`;
         wrap.style.display = 'block';
+        this._syncAuthorCandidateHighlight();
     },
 
     _hideAuthorCandidates() {
         const wrap = this._q('#wf-dash-author-candidates');
         if (wrap) { wrap.style.display = 'none'; wrap.innerHTML = ''; }
         this._state._candidates = [];
+        this._state._candidateIndex = -1;
     },
 
     _isDashSessionRefreshError(err) {
@@ -2609,7 +2661,7 @@ const plugin = {
     id: 'search-output-left-pane',
     name: 'Search Output left pane',
     description: 'Worker Output Search tab — left pane',
-    _version: '5.17',
+    _version: '5.18',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -1872,6 +1872,15 @@ const searchOutputResultsPaneMethods = {
         this._state.resultsPage = 0;
         Logger.log('search-output: review status → ' + next);
         this._syncReviewStatusToggleUi();
+        const wsId = typeof this._resolveActiveOutputWsId === 'function'
+            ? this._resolveActiveOutputWsId()
+            : (this._state && this._state.wsId);
+        if ((wsId === 'disputes' || wsId === 'sr-review')
+            && typeof this._loadPrefetchInventoryWorkspace === 'function') {
+            // Replace list with the matching half — do not merge opposite-status cards.
+            void this._loadPrefetchInventoryWorkspace(wsId, { merge: false });
+            return;
+        }
         this._renderResults();
         this._syncResultsPagerUi();
         this._updateResultsStatus();
@@ -8037,7 +8046,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '10.6',
+    _version: '10.7',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -414,7 +414,7 @@ const searchOutputResultsPaneMethods = {
                             </div>
                         </div>
                     </div>
-                    <div ${el('results')} style="flex: 1; min-height: 0; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 24px;"></div>
+                    <div ${el('results')} style="flex: 1; min-height: 0; overflow-y: auto; overflow-anchor: none; padding: 16px; display: flex; flex-direction: column; gap: 24px;"></div>
                 </div>`;
     },
 
@@ -5598,16 +5598,83 @@ const searchOutputResultsPaneMethods = {
         }
     },
 
-    _withResultsScrollPreserved(fn) {
+    _findResultsCardEl(wrap, itemId) {
+        if (!wrap || !itemId) return null;
+        for (const el of wrap.querySelectorAll('[data-wf-dash-task-card]')) {
+            if (el.getAttribute('data-item-id') === itemId) return el;
+        }
+        return null;
+    },
+
+    _resultsScrollAnchor(wrap, preferredItemId) {
+        if (!wrap) return null;
+        const wrapRect = wrap.getBoundingClientRect();
+        if (preferredItemId) {
+            const preferred = this._findResultsCardEl(wrap, preferredItemId);
+            if (preferred) {
+                const rect = preferred.getBoundingClientRect();
+                return {
+                    itemId: preferredItemId,
+                    offset: rect.top - wrapRect.top
+                };
+            }
+        }
+        for (const card of wrap.querySelectorAll('[data-wf-dash-task-card]')) {
+            const rect = card.getBoundingClientRect();
+            if (rect.bottom > wrapRect.top) {
+                const itemId = card.getAttribute('data-item-id');
+                if (!itemId) continue;
+                return {
+                    itemId,
+                    offset: rect.top - wrapRect.top
+                };
+            }
+        }
+        return null;
+    },
+
+    _restoreResultsScrollAnchor(wrap, anchor, savedScrollTop) {
+        if (!wrap || !wrap.isConnected) return;
+        const max = Math.max(0, wrap.scrollHeight - wrap.clientHeight);
+        if (!anchor || !anchor.itemId) {
+            wrap.scrollTop = Math.min(Math.max(0, savedScrollTop || 0), max);
+            return;
+        }
+        const card = this._findResultsCardEl(wrap, anchor.itemId);
+        if (!card) {
+            wrap.scrollTop = Math.min(Math.max(0, savedScrollTop || 0), max);
+            return;
+        }
+        const wrapRect = wrap.getBoundingClientRect();
+        const cardRect = card.getBoundingClientRect();
+        const currentOffset = cardRect.top - wrapRect.top;
+        const delta = currentOffset - anchor.offset;
+        let next = wrap.scrollTop + delta;
+        next = Math.min(Math.max(0, next), max);
+        // After a shrink, keep the card from scrolling entirely past the viewport.
+        const cardTopInScroll = wrap.scrollTop + currentOffset;
+        const maxKeepVisible = cardTopInScroll + Math.max(0, cardRect.height - wrap.clientHeight);
+        next = Math.min(next, Math.max(0, maxKeepVisible));
+        if (Math.abs(delta) > 0.5) {
+            Logger.debug('results scroll anchor restored — ' + anchor.itemId
+                + ' · delta ' + Math.round(delta) + 'px');
+        }
+        wrap.scrollTop = next;
+    },
+
+    _withResultsScrollPreserved(fn, opts) {
+        const options = opts || {};
         const wrap = this._q('#wf-dash-results');
         const saved = wrap ? wrap.scrollTop : 0;
+        const anchor = wrap
+            ? this._resultsScrollAnchor(wrap, options.anchorItemId || null)
+            : null;
         try {
             return fn();
         } finally {
             if (!wrap || !wrap.isConnected) return;
             const restore = () => {
-                const max = Math.max(0, wrap.scrollHeight - wrap.clientHeight);
-                wrap.scrollTop = Math.min(Math.max(0, saved), max);
+                this._restoreResultsScrollAnchor(wrap, anchor, saved);
             };
             restore();
             if (typeof requestAnimationFrame === 'function') {
@@ -5623,14 +5690,7 @@ const searchOutputResultsPaneMethods = {
         const item = this._findCachedItem(itemId) || this._findResultItem(itemId);
         if (!item) return;
         this._withResultsScrollPreserved(() => {
-            const cards = wrap.querySelectorAll('[data-wf-dash-task-card]');
-            let existing = null;
-            for (const el of cards) {
-                if (el.getAttribute('data-item-id') === itemId) {
-                    existing = el;
-                    break;
-                }
-            }
+            const existing = this._findResultsCardEl(wrap, itemId);
             const html = this._resultCardHtml(item);
             const doc = this._pageWindow().document;
             const temp = doc.createElement('div');
@@ -5660,7 +5720,7 @@ const searchOutputResultsPaneMethods = {
             }
             this._syncAutoGrowTextareasIn(newCard);
             this._syncResultsHydrateBannerUi();
-        });
+        }, { anchorItemId: itemId });
     },
 
     _syncAutoGrowTextarea(ta, minHeightPx) {
@@ -7974,7 +8034,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '10.2',
+    _version: '10.3',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -5609,19 +5609,25 @@ const searchOutputResultsPaneMethods = {
     _resultsScrollAnchor(wrap, preferredItemId) {
         if (!wrap) return null;
         const wrapRect = wrap.getBoundingClientRect();
+        const intersectsViewport = (rect) => rect.bottom > wrapRect.top && rect.top < wrapRect.bottom;
         if (preferredItemId) {
             const preferred = this._findResultsCardEl(wrap, preferredItemId);
             if (preferred) {
                 const rect = preferred.getBoundingClientRect();
-                return {
-                    itemId: preferredItemId,
-                    offset: rect.top - wrapRect.top
-                };
+                // Only anchor on the patched card when it is actually on screen.
+                // Offscreen patches must not become the scroll anchor — that yanks
+                // the viewport to background hydrates / prefetch re-overlays.
+                if (intersectsViewport(rect)) {
+                    return {
+                        itemId: preferredItemId,
+                        offset: rect.top - wrapRect.top
+                    };
+                }
             }
         }
         for (const card of wrap.querySelectorAll('[data-wf-dash-task-card]')) {
             const rect = card.getBoundingClientRect();
-            if (rect.bottom > wrapRect.top) {
+            if (intersectsViewport(rect)) {
                 const itemId = card.getAttribute('data-item-id');
                 if (!itemId) continue;
                 return {
@@ -5636,13 +5642,18 @@ const searchOutputResultsPaneMethods = {
     _restoreResultsScrollAnchor(wrap, anchor, savedScrollTop) {
         if (!wrap || !wrap.isConnected) return;
         const max = Math.max(0, wrap.scrollHeight - wrap.clientHeight);
+        const applyScrollTop = (next) => {
+            const clamped = Math.min(Math.max(0, next), max);
+            if (Math.abs(clamped - wrap.scrollTop) < 1) return;
+            wrap.scrollTop = clamped;
+        };
         if (!anchor || !anchor.itemId) {
-            wrap.scrollTop = Math.min(Math.max(0, savedScrollTop || 0), max);
+            applyScrollTop(savedScrollTop || 0);
             return;
         }
         const card = this._findResultsCardEl(wrap, anchor.itemId);
         if (!card) {
-            wrap.scrollTop = Math.min(Math.max(0, savedScrollTop || 0), max);
+            applyScrollTop(savedScrollTop || 0);
             return;
         }
         const wrapRect = wrap.getBoundingClientRect();
@@ -5651,15 +5662,18 @@ const searchOutputResultsPaneMethods = {
         const delta = currentOffset - anchor.offset;
         let next = wrap.scrollTop + delta;
         next = Math.min(Math.max(0, next), max);
-        // After a shrink, keep the card from scrolling entirely past the viewport.
-        const cardTopInScroll = wrap.scrollTop + currentOffset;
-        const maxKeepVisible = cardTopInScroll + Math.max(0, cardRect.height - wrap.clientHeight);
-        next = Math.min(next, Math.max(0, maxKeepVisible));
+        // Keep-visible clamp only when the user was scrolled into this card
+        // (top was above the viewport). Never pull the view to an offscreen card.
+        if (anchor.offset < 0) {
+            const cardTopInScroll = wrap.scrollTop + currentOffset;
+            const maxKeepVisible = cardTopInScroll + Math.max(0, cardRect.height - wrap.clientHeight);
+            next = Math.min(next, Math.max(0, maxKeepVisible));
+        }
         if (Math.abs(delta) > 0.5) {
             Logger.debug('results scroll anchor restored — ' + anchor.itemId
                 + ' · delta ' + Math.round(delta) + 'px');
         }
-        wrap.scrollTop = next;
+        applyScrollTop(next);
     },
 
     _withResultsScrollPreserved(fn, opts) {
@@ -8034,7 +8048,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '10.3',
+    _version: '10.4',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -414,7 +414,7 @@ const searchOutputResultsPaneMethods = {
                             </div>
                         </div>
                     </div>
-                    <div ${el('results')} style="flex: 1; min-height: 0; overflow-y: auto; overflow-anchor: none; padding: 16px; display: flex; flex-direction: column; gap: 24px;"></div>
+                    <div ${el('results')} style="flex: 1; min-height: 0; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 24px;"></div>
                 </div>`;
     },
 
@@ -5606,90 +5606,83 @@ const searchOutputResultsPaneMethods = {
         return null;
     },
 
-    _resultsScrollAnchor(wrap, preferredItemId) {
-        if (!wrap) return null;
+    _resultsCardIntersectsViewport(wrap, card) {
+        if (!wrap || !card) return false;
         const wrapRect = wrap.getBoundingClientRect();
-        const intersectsViewport = (rect) => rect.bottom > wrapRect.top && rect.top < wrapRect.bottom;
-        if (preferredItemId) {
-            const preferred = this._findResultsCardEl(wrap, preferredItemId);
-            if (preferred) {
-                const rect = preferred.getBoundingClientRect();
-                // Only anchor on the patched card when it is actually on screen.
-                // Offscreen patches must not become the scroll anchor — that yanks
-                // the viewport to background hydrates / prefetch re-overlays.
-                if (intersectsViewport(rect)) {
-                    return {
-                        itemId: preferredItemId,
-                        offset: rect.top - wrapRect.top
-                    };
-                }
-            }
-        }
-        for (const card of wrap.querySelectorAll('[data-wf-dash-task-card]')) {
-            const rect = card.getBoundingClientRect();
-            if (intersectsViewport(rect)) {
-                const itemId = card.getAttribute('data-item-id');
-                if (!itemId) continue;
-                return {
-                    itemId,
-                    offset: rect.top - wrapRect.top
-                };
-            }
-        }
-        return null;
+        const rect = card.getBoundingClientRect();
+        return rect.bottom > wrapRect.top && rect.top < wrapRect.bottom;
     },
 
-    _restoreResultsScrollAnchor(wrap, anchor, savedScrollTop) {
+    /** Anchor only when the preferred card is on screen — never fall back to another card. */
+    _resultsScrollAnchorForItem(wrap, itemId) {
+        if (!wrap || !itemId) return null;
+        const card = this._findResultsCardEl(wrap, itemId);
+        if (!card || !this._resultsCardIntersectsViewport(wrap, card)) return null;
+        const wrapRect = wrap.getBoundingClientRect();
+        const rect = card.getBoundingClientRect();
+        return {
+            itemId,
+            offset: rect.top - wrapRect.top
+        };
+    },
+
+    _applyResultsScrollTop(wrap, next, meta) {
         if (!wrap || !wrap.isConnected) return;
         const max = Math.max(0, wrap.scrollHeight - wrap.clientHeight);
-        const applyScrollTop = (next) => {
-            const clamped = Math.min(Math.max(0, next), max);
-            if (Math.abs(clamped - wrap.scrollTop) < 1) return;
-            wrap.scrollTop = clamped;
-        };
-        if (!anchor || !anchor.itemId) {
-            applyScrollTop(savedScrollTop || 0);
-            return;
-        }
+        const clamped = Math.min(Math.max(0, next), max);
+        const prev = wrap.scrollTop;
+        if (Math.abs(clamped - prev) < 1) return;
+        wrap.scrollTop = clamped;
+        const info = meta || {};
+        Logger.debug('results scrollTop write — ' + (info.path || 'unknown')
+            + (info.itemId ? (' · ' + info.itemId) : '')
+            + ' · delta ' + Math.round(clamped - prev) + 'px');
+    },
+
+    _restoreResultsScrollAnchor(wrap, anchor) {
+        if (!wrap || !wrap.isConnected || !anchor || !anchor.itemId) return;
         const card = this._findResultsCardEl(wrap, anchor.itemId);
-        if (!card) {
-            applyScrollTop(savedScrollTop || 0);
-            return;
-        }
+        if (!card) return;
         const wrapRect = wrap.getBoundingClientRect();
         const cardRect = card.getBoundingClientRect();
         const currentOffset = cardRect.top - wrapRect.top;
         const delta = currentOffset - anchor.offset;
         let next = wrap.scrollTop + delta;
-        next = Math.min(Math.max(0, next), max);
-        // Keep-visible clamp only when the user was scrolled into this card
-        // (top was above the viewport). Never pull the view to an offscreen card.
+        // Keep-visible clamp only when the user was scrolled into this card.
         if (anchor.offset < 0) {
             const cardTopInScroll = wrap.scrollTop + currentOffset;
             const maxKeepVisible = cardTopInScroll + Math.max(0, cardRect.height - wrap.clientHeight);
             next = Math.min(next, Math.max(0, maxKeepVisible));
         }
-        if (Math.abs(delta) > 0.5) {
-            Logger.debug('results scroll anchor restored — ' + anchor.itemId
-                + ' · delta ' + Math.round(delta) + 'px');
-        }
-        applyScrollTop(next);
+        this._applyResultsScrollTop(wrap, next, {
+            path: 'anchor',
+            itemId: anchor.itemId
+        });
     },
 
     _withResultsScrollPreserved(fn, opts) {
         const options = opts || {};
         const wrap = this._q('#wf-dash-results');
         const saved = wrap ? wrap.scrollTop : 0;
-        const anchor = wrap
-            ? this._resultsScrollAnchor(wrap, options.anchorItemId || null)
-            : null;
+        const preferredId = options.anchorItemId || null;
+        // Patch path: only restore when the patched card is on screen.
+        // Offscreen patches — zero scrollTop writes (browser overflow-anchor handles above-viewport churn).
+        if (preferredId) {
+            const anchor = wrap ? this._resultsScrollAnchorForItem(wrap, preferredId) : null;
+            try {
+                return fn();
+            } finally {
+                if (!wrap || !wrap.isConnected) return;
+                if (!anchor) return;
+                this._restoreResultsScrollAnchor(wrap, anchor);
+            }
+        }
+        // Full rebuild (_renderResults): original pre-anchor behavior — clamp saved scrollTop once.
         try {
             return fn();
         } finally {
             if (!wrap || !wrap.isConnected) return;
-            // Sync-only: a deferred rAF restore re-applies a stale card offset after
-            // the user has already scrolled and amplifies wheel motion into huge jumps.
-            this._restoreResultsScrollAnchor(wrap, anchor, saved);
+            this._applyResultsScrollTop(wrap, saved, { path: 'saved' });
         }
     },
 
@@ -8044,7 +8037,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '10.5',
+    _version: '10.6',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output-results-pane.js
+++ b/plugins/core/main/search-output-results-pane.js
@@ -5687,13 +5687,9 @@ const searchOutputResultsPaneMethods = {
             return fn();
         } finally {
             if (!wrap || !wrap.isConnected) return;
-            const restore = () => {
-                this._restoreResultsScrollAnchor(wrap, anchor, saved);
-            };
-            restore();
-            if (typeof requestAnimationFrame === 'function') {
-                requestAnimationFrame(restore);
-            }
+            // Sync-only: a deferred rAF restore re-applies a stale card offset after
+            // the user has already scrolled and amplifies wheel motion into huge jumps.
+            this._restoreResultsScrollAnchor(wrap, anchor, saved);
         }
     },
 
@@ -8048,7 +8044,7 @@ const plugin = {
     id: 'search-output-results-pane',
     name: 'Search Output results pane',
     description: 'Worker Output Search tab — results pane',
-    _version: '10.4',
+    _version: '10.5',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -1777,23 +1777,33 @@ const searchOutputCoreMethods = {
         if (typeof this._updateResultsStatus === 'function') {
             this._updateResultsStatus();
         }
-        if (typeof this._refreshPrefetchInventoryTabs === 'function') {
-            void this._refreshPrefetchInventoryTabs(kind);
-        }
-        void this._withOutputWsAsync('search-output', async () => {
-            if (!this._state.cachedItems || this._state.cachedItems.length === 0) {
-                Logger.debug('dashboard: ' + this._prefetchLabel(kind)
-                    + ' prefetch complete — no cached cards to re-overlay');
-                return;
+        void this._enqueuePrefetchUiWork(async () => {
+            if (typeof this._refreshPrefetchInventoryTabs === 'function') {
+                await this._refreshPrefetchInventoryTabs(kind);
             }
-            try {
-                const changedIds = await this._reoverlayAllCachedItems();
-                if (!changedIds || changedIds.length === 0) return;
-                this._refreshResultsView({ filterSource: 'results-mutate', reindexFilters: true });
-            } catch (e) {
-                Logger.warn('dashboard: prefetch re-overlay failed after ' + this._prefetchLabel(kind), e);
-            }
+            await this._withOutputWsAsync('search-output', async () => {
+                if (!this._state.cachedItems || this._state.cachedItems.length === 0) {
+                    Logger.debug('dashboard: ' + this._prefetchLabel(kind)
+                        + ' prefetch complete — no cached cards to re-overlay');
+                    return;
+                }
+                try {
+                    const changedIds = await this._reoverlayAllCachedItems();
+                    if (!changedIds || changedIds.length === 0) return;
+                    this._refreshResultsView({ filterSource: 'results-mutate', reindexFilters: true });
+                } catch (e) {
+                    Logger.warn('dashboard: prefetch re-overlay failed after ' + this._prefetchLabel(kind), e);
+                }
+            });
         });
+    },
+
+    _enqueuePrefetchUiWork(fn) {
+        const run = typeof fn === 'function' ? fn : async () => {};
+        const prev = this._prefetchUiQueue || Promise.resolve();
+        const next = prev.then(() => run(), () => run());
+        this._prefetchUiQueue = next.then(() => undefined, () => undefined);
+        return next;
     },
 
     _prefetchInventoryProfilesMap() {
@@ -1827,7 +1837,7 @@ const searchOutputCoreMethods = {
         let profilesMap = new Map();
         if (profileIds.length > 0 && typeof this._fetchProfilesByIds === 'function') {
             try {
-                const rows = await this._fetchProfilesByIds(profileIds, 'search', null);
+                const rows = await this._fetchProfilesByIds(profileIds, 'ondemand', null);
                 profilesMap = this._buildProfilesMap(rows);
             } catch (e) {
                 Logger.warn('dispute inventory profiles failed', e);
@@ -1860,7 +1870,7 @@ const searchOutputCoreMethods = {
         let profilesMap = new Map();
         if (profileIds.length > 0 && typeof this._fetchProfilesByIds === 'function') {
             try {
-                const rows = await this._fetchProfilesByIds(profileIds, 'search', null);
+                const rows = await this._fetchProfilesByIds(profileIds, 'ondemand', null);
                 profilesMap = this._buildProfilesMap(rows);
             } catch (e) {
                 Logger.warn('flag inventory profiles failed', e);
@@ -4625,10 +4635,9 @@ const searchOutputCoreMethods = {
             if (wrap) return wrap;
         }
         if (typeof this._q === 'function') {
-            const scoped = this._q('[data-wf-dash-ms-wrap="' + scopeKey + '"]');
-            if (scoped) return scoped;
+            return this._q('[data-wf-dash-ms-wrap="' + scopeKey + '"]');
         }
-        return this._modal ? this._modal.querySelector('[data-wf-dash-ms-wrap="' + scopeKey + '"]') : null;
+        return null;
     },
 
     _reindexFilterListsFromScope(resetDrafts) {
@@ -6580,7 +6589,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.52',
+    _version: '9.53',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -5438,6 +5438,20 @@ function attachSearchOutputListeners(modal, dash) {
         if (authorBox && authorInput) {
             authorBox.addEventListener('click', () => authorInput.focus());
             authorInput.addEventListener('keydown', (e) => {
+                const candidates = dash._state._candidates || [];
+                const listOpen = candidates.length > 0;
+                if (listOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+                    e.preventDefault();
+                    dash._moveAuthorCandidateHighlight(e.key === 'ArrowDown' ? 1 : -1);
+                    return;
+                }
+                if (listOpen && e.key === 'Enter') {
+                    e.preventDefault();
+                    const idx = Math.max(0, Number(dash._state._candidateIndex) || 0);
+                    const cand = candidates[idx];
+                    if (cand) dash._addAuthorToken(cand);
+                    return;
+                }
                 if (e.key === 'Enter') {
                     e.preventDefault();
                     const query = authorInput.value.trim();
@@ -6082,7 +6096,7 @@ function attachSearchOutputListeners(modal, dash) {
             if (candidate && modal.contains(candidate)) {
                 const id = candidate.getAttribute('data-wf-dash-candidate');
                 const cand = (dash._state._candidates || []).find((c) => c.id === id);
-                if (cand) { dash._addAuthorToken(cand); if (authorInput) authorInput.value = ''; }
+                if (cand) dash._addAuthorToken(cand);
                 return;
             }
             const removeTok = e.target.closest('[data-wf-dash-remove-token]');
@@ -6589,7 +6603,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.53',
+    _version: '9.54',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -1211,8 +1211,12 @@ const searchOutputCoreMethods = {
         if ((item.task.allFeedback || []).length > 0 || item.qaFeedback) {
             this._addItemOutputKind(item, 'qa');
         }
-        if ((item.disputes || []).length > 0) this._addItemOutputKind(item, 'dispute');
-        if ((item.flags || []).length > 0) this._addItemOutputKind(item, 'senior_review');
+        if ((item.disputes || []).length > 0 && this._prefetchDisputesFamilyReady()) {
+            this._addItemOutputKind(item, 'dispute');
+        }
+        if ((item.flags || []).length > 0 && this._prefetchFlagsFamilyReady()) {
+            this._addItemOutputKind(item, 'senior_review');
+        }
     },
 
     /**
@@ -1711,6 +1715,22 @@ const searchOutputCoreMethods = {
         return (kinds || DASH_PREFETCH_KINDS).some((kind) => this._isPrefetchIncomplete(kind));
     },
 
+    _prefetchSlotTerminal(kind) {
+        const slot = this._getPrefetchSlot(kind);
+        const status = slot && slot.status;
+        return status === 'done' || status === 'error';
+    },
+
+    _prefetchDisputesFamilyReady() {
+        return this._prefetchSlotTerminal('openDisputes')
+            && this._prefetchSlotTerminal('resolvedDisputes');
+    },
+
+    _prefetchFlagsFamilyReady() {
+        return this._prefetchSlotTerminal('pendingFlags')
+            && this._prefetchSlotTerminal('resolvedFlags');
+    },
+
     _ensurePrefetch(kind, loadTracker) {
         const slot = this._getPrefetchSlot(kind);
         if (!slot) return Promise.resolve(0);
@@ -1777,9 +1797,21 @@ const searchOutputCoreMethods = {
         if (typeof this._updateResultsStatus === 'function') {
             this._updateResultsStatus();
         }
+        const disputeKinds = kind === 'openDisputes' || kind === 'resolvedDisputes';
+        const flagKinds = kind === 'pendingFlags' || kind === 'resolvedFlags';
         void this._enqueuePrefetchUiWork(async () => {
             if (typeof this._refreshPrefetchInventoryTabs === 'function') {
                 await this._refreshPrefetchInventoryTabs(kind);
+            }
+            const familyReady = disputeKinds
+                ? this._prefetchDisputesFamilyReady()
+                : flagKinds
+                    ? this._prefetchFlagsFamilyReady()
+                    : false;
+            if (!familyReady) {
+                Logger.debug('dashboard: ' + this._prefetchLabel(kind)
+                    + ' prefetch complete — waiting for family before Search Output overlay');
+                return;
             }
             await this._withOutputWsAsync('search-output', async () => {
                 if (!this._state.cachedItems || this._state.cachedItems.length === 0) {
@@ -1884,18 +1916,8 @@ const searchOutputCoreMethods = {
     },
 
     _prefetchInventoryKindsReady(wsId) {
-        if (wsId === 'disputes') {
-            return ['openDisputes', 'resolvedDisputes'].some((kind) => {
-                const slot = this._getPrefetchSlot(kind);
-                return slot && slot.status === 'done';
-            });
-        }
-        if (wsId === 'sr-review') {
-            return ['pendingFlags', 'resolvedFlags'].some((kind) => {
-                const slot = this._getPrefetchSlot(kind);
-                return slot && slot.status === 'done';
-            });
-        }
+        if (wsId === 'disputes') return this._prefetchDisputesFamilyReady();
+        if (wsId === 'sr-review') return this._prefetchFlagsFamilyReady();
         return false;
     },
 
@@ -2853,48 +2875,99 @@ const searchOutputCoreMethods = {
         }
     },
 
+    _removeItemOutputKind(item, kind) {
+        if (!item || !kind) return;
+        const kinds = this._ensureItemKindsArray(item);
+        if (!kinds.includes(kind)) return;
+        item.kinds = kinds.filter((k) => k !== kind);
+        if (item.kinds.length === 0) {
+            item.kinds = [item.kind && item.kind !== kind ? item.kind : 'task_creation'];
+        }
+        if (item.kind === kind) {
+            item.kind = item.kinds[0];
+        }
+    },
+
+    _clearDisputeOverlaySide(item) {
+        if (!item) return false;
+        let changed = false;
+        if ((item.disputes || []).length > 0) {
+            item.disputes = [];
+            changed = true;
+        }
+        const kinds = this._ensureItemKindsArray(item);
+        if (kinds.includes('dispute') && kinds.some((k) => k !== 'dispute')) {
+            this._removeItemOutputKind(item, 'dispute');
+            changed = true;
+        }
+        return changed;
+    },
+
+    _clearFlagOverlaySide(item) {
+        if (!item) return false;
+        let changed = false;
+        if ((item.flags || []).length > 0) {
+            item.flags = [];
+            changed = true;
+        }
+        const kinds = this._ensureItemKindsArray(item);
+        if (kinds.includes('senior_review') && kinds.some((k) => k !== 'senior_review')) {
+            this._removeItemOutputKind(item, 'senior_review');
+            changed = true;
+        }
+        return changed;
+    },
+
     async _overlayDisputesAndFlagsForItem(item, profilesMap, scope, afterIso, beforeIso, contributorSet) {
         if (!item || !item.task || !item.task.id) return false;
         const taskId = item.task.id;
         let changed = false;
         this._ensureItemKindsArray(item);
 
-        const openRows = this._getAllCachedOpenDisputeRows(taskId);
-        let resolvedRows = this._getAllCachedResolvedDisputeRows(taskId);
-        const resolvedSlot = this._getPrefetchSlot('resolvedDisputes');
-        const prefetchFailed = resolvedSlot && resolvedSlot.status === 'error';
-        const cacheIncomplete = this._isPrefetchIncomplete('resolvedDisputes');
-        if (resolvedRows.length === 0 && (prefetchFailed || cacheIncomplete)) {
-            const fetched = await this._fetchTaskDisputesBatch([taskId]);
-            resolvedRows = this._filterDisputeRowsForTask(fetched.get(String(taskId)) || [], taskId);
-        }
-        const combinedDisputes = [...openRows, ...resolvedRows];
-        if (combinedDisputes.length > 0) {
-            const resolverProfileIds = [];
-            for (const row of resolvedRows) {
-                if (row && row.resolved_by) resolverProfileIds.push(row.resolved_by);
+        if (!this._prefetchDisputesFamilyReady()) {
+            if (this._clearDisputeOverlaySide(item)) changed = true;
+        } else {
+            const openRows = this._getAllCachedOpenDisputeRows(taskId);
+            let resolvedRows = this._getAllCachedResolvedDisputeRows(taskId);
+            const resolvedSlot = this._getPrefetchSlot('resolvedDisputes');
+            const prefetchFailed = resolvedSlot && resolvedSlot.status === 'error';
+            const cacheIncomplete = this._isPrefetchIncomplete('resolvedDisputes');
+            if (resolvedRows.length === 0 && (prefetchFailed || cacheIncomplete)) {
+                const fetched = await this._fetchTaskDisputesBatch([taskId]);
+                resolvedRows = this._filterDisputeRowsForTask(fetched.get(String(taskId)) || [], taskId);
             }
-            if (resolverProfileIds.length > 0) {
-                await this._supplementProfilesMap(profilesMap, resolverProfileIds);
+            const combinedDisputes = [...openRows, ...resolvedRows];
+            if (combinedDisputes.length > 0) {
+                const resolverProfileIds = [];
+                for (const row of resolvedRows) {
+                    if (row && row.resolved_by) resolverProfileIds.push(row.resolved_by);
+                }
+                if (resolverProfileIds.length > 0) {
+                    await this._supplementProfilesMap(profilesMap, resolverProfileIds);
+                }
+                this._mergeBulkDisputesOntoItem(item, combinedDisputes, profilesMap);
+                this._addItemOutputKind(item, 'dispute');
+                changed = true;
             }
-            this._mergeBulkDisputesOntoItem(item, combinedDisputes, profilesMap);
-            this._addItemOutputKind(item, 'dispute');
-            changed = true;
         }
 
-        const flagRows = this._getAllCachedFlagRows(taskId);
-        if (flagRows.length > 0) {
-            const flagProfileIds = [];
-            for (const row of flagRows) {
-                if (row && row.flagger_id) flagProfileIds.push(row.flagger_id);
-                if (row && row.resolved_by) flagProfileIds.push(row.resolved_by);
+        if (!this._prefetchFlagsFamilyReady()) {
+            if (this._clearFlagOverlaySide(item)) changed = true;
+        } else {
+            const flagRows = this._getAllCachedFlagRows(taskId);
+            if (flagRows.length > 0) {
+                const flagProfileIds = [];
+                for (const row of flagRows) {
+                    if (row && row.flagger_id) flagProfileIds.push(row.flagger_id);
+                    if (row && row.resolved_by) flagProfileIds.push(row.resolved_by);
+                }
+                if (flagProfileIds.length > 0) {
+                    await this._supplementProfilesMap(profilesMap, flagProfileIds);
+                }
+                this._mergeBulkFlagsOntoItem(item, flagRows, profilesMap);
+                this._addItemOutputKind(item, 'senior_review');
+                changed = true;
             }
-            if (flagProfileIds.length > 0) {
-                await this._supplementProfilesMap(profilesMap, flagProfileIds);
-            }
-            this._mergeBulkFlagsOntoItem(item, flagRows, profilesMap);
-            this._addItemOutputKind(item, 'senior_review');
-            changed = true;
         }
         return changed;
     },
@@ -6608,7 +6681,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.55',
+    _version: '9.56',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -1211,10 +1211,10 @@ const searchOutputCoreMethods = {
         if ((item.task.allFeedback || []).length > 0 || item.qaFeedback) {
             this._addItemOutputKind(item, 'qa');
         }
-        if ((item.disputes || []).length > 0 && this._prefetchDisputesFamilyReady()) {
+        if ((item.disputes || []).length > 0 && this._prefetchDisputesAnyHalfReady()) {
             this._addItemOutputKind(item, 'dispute');
         }
-        if ((item.flags || []).length > 0 && this._prefetchFlagsFamilyReady()) {
+        if ((item.flags || []).length > 0 && this._prefetchFlagsAnyHalfReady()) {
             this._addItemOutputKind(item, 'senior_review');
         }
     },
@@ -1721,14 +1721,33 @@ const searchOutputCoreMethods = {
         return status === 'done' || status === 'error';
     },
 
-    _prefetchDisputesFamilyReady() {
-        return this._prefetchSlotTerminal('openDisputes')
-            && this._prefetchSlotTerminal('resolvedDisputes');
+    _resultsReviewStatusValue() {
+        return this._state.resultsReviewStatus === 'resolved' ? 'resolved' : 'pending';
     },
 
-    _prefetchFlagsFamilyReady() {
+    /** Inventory / review-status toggle: only the Pending or Resolved half must be ready. */
+    _prefetchDisputesHalfReady(status) {
+        const want = status === 'resolved' ? 'resolved' : 'pending';
+        return want === 'resolved'
+            ? this._prefetchSlotTerminal('resolvedDisputes')
+            : this._prefetchSlotTerminal('openDisputes');
+    },
+
+    _prefetchFlagsHalfReady(status) {
+        const want = status === 'resolved' ? 'resolved' : 'pending';
+        return want === 'resolved'
+            ? this._prefetchSlotTerminal('resolvedFlags')
+            : this._prefetchSlotTerminal('pendingFlags');
+    },
+
+    _prefetchDisputesAnyHalfReady() {
+        return this._prefetchSlotTerminal('openDisputes')
+            || this._prefetchSlotTerminal('resolvedDisputes');
+    },
+
+    _prefetchFlagsAnyHalfReady() {
         return this._prefetchSlotTerminal('pendingFlags')
-            && this._prefetchSlotTerminal('resolvedFlags');
+            || this._prefetchSlotTerminal('resolvedFlags');
     },
 
     _ensurePrefetch(kind, loadTracker) {
@@ -1803,16 +1822,9 @@ const searchOutputCoreMethods = {
             if (typeof this._refreshPrefetchInventoryTabs === 'function') {
                 await this._refreshPrefetchInventoryTabs(kind);
             }
-            const familyReady = disputeKinds
-                ? this._prefetchDisputesFamilyReady()
-                : flagKinds
-                    ? this._prefetchFlagsFamilyReady()
-                    : false;
-            if (!familyReady) {
-                Logger.debug('dashboard: ' + this._prefetchLabel(kind)
-                    + ' prefetch complete — waiting for family before Search Output overlay');
-                return;
-            }
+            // Re-overlay as soon as each half finishes — Pending/Resolved UI does not wait
+            // for the opposite status to load.
+            if (!disputeKinds && !flagKinds) return;
             await this._withOutputWsAsync('search-output', async () => {
                 if (!this._state.cachedItems || this._state.cachedItems.length === 0) {
                     Logger.debug('dashboard: ' + this._prefetchLabel(kind)
@@ -1861,8 +1873,12 @@ const searchOutputCoreMethods = {
                 for (const row of rows || []) dest.push(row);
             }
         };
-        mergeSlot(openSlot);
-        mergeSlot(resolvedSlot);
+        // Only the half matching Pending/Resolved — opposite status stays out of this inventory view.
+        if (this._resultsReviewStatusValue() === 'resolved') {
+            mergeSlot(resolvedSlot);
+        } else {
+            mergeSlot(openSlot);
+        }
         const profileIds = this._collectPrefetchDisputeProfileIds
             ? this._collectPrefetchDisputeProfileIds(grouped)
             : [];
@@ -1894,8 +1910,11 @@ const searchOutputCoreMethods = {
                 for (const row of rows || []) dest.push(row);
             }
         };
-        mergeSlot(pendingSlot);
-        mergeSlot(resolvedSlot);
+        if (this._resultsReviewStatusValue() === 'resolved') {
+            mergeSlot(resolvedSlot);
+        } else {
+            mergeSlot(pendingSlot);
+        }
         const profileIds = this._collectPrefetchFlagProfileIds
             ? this._collectPrefetchFlagProfileIds(grouped)
             : [];
@@ -1916,8 +1935,9 @@ const searchOutputCoreMethods = {
     },
 
     _prefetchInventoryKindsReady(wsId) {
-        if (wsId === 'disputes') return this._prefetchDisputesFamilyReady();
-        if (wsId === 'sr-review') return this._prefetchFlagsFamilyReady();
+        const status = this._resultsReviewStatusValue();
+        if (wsId === 'disputes') return this._prefetchDisputesHalfReady(status);
+        if (wsId === 'sr-review') return this._prefetchFlagsHalfReady(status);
         return false;
     },
 
@@ -1968,7 +1988,7 @@ const searchOutputCoreMethods = {
                 this._state.loading = false;
                 this._state.leftTab = 'filters';
                 this._state.statsTab = 'chat';
-                if (!this._state.cachedItems) {
+                if (!merge || !this._state.cachedItems) {
                     this._state.cachedItems = [];
                     this._state.filteredItems = [];
                 }
@@ -2033,12 +2053,15 @@ const searchOutputCoreMethods = {
     },
 
     async _refreshPrefetchInventoryTabs(kind) {
-        const disputeKinds = kind === 'openDisputes' || kind === 'resolvedDisputes';
-        const flagKinds = kind === 'pendingFlags' || kind === 'resolvedFlags';
-        if (disputeKinds) {
+        const status = this._resultsReviewStatusValue();
+        // Only refresh the inventory half that matches the Pending/Resolved toggle.
+        if (kind === 'openDisputes' && status === 'pending') {
             await this._loadPrefetchInventoryWorkspace('disputes', { merge: true });
-        }
-        if (flagKinds) {
+        } else if (kind === 'resolvedDisputes' && status === 'resolved') {
+            await this._loadPrefetchInventoryWorkspace('disputes', { merge: true });
+        } else if (kind === 'pendingFlags' && status === 'pending') {
+            await this._loadPrefetchInventoryWorkspace('sr-review', { merge: true });
+        } else if (kind === 'resolvedFlags' && status === 'resolved') {
             await this._loadPrefetchInventoryWorkspace('sr-review', { merge: true });
         }
     },
@@ -2924,17 +2947,23 @@ const searchOutputCoreMethods = {
         let changed = false;
         this._ensureItemKindsArray(item);
 
-        if (!this._prefetchDisputesFamilyReady()) {
+        const openDisputesReady = this._prefetchSlotTerminal('openDisputes');
+        const resolvedDisputesReady = this._prefetchSlotTerminal('resolvedDisputes');
+        if (!openDisputesReady && !resolvedDisputesReady) {
             if (this._clearDisputeOverlaySide(item)) changed = true;
         } else {
-            const openRows = this._getAllCachedOpenDisputeRows(taskId);
-            let resolvedRows = this._getAllCachedResolvedDisputeRows(taskId);
-            const resolvedSlot = this._getPrefetchSlot('resolvedDisputes');
-            const prefetchFailed = resolvedSlot && resolvedSlot.status === 'error';
-            const cacheIncomplete = this._isPrefetchIncomplete('resolvedDisputes');
-            if (resolvedRows.length === 0 && (prefetchFailed || cacheIncomplete)) {
-                const fetched = await this._fetchTaskDisputesBatch([taskId]);
-                resolvedRows = this._filterDisputeRowsForTask(fetched.get(String(taskId)) || [], taskId);
+            const openRows = openDisputesReady ? this._getAllCachedOpenDisputeRows(taskId) : [];
+            let resolvedRows = resolvedDisputesReady
+                ? this._getAllCachedResolvedDisputeRows(taskId)
+                : [];
+            if (resolvedDisputesReady) {
+                const resolvedSlot = this._getPrefetchSlot('resolvedDisputes');
+                const prefetchFailed = resolvedSlot && resolvedSlot.status === 'error';
+                const cacheIncomplete = this._isPrefetchIncomplete('resolvedDisputes');
+                if (resolvedRows.length === 0 && (prefetchFailed || cacheIncomplete)) {
+                    const fetched = await this._fetchTaskDisputesBatch([taskId]);
+                    resolvedRows = this._filterDisputeRowsForTask(fetched.get(String(taskId)) || [], taskId);
+                }
             }
             const combinedDisputes = [...openRows, ...resolvedRows];
             if (combinedDisputes.length > 0) {
@@ -2951,10 +2980,19 @@ const searchOutputCoreMethods = {
             }
         }
 
-        if (!this._prefetchFlagsFamilyReady()) {
+        const pendingFlagsReady = this._prefetchSlotTerminal('pendingFlags');
+        const resolvedFlagsReady = this._prefetchSlotTerminal('resolvedFlags');
+        if (!pendingFlagsReady && !resolvedFlagsReady) {
             if (this._clearFlagOverlaySide(item)) changed = true;
         } else {
-            const flagRows = this._getAllCachedFlagRows(taskId);
+            const tid = taskId != null ? String(taskId) : '';
+            const pending = pendingFlagsReady
+                ? ((this._getPrefetchCache('pendingFlags').get(tid) || []).slice())
+                : [];
+            const resolved = resolvedFlagsReady
+                ? ((this._getPrefetchCache('resolvedFlags').get(tid) || []).slice())
+                : [];
+            const flagRows = [...pending, ...resolved];
             if (flagRows.length > 0) {
                 const flagProfileIds = [];
                 for (const row of flagRows) {
@@ -6681,7 +6719,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.56',
+    _version: '9.57',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/search-output.js
+++ b/plugins/core/main/search-output.js
@@ -5455,7 +5455,12 @@ function attachSearchOutputListeners(modal, dash) {
                 if (e.key === 'Enter') {
                     e.preventDefault();
                     const query = authorInput.value.trim();
-                    if (query) void dash._resolveAuthorToken(query);
+                    if (query) {
+                        void dash._resolveAuthorToken(query);
+                    } else if (dash._state.draftTokens.length > 0) {
+                        Logger.debug('dashboard: Enter in Contributors with resolved tokens — submitting search');
+                        void dash._submitSearch();
+                    }
                 } else if (e.key === 'Backspace' && authorInput.value === '' && dash._state.draftTokens.length > 0) {
                     dash._removeAuthorToken(dash._state.draftTokens[dash._state.draftTokens.length - 1].id);
                 }
@@ -6603,7 +6608,7 @@ const plugin = {
     id: 'search-output',
     name: 'Search Output',
     description: 'Worker Output Search tab core: bootstrap, search, prefetch, filter engine',
-    _version: '9.54',
+    _version: '9.55',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '11.14',
+    _version: '11.15',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
 
@@ -854,6 +854,11 @@ const plugin = {
                     ${this._createSwitchHTML(`wf-plugin-log-${plugin.id}`, moduleLoggingEnabled, null, isDisabled, { size: 'small', variant: 'log' })}
                 </div>
         ` : '';
+        const removeFromCacheHTML = !isEnabled ? `
+                <div style="margin-top: 10px; padding-top: 10px; border-top: 1px dashed ${c.border};">
+                    <button type="button" id="wf-plugin-clear-cache-${plugin.id}" class="${this._settingsBtnClass('basic', 'compact')} wf-dash-btn--full" data-plugin-id="${plugin.id}">Remove from Cache</button>
+                </div>
+        ` : '';
         return `
             <div class="wf-plugin-item" data-plugin-id="${plugin.id}" style="position: relative; display: flex; flex-direction: column; padding: 12px; border: 1px solid ${c.border}; border-radius: 8px; margin-bottom: 10px; background: ${this._settingsThemeColors().card}; will-change: transform;">
                 <div style="display: flex; align-items: center; justify-content: space-between;">
@@ -879,6 +884,7 @@ const plugin = {
                 </div>
                 ${subOptionsHTML}
                 ${moduleToggleHTML}
+                ${removeFromCacheHTML}
             </div>
         `;
     },
@@ -1537,6 +1543,33 @@ const plugin = {
                     this._handleToggleChange(e);
                     Logger.setModuleLoggingEnabled(plugin.id, e.target.checked);
                     this._updateSettingsMessage(modal, plugins);
+                });
+            }
+
+            const clearCacheBtn = Context.dom.query(`#wf-plugin-clear-cache-${plugin.id}`, {
+                root: modal,
+                context: `${this.id}.pluginClearCache`
+            });
+            if (clearCacheBtn) {
+                clearCacheBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const live = PluginManager.get(plugin.id) || plugin;
+                    try {
+                        const result = Storage.clearModuleLocalData(live);
+                        Logger.log(
+                            `removed from cache: ${live.id}`
+                            + (result && result.sourcePath ? ` (${result.sourcePath})` : '')
+                        );
+                        if (Context.buttonFeedback && typeof Context.buttonFeedback.flashSuccess === 'function') {
+                            Context.buttonFeedback.flashSuccess(clearCacheBtn);
+                        }
+                    } catch (err) {
+                        Logger.error(`Failed to remove ${plugin.id} from cache:`, err);
+                        if (Context.buttonFeedback && typeof Context.buttonFeedback.flashFailure === 'function') {
+                            Context.buttonFeedback.flashFailure(clearCacheBtn);
+                        }
+                    }
                 });
             }
         });

--- a/plugins/core/main/settings-ui.js
+++ b/plugins/core/main/settings-ui.js
@@ -7,7 +7,7 @@ const plugin = {
     id: 'settings-ui',
     name: 'Settings UI',
     description: 'Provides the settings panel for managing plugins',
-    _version: '11.15',
+    _version: '11.17',
     phase: 'core', // Special phase - loaded once, never cleaned up
     enabledByDefault: true,
 
@@ -2651,11 +2651,7 @@ const plugin = {
         return `
             <div class="${ab.root} ${ab.amberSoft}">
                 <div style="display: flex; align-items: center; margin-bottom: 8px;">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 8px; color: #f59e0b;">
-                        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-                        <line x1="12" y1="9" x2="12" y2="13"></line>
-                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
-                    </svg>
+                    ${Context.uiLib.alertTriangleIconSvg({ size: 16, style: 'margin-right: 8px; color: #f59e0b;' })}
                     <h3 class="${ab.title}" style="font-size: 14px; font-weight: 600; margin: 0;">
                         Outdated Plugins (${outdatedPlugins.length})
                     </h3>
@@ -2731,11 +2727,7 @@ const plugin = {
         return `
             <div id="wf-ops-refresh-banner" class="${ab.root} ${ab.amber}">
                 <div style="display: flex; align-items: flex-start; margin-bottom: 10px;">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 10px; color: #b45309; flex-shrink: 0; margin-top: 2px;">
-                        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-                        <line x1="12" y1="9" x2="12" y2="13"></line>
-                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
-                    </svg>
+                    ${Context.uiLib.alertTriangleIconSvg({ size: 18, style: 'margin-right: 10px; color: #b45309; margin-top: 2px;' })}
                     <div style="flex: 1;">
                         <h3 class="${ab.title}" style="font-size: 15px; font-weight: 600; margin: 0 0 8px 0;">
                             Ops Tab Unlock Pending
@@ -2839,11 +2831,7 @@ const plugin = {
         return `
             <div id="wf-update-notification-banner" class="${ab.root} ${ab.danger}">
                 <div style="display: flex; align-items: flex-start; margin-bottom: 10px;">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 10px; color: #dc2626; flex-shrink: 0; margin-top: 2px;">
-                        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-                        <line x1="12" y1="9" x2="12" y2="13"></line>
-                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
-                    </svg>
+                    ${Context.uiLib.alertTriangleIconSvg({ size: 18, style: 'margin-right: 10px; color: #dc2626; margin-top: 2px;' })}
                     <div style="flex: 1;">
                         <h3 class="${ab.title}" style="font-size: 15px; font-weight: 600; margin: 0 0 8px 0;">
                             Extension Update Available

--- a/plugins/core/main/team-members.js
+++ b/plugins/core/main/team-members.js
@@ -343,14 +343,11 @@ const teamMembersController = {
     _renderOpsTeamSearchActionRefreshBannerHtml() {
         this._ensureOpsAlertBannerStyles();
         const ab = this._opsAlertBannerClasses();
+        const icon = Context.uiLib.alertTriangleIconSvg({ size: 18, style: 'margin-right: 10px; color: #dc2626; margin-top: 2px;' });
         return [
             '<div id="wf-ops-team-search-action-refresh-banner" class="' + ab.root + ' ' + ab.danger + '">',
             '<div style="display: flex; align-items: flex-start; margin-bottom: 10px;">',
-            '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right: 10px; color: #dc2626; flex-shrink: 0; margin-top: 2px;">',
-            '<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>',
-            '<line x1="12" y1="9" x2="12" y2="13"></line>',
-            '<line x1="12" y1="17" x2="12.01" y2="17"></line>',
-            '</svg>',
+            icon,
             '<div style="flex: 1;">',
             '<h3 class="' + ab.title + '" style="font-size: 15px; font-weight: 600; margin: 0 0 8px 0;">Team Search Unavailable</h3>',
             '<p class="' + ab.body + '" style="font-size: 13px; margin: 0; line-height: 1.5;">',
@@ -2118,7 +2115,7 @@ const plugin = {
     id: 'team-members',
     name: 'Team Members',
     description: 'Team member search tab for the Ops dashboard',
-    _version: '5.0',
+    _version: '5.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/team-members.js
+++ b/plugins/core/main/team-members.js
@@ -359,8 +359,8 @@ const teamMembersController = {
             '</div>',
             '</div>',
             '<div class="' + ab.footer + '">',
-            '<button type="button" id="wf-ops-team-search-open-team" class="' + ab.btnSecondary + '">Refresh credentials</button>',
-            '<button type="button" id="wf-ops-team-search-retry-btn" class="' + ab.btnPrimary + '">Retry search</button>',
+            '<button type="button" id="wf-ops-team-search-open-team" class="' + ab.btnPrimary + '">Refresh credentials</button>',
+            '<button type="button" id="wf-ops-team-search-retry-btn" class="' + ab.btnSecondary + '" style="display: none;">Retry search</button>',
             '</div>',
             '</div>'
         ].join('');
@@ -405,12 +405,13 @@ const teamMembersController = {
             cards.innerHTML = this._renderOpsTeamSearchActionRefreshBannerHtml();
             const self = this;
             const openTeamBtn = cards.querySelector('#wf-ops-team-search-open-team');
+            const retryBtn = cards.querySelector('#wf-ops-team-search-retry-btn');
             if (openTeamBtn) {
                 openTeamBtn.addEventListener('click', () => {
+                    if (retryBtn) retryBtn.style.display = '';
                     Context.opsTab.openTeamPageForCredRefresh(modal);
                 });
             }
-            const retryBtn = cards.querySelector('#wf-ops-team-search-retry-btn');
             if (retryBtn) {
                 retryBtn.addEventListener('click', () => {
                     void self._handleOpsTeamSearchCredentialRetry(modal);
@@ -2115,7 +2116,7 @@ const plugin = {
     id: 'team-members',
     name: 'Team Members',
     description: 'Team member search tab for the Ops dashboard',
-    _version: '5.2',
+    _version: '5.3',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/core/main/ui-lib.js
+++ b/plugins/core/main/ui-lib.js
@@ -1390,6 +1390,18 @@ function fleetUiCopyIconSvg(opts) {
         + '</svg>';
 }
 
+function fleetUiAlertTriangleIconSvg(opts) {
+    const raw = opts && opts.size != null ? Number(opts.size) : 18;
+    const size = Number.isFinite(raw) && raw > 0 ? raw : 18;
+    const extraStyle = opts && opts.style != null ? String(opts.style) : '';
+    const style = extraStyle ? 'flex-shrink:0; ' + extraStyle : 'flex-shrink:0;';
+    return '<svg width="' + size + '" height="' + size + '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="' + style + '">'
+        + '<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>'
+        + '<line x1="12" y1="9" x2="12" y2="13"></line>'
+        + '<circle cx="12" cy="17" r="1" fill="currentColor" stroke="none"></circle>'
+        + '</svg>';
+}
+
 function fleetUiFlashTabSuccess(tabEl) {
     if (!tabEl) return;
     tabEl.classList.remove('fleet-ui-tab--pulse', 'wf-dash-tab--add-pulse');
@@ -1451,7 +1463,7 @@ const plugin = {
     id: 'ui-lib',
     name: 'UI Lib',
     description: 'Shared UI tokens, buttons, icon SVGs, segments, filter toggles, panels, and copy feedback',
-    _version: '3.18',
+    _version: '3.19',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },
@@ -1592,6 +1604,7 @@ const plugin = {
             funnelIconSvg: fleetUiFunnelIconSvg,
             externalLinkIconSvg: fleetUiExternalLinkIconSvg,
             copyIconSvg: fleetUiCopyIconSvg,
+            alertTriangleIconSvg: fleetUiAlertTriangleIconSvg,
 
             segmentBtnClass: fleetUiSegmentBtnClass,
             segmentBtnHtml: fleetUiSegmentBtnHtml,


### PR DESCRIPTION
## Summary

Keep Search Output usable while background hydrates and prefetch overlays run, and keep the extension loading when GitHub is briefly unreachable.

## Changes

- Persist a branch-scoped last-known-good `archetypes.json` and fall back to it on network errors, timeouts, and garbage responses. Probe raw GitHub first, then jsDelivr, and lock the successful CDN for the rest of the page session; if both miss, load plugins and settings docs from cache only.
- Add **Remove from Cache** on disabled Settings module rows so operators can clear a module’s code cache and associated settings without turning the row off. Draw the warning-triangle glyph from shared UI so the exclamation mark’s period stays visible on update banners.
- On the Team Search credentials banner, make **Refresh credentials** the primary action and show **Retry search** only after that click.
- Stop Disputes and Sr Review inventory lookups from disabling or blanking Search Output controls. Scope queries to the active output panel, serialize prefetch UI work on a nested workspace stack, and fetch inventory profiles on the ondemand channel.
- In Contributors, highlight the first of several name matches and let Arrow keys plus Enter (or click) add a chip. Empty-input Enter runs search when at least one contributor is already resolved, matching the Search button.
- Keep task cards in place when they are patched or hydrated. Restore scroll only for on-screen cards, skip no-op `scrollTop` writes, and avoid a deferred restore that fought the wheel. Gate dispute and Sr Review flag overlays until each prefetch family is complete, then unlock Pending/Resolved inventory as the matching half finishes so operators are not waiting on the other status.
