### PR TITLE
Add Guidelines editor tools and CU pane Hide/Unhide

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 
 ### Guidelines
 - **Export Guideline Markdown**: Download the open guideline as a Markdown file from the edit toolbar
+- **Guideline Theme Presets**: Apply named text themes from the edit toolbar
 
 ### Task View
 *No production plugins are configured for this archetype.*

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 ### Session Trace Review Page
 - **Auto-expand Verifier Output**: Expands the Verifier Output section on load by activating the score/timing header once (same as a user click)
 
+### Guidelines
+- **Export Guideline Markdown**: Download the open guideline as a Markdown file from the edit toolbar
+
 ### Task View
 *No production plugins are configured for this archetype.*
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls in the page header (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
 - **Time Remaining Chip**: Keeps the Time remaining countdown from shifting the header as digits change
+- **Toggle Main Panels**: Hide or unhide either main pane (task detail or environment); the other pane expands to full width
 
 ### Computer Use Task Revision Page
 - **Prompt Text Counter**: Shows a live word and character count below the prompt
@@ -129,6 +130,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls in the page header (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
+- **Toggle Main Panels**: Hide or unhide either main pane (task detail or environment); the other pane expands to full width
 
 ### QA Tool Use Review Page
 - **"Accept Task" Modal Improvements**: Add a button above the optional comments box to paste a positive blurb
@@ -155,6 +157,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls beside the Verifier tab (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
+- **Toggle Main Panels**: Hide or unhide either main pane (task detail or environment); the other pane expands to full width
 
 ### Dispute Review Page
 - **Dispute List Collapse**: Hijacks the native expand control for a full collapse that hides everything except the status/time/#id header row; remembers closed dispute numbers across reloads

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.443",
+  "archetypesVersion": "14.444",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -1228,6 +1228,12 @@
           "name": "export-markdown.js",
           "version": "1.0",
           "hash": "sha256-3c740d6e2dcb70c7663da7f16a5b1862e01e12278787f9dfe743fb6e47f8c3d9",
+          "log": false
+        },
+        {
+          "name": "theme-presets.js",
+          "version": "1.0",
+          "hash": "sha256-04adcb559469e6b68b1ec8229c951af04b4804c2914d23762d8023f7035a6065",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.445",
+  "archetypesVersion": "14.446",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -1232,8 +1232,8 @@
         },
         {
           "name": "theme-presets.js",
-          "version": "1.1",
-          "hash": "sha256-98d77a3457b7d0a7ffac073e6206d8b15a4192fd96b8ef1ca2b6d84367b7b988",
+          "version": "1.2",
+          "hash": "sha256-debc19652d12849c9ade7d46972b7e9685f91ac57a79d30c220958a0ffeb4ddf",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.442",
+  "archetypesVersion": "14.443",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -1213,6 +1213,21 @@
           "name": "grade-question-pasted-text.js",
           "version": "1.9",
           "hash": "sha256-b9f3a7c0490a304290b06ad76934e3ec4570d5bb9ee46f87719a1d73cc8604b8",
+          "log": false
+        }
+      ]
+    },
+    {
+      "id": "guidelines",
+      "name": "Guidelines",
+      "description": "Guidelines list and editor",
+      "urlPattern": "work/guidelines",
+      "disambiguationSelectors": [],
+      "plugins": [
+        {
+          "name": "export-markdown.js",
+          "version": "1.0",
+          "hash": "sha256-3c740d6e2dcb70c7663da7f16a5b1862e01e12278787f9dfe743fb6e47f8c3d9",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.441",
+  "archetypesVersion": "14.442",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -108,8 +108,8 @@
     },
     {
       "name": "fos-iframe-autoconnect.js",
-      "version": "1.1",
-      "hash": "sha256-febaf9f3aeb018f567f184e4cbaf76fc66548ba23e7159d759c92dc581bef565",
+      "version": "1.2",
+      "hash": "sha256-ad3b70a082fa2e3ddf5ca934ab86cb13c6aeed02e6f138643e46ee491361b0fa",
       "log": false
     },
     {
@@ -146,6 +146,12 @@
       "name": "top-nav-horizontal-scroll.js",
       "version": "3.2",
       "hash": "sha256-3a83b51180ecac0c1437d3bb7c398b9934d658e5557a727eff608100678731d1",
+      "log": false
+    },
+    {
+      "name": "toggle-main-panels.js",
+      "version": "1.11",
+      "hash": "sha256-ce63fa0133b40c17d6eaf1f6297983fd64b02f64864e67fe1b4c6d572a98c6c7",
       "log": false
     },
     {
@@ -557,7 +563,8 @@
         "fos-iframe-autoconnect.js",
         "prompt-text-counter.js",
         "user-story-markdown.js",
-        "user-story-collapse.js"
+        "user-story-collapse.js",
+        "toggle-main-panels.js"
       ],
       "plugins": [
         {
@@ -580,8 +587,8 @@
         },
         {
           "name": "fos-iframe-autoconnect.js",
-          "version": "1.1",
-          "hash": "sha256-a2d9843e984e5bb9f59d1ae37ec531cb9fac349bbf164e0cb83b7654e6dc7103",
+          "version": "1.2",
+          "hash": "sha256-7ae4d81165d55305d48d9e3051e4d1b0ab40e3ef60234cd72e890f11d872d775",
           "log": false
         },
         {
@@ -619,6 +626,12 @@
           "version": "1.0",
           "hash": "sha256-d8b2c80adfe4eed14ecc7726fa5f87de24f2ce7d5e5aa321a9cfc0b4d1dcb959",
           "log": false
+        },
+        {
+          "name": "toggle-main-panels.js",
+          "version": "1.0",
+          "log": false,
+          "hash": "sha256-f8778c48ed98c701c8d32bdbd155d551072f97be5b62f4c5cf462b62202f6e2f"
         }
       ]
     },
@@ -636,7 +649,8 @@
         "fos-vm-clipboard-bar.js",
         "fos-iframe-autoconnect.js",
         "user-story-markdown.js",
-        "user-story-collapse.js"
+        "user-story-collapse.js",
+        "toggle-main-panels.js"
       ],
       "plugins": [
         {
@@ -659,8 +673,8 @@
         },
         {
           "name": "fos-iframe-autoconnect.js",
-          "version": "1.1",
-          "hash": "sha256-7ae0c747ecae9196dff1d8878537a333362d3d10f20d663e674849834f4da8bf",
+          "version": "1.2",
+          "hash": "sha256-a9540416f8f6b1f9f4b9750957705033f90ad4d620569e72798cb43b1f411be8",
           "log": false
         },
         {
@@ -686,6 +700,12 @@
           "version": "1.0",
           "hash": "sha256-d8b2c80adfe4eed14ecc7726fa5f87de24f2ce7d5e5aa321a9cfc0b4d1dcb959",
           "log": false
+        },
+        {
+          "name": "toggle-main-panels.js",
+          "version": "1.0",
+          "log": false,
+          "hash": "sha256-f8778c48ed98c701c8d32bdbd155d551072f97be5b62f4c5cf462b62202f6e2f"
         }
       ]
     },
@@ -816,7 +836,8 @@
         "screenshot-upload-improvement.js",
         "top-nav-horizontal-scroll.js",
         "user-story-markdown.js",
-        "user-story-collapse.js"
+        "user-story-collapse.js",
+        "toggle-main-panels.js"
       ],
       "plugins": [
         {
@@ -863,8 +884,8 @@
         },
         {
           "name": "fos-iframe-autoconnect.js",
-          "version": "1.1",
-          "hash": "sha256-5589efe8ee5758e14a0b4707105f8caab82da49f33423f314700a3a27bf1cf2d",
+          "version": "1.2",
+          "hash": "sha256-4cebf3f63cdbcfc8cf2e246153465e7299691dafbf8199e1c25e45807721a052",
           "log": false
         },
         {
@@ -893,9 +914,9 @@
         },
         {
           "name": "toggle-main-panels.js",
-          "version": "1.10",
+          "version": "1.11",
           "log": false,
-          "hash": "sha256-1e9aaac738759fe4ecb92bd72c661444e5a302eb44dff26646cb67df286ac5f3"
+          "hash": "sha256-57e883d0db1eaaf784343de7a4ece06eaff54d108860971027692f8e5b6ab201"
         },
         {
           "name": "user-story-markdown.js",
@@ -1016,8 +1037,8 @@
         },
         {
           "name": "fos-iframe-autoconnect.js",
-          "version": "1.1",
-          "hash": "sha256-984c3ab6639460b716f71e6c399f0ac107af368a96353f0ca8c4a33d7f11a4aa",
+          "version": "1.2",
+          "hash": "sha256-662ca9bd9c4883de4250fb87deb48291a4f15b5740a081421cf4e7f2d0dd7db2",
           "log": false
         },
         {

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.446",
+  "archetypesVersion": "14.447",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -1232,8 +1232,8 @@
         },
         {
           "name": "theme-presets.js",
-          "version": "1.2",
-          "hash": "sha256-debc19652d12849c9ade7d46972b7e9685f91ac57a79d30c220958a0ffeb4ddf",
+          "version": "1.3",
+          "hash": "sha256-5ee8ef0bef04babd14541a87ca4af0228350bebc1d1689ca198c9088f640aa25",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.444",
+  "archetypesVersion": "14.445",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -1232,8 +1232,8 @@
         },
         {
           "name": "theme-presets.js",
-          "version": "1.0",
-          "hash": "sha256-04adcb559469e6b68b1ec8229c951af04b4804c2914d23762d8023f7035a6065",
+          "version": "1.1",
+          "hash": "sha256-98d77a3457b7d0a7ffac073e6206d8b15a4192fd96b8ef1ca2b6d84367b7b988",
           "log": false
         }
       ]

--- a/archetypes.json
+++ b/archetypes.json
@@ -1,7 +1,7 @@
 {
   "version": "13.11",
   "coreOnlyMode": false,
-  "archetypesVersion": "14.447",
+  "archetypesVersion": "14.448",
   "logs": {
     "debug": false,
     "verbose": false,
@@ -323,7 +323,7 @@
     },
     {
       "name": "features-tab.md",
-      "version": "1.40"
+      "version": "1.41"
     }
   ],
   "archetypes": [

--- a/dev/descriptions.json
+++ b/dev/descriptions.json
@@ -483,6 +483,11 @@
       "file": "export-markdown.js",
       "name": "Export Guideline Markdown",
       "description": "Download the open guideline as a Markdown file from the edit toolbar"
+    },
+    {
+      "file": "theme-presets.js",
+      "name": "Guideline Theme Presets",
+      "description": "Apply named text themes from the edit toolbar"
     }
   ]
 }

--- a/dev/descriptions.json
+++ b/dev/descriptions.json
@@ -53,6 +53,11 @@
       "file": "user-story-collapse.js",
       "name": "User Story Collapse",
       "description": "Adds Hide/Show on the User Story row to collapse the story body below the label"
+    },
+    {
+      "file": "toggle-main-panels.js",
+      "name": "Toggle Main Panels",
+      "description": "Hide or unhide either main pane (task detail or environment); the other pane expands to full width"
     }
   ],
   "archetypes/comp-use-task-creation/main": [
@@ -90,6 +95,11 @@
       "file": "user-story-collapse.js",
       "name": "User Story Collapse",
       "description": "Adds Hide/Show on the User Story row to collapse the story body below the label"
+    },
+    {
+      "file": "toggle-main-panels.js",
+      "name": "Toggle Main Panels",
+      "description": "Hide or unhide either main pane (task detail or environment); the other pane expands to full width"
     }
   ],
   "archetypes/dashboard/main": [

--- a/dev/descriptions.json
+++ b/dev/descriptions.json
@@ -477,5 +477,12 @@
       "name": "Expert Feedback Tooltip Fix",
       "description": "Fixes Recent Feedback tooltip text color and enables scrolling for long feedback on expert profile pages"
     }
+  ],
+  "archetypes/guidelines/main": [
+    {
+      "file": "export-markdown.js",
+      "name": "Export Guideline Markdown",
+      "description": "Download the open guideline as a Markdown file from the edit toolbar"
+    }
   ]
 }

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'feat/dashboard';
+    const BRANCH_NAME = 'main';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/dev/fleet-dev-id.user.js
+++ b/dev/fleet-dev-id.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         DEV-ID - Fleet UX Enhancer - (dev identifier)
+// @name         [feat/dashboard] DEV-ID - Fleet UX Enhancer - (dev identifier)
 // @namespace    http://tampermonkey.net/
 // @version      1.0
 // @description  Dev-only branch identifier for Fleet UX Enhancer dev builds.
@@ -9,8 +9,8 @@
 // @match        https://fleetai.com/*
 // @include      /^https:\/\/[^/]+\.env\.[^/]+\.fleetai\.com/
 // @connect      raw.githubusercontent.com
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/dev/fleet-dev-id.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/dev/fleet-dev-id.user.js
 // @run-at       document-start
 // ==/UserScript==
 
@@ -22,7 +22,7 @@
     }
 
     const DEV_ID_STORAGE_KEY = 'fleet-dev-branch-id';
-    const BRANCH_NAME = 'main';
+    const BRANCH_NAME = 'feat/dashboard';
 
     try {
         const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;

--- a/docs/settings-modal/features-tab.md
+++ b/docs/settings-modal/features-tab.md
@@ -1,4 +1,4 @@
-1.40
+1.41
 
 ## Features
 
@@ -41,6 +41,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls in the page header (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
 - **Time Remaining Chip**: Keeps the Time remaining countdown from shifting the header as digits change
+- **Toggle Main Panels**: Hide or unhide either main pane (task detail or environment); the other pane expands to full width
 
 ### Computer Use Task Revision Page
 - **Prompt Text Counter**: Shows a live word and character count below the prompt
@@ -49,6 +50,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls in the page header (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
+- **Toggle Main Panels**: Hide or unhide either main pane (task detail or environment); the other pane expands to full width
 
 ### QA Tool Use Review Page
 - **"Accept Task" Modal Improvements**: Add a button above the optional comments box to paste a positive blurb
@@ -71,6 +73,7 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **User Story Markdown**: Hide native User Story bodies and show markdown-rendered blue-framed replicas
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls beside the Verifier tab (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
+- **Toggle Main Panels**: Hide or unhide either main pane (task detail or environment); the other pane expands to full width
 
 ### Dispute Detail Page
 - **Clear Tool Search**: Adds a clear `X` button to the tool search box when it has text
@@ -84,6 +87,10 @@ Many of the original modifications (such as a 3-column layout in the Kinesis tas
 - **Verifier Expand Mismatch Rows**: Expands Per-Field Comparison rows that failed (red X) so Expected vs Your Answer is visible without clicking each field
 - **VM Clipboard**: Extract/Overwrite VM Clipboard controls after the Computer Use badge (shown when FOS env is ready)
 - **FOS Viewport Resize**: Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again
+
+### Guidelines
+- **Export Guideline Markdown**: Download the open guideline as a Markdown file from the edit toolbar
+- **Guideline Theme Presets**: Apply named text themes from the edit toolbar
 
 ### Task View
 *No production plugins are configured for this archetype.*

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         Fleet Workflow Builder UX Enhancer
+// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      13.11
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'main',
+        branch: 'feat/dashboard',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/fleet.user.js
+++ b/fleet.user.js
@@ -1,6 +1,6 @@
 
 // ==UserScript==
-// @name         [feat/dashboard] Fleet Workflow Builder UX Enhancer
+// @name         Fleet Workflow Builder UX Enhancer
 // @namespace    http://tampermonkey.net/
 // @version      13.11
 // @description  UX improvements for workflow builder tool with archetype-based plugin loading
@@ -19,8 +19,8 @@
 // @connect      cdn.jsdelivr.net
 // @connect      openrouter.ai
 // @run-at       document-start
-// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
-// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/feat/dashboard/fleet.user.js
+// @downloadURL  https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
+// @updateURL    https://raw.githubusercontent.com/Fleet-AI-Operations/fleet-ux-improvements/main/fleet.user.js
 // ==/UserScript==
 
 (function() {
@@ -96,7 +96,7 @@
     const GITHUB_CONFIG = {
         owner: 'Fleet-AI-Operations',
         repo: 'fleet-ux-improvements',
-        branch: 'feat/dashboard',
+        branch: 'main',
         pluginsPath: 'plugins',
         corePath: 'core',
         devPath: 'dev',

--- a/plugins/archetypes/comp-use-revision/main/fos-iframe-autoconnect.js
+++ b/plugins/archetypes/comp-use-revision/main/fos-iframe-autoconnect.js
@@ -5,8 +5,8 @@ const plugin = {
     id: 'compUseRevisionFosIframeAutoconnect',
     name: 'FOS Viewport Resize',
     description:
-        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again',
-    _version: '1.1',
+        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again unless the environment pane is hidden',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -20,7 +20,8 @@ const plugin = {
         visibilityInstalled: false,
         wasHidden: false,
         desktopUnsub: null,
-        reloadTimer: null
+        reloadTimer: null,
+        pendingFocusReconnect: false
     },
 
     onMutation(state) {

--- a/plugins/archetypes/comp-use-revision/main/toggle-main-panels.js
+++ b/plugins/archetypes/comp-use-revision/main/toggle-main-panels.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'toggleMainPanels',
     name: 'Toggle Main Panels',
     description: 'Hide or unhide either main pane (task detail or environment); the other pane expands to full width',
-    _version: '1.11',
+    _version: '1.0',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {

--- a/plugins/archetypes/comp-use-task-creation/main/fos-iframe-autoconnect.js
+++ b/plugins/archetypes/comp-use-task-creation/main/fos-iframe-autoconnect.js
@@ -5,8 +5,8 @@ const plugin = {
     id: 'compUseTaskCreationFosIframeAutoconnect',
     name: 'FOS Viewport Resize',
     description:
-        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again',
-    _version: '1.1',
+        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again unless the environment pane is hidden',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -20,7 +20,8 @@ const plugin = {
         visibilityInstalled: false,
         wasHidden: false,
         desktopUnsub: null,
-        reloadTimer: null
+        reloadTimer: null,
+        pendingFocusReconnect: false
     },
 
     onMutation(state) {

--- a/plugins/archetypes/comp-use-task-creation/main/toggle-main-panels.js
+++ b/plugins/archetypes/comp-use-task-creation/main/toggle-main-panels.js
@@ -5,7 +5,7 @@ const plugin = {
     id: 'toggleMainPanels',
     name: 'Toggle Main Panels',
     description: 'Hide or unhide either main pane (task detail or environment); the other pane expands to full width',
-    _version: '1.11',
+    _version: '1.0',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {

--- a/plugins/archetypes/dispute-detail/main/fos-iframe-autoconnect.js
+++ b/plugins/archetypes/dispute-detail/main/fos-iframe-autoconnect.js
@@ -5,8 +5,8 @@ const plugin = {
     id: 'disputeDetailFosIframeAutoconnect',
     name: 'FOS Viewport Resize',
     description:
-        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again',
-    _version: '1.1',
+        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again unless the environment pane is hidden',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -20,7 +20,8 @@ const plugin = {
         visibilityInstalled: false,
         wasHidden: false,
         desktopUnsub: null,
-        reloadTimer: null
+        reloadTimer: null,
+        pendingFocusReconnect: false
     },
 
     onMutation(state) {

--- a/plugins/archetypes/guidelines/main/export-markdown.js
+++ b/plugins/archetypes/guidelines/main/export-markdown.js
@@ -1,0 +1,597 @@
+// ============= export-markdown.js =============
+// Archetype: guidelines (work/guidelines).
+// Injects an export control on the TipTap edit toolbar and downloads the document as Markdown.
+
+const EDITOR_SEL = '[data-guidelines-editor="true"]';
+const BTN_MARKER = 'data-fleet-guidelines-export';
+const TITLE_INPUT_ID = 'title';
+const FALLBACK_FILENAME = 'guideline.md';
+
+const plugin = {
+    id: 'guidelinesExportMarkdown',
+    name: 'Export Guideline Markdown',
+    description:
+        'Download the open guideline as a Markdown file from the edit toolbar',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        activationLogged: false
+    },
+
+    findEditor() {
+        return document.querySelector(EDITOR_SEL);
+    },
+
+    findToolbar(editor) {
+        if (!editor) {
+            return null;
+        }
+        const shell = editor.closest('div.rounded-md.border') || editor.parentElement;
+        if (!shell) {
+            return null;
+        }
+        const candidates = shell.querySelectorAll('div');
+        for (const el of candidates) {
+            const cl = el.classList;
+            if (
+                cl.contains('sticky') &&
+                cl.contains('top-0') &&
+                cl.contains('z-10') &&
+                cl.contains('flex') &&
+                cl.contains('flex-wrap')
+            ) {
+                return el;
+            }
+        }
+        return null;
+    },
+
+    downloadIcon() {
+        const ns = 'http://www.w3.org/2000/svg';
+        const svg = document.createElementNS(ns, 'svg');
+        svg.setAttribute('width', '16');
+        svg.setAttribute('height', '16');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('stroke-width', '2');
+        svg.setAttribute('stroke-linecap', 'round');
+        svg.setAttribute('stroke-linejoin', 'round');
+        svg.setAttribute('aria-hidden', 'true');
+        svg.setAttribute('class', 'h-4 w-4');
+
+        const tray = document.createElementNS(ns, 'path');
+        tray.setAttribute('d', 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4');
+        svg.appendChild(tray);
+
+        const poly = document.createElementNS(ns, 'polyline');
+        poly.setAttribute('points', '7 10 12 15 17 10');
+        const line = document.createElementNS(ns, 'line');
+        line.setAttribute('x1', '12');
+        line.setAttribute('y1', '15');
+        line.setAttribute('x2', '12');
+        line.setAttribute('y2', '3');
+        svg.append(poly, line);
+        return svg;
+    },
+
+    injectButton(toolbar) {
+        if (!toolbar || toolbar.querySelector(`[${BTN_MARKER}="1"]`)) {
+            return false;
+        }
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.title = 'Export as Markdown';
+        btn.setAttribute('aria-label', 'Export as Markdown');
+        btn.setAttribute(BTN_MARKER, '1');
+        btn.className = 'rounded p-1.5 transition-colors hover:bg-muted';
+        btn.style.marginLeft = 'auto';
+        btn.appendChild(this.downloadIcon());
+        btn.addEventListener('click', (evt) => {
+            evt.preventDefault();
+            evt.stopPropagation();
+            this.onExportClick(btn);
+        });
+        toolbar.appendChild(btn);
+        return true;
+    },
+
+    filenameFromTitle() {
+        const input = document.getElementById(TITLE_INPUT_ID);
+        let name = input && typeof input.value === 'string' ? input.value.trim() : '';
+        if (!name) {
+            return FALLBACK_FILENAME;
+        }
+        name = name.replace(/[^\w.\- ]+/g, '_').replace(/^[\s_]+|[\s_]+$/g, '').trim();
+        if (!name) {
+            return FALLBACK_FILENAME;
+        }
+        if (!/\.md$/i.test(name)) {
+            name += '.md';
+        }
+        return name;
+    },
+
+    downloadTextFile(filename, content) {
+        const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    },
+
+    flash(btn, ok) {
+        const fb = Context.buttonFeedback;
+        if (!btn || !fb) {
+            return;
+        }
+        if (ok && typeof fb.flashSuccess === 'function') {
+            fb.flashSuccess(btn);
+        } else if (!ok && typeof fb.flashFailure === 'function') {
+            fb.flashFailure(btn);
+        }
+    },
+
+    onExportClick(btn) {
+        const editor = this.findEditor();
+        if (!editor) {
+            this.flash(btn, false);
+            Logger.warn('export failed — editor not found');
+            return;
+        }
+        let markdown;
+        try {
+            markdown = this.editorToMarkdown(editor);
+        } catch (err) {
+            this.flash(btn, false);
+            Logger.error('export failed — conversion threw', err);
+            return;
+        }
+        if (!markdown || !String(markdown).trim()) {
+            this.flash(btn, false);
+            Logger.warn('export failed — empty document');
+            return;
+        }
+        const filename = this.filenameFromTitle();
+        try {
+            this.downloadTextFile(filename, markdown);
+        } catch (err) {
+            this.flash(btn, false);
+            Logger.error('export failed — download threw', err);
+            return;
+        }
+        this.flash(btn, true);
+        Logger.log(`exported ${filename} (${markdown.length} chars)`);
+    },
+
+    forElementChildren(el, fn) {
+        if (!el) {
+            return;
+        }
+        for (const child of el.childNodes) {
+            if (child.nodeType === Node.ELEMENT_NODE) {
+                fn(child);
+            }
+        }
+    },
+
+    isEmptyParagraph(el) {
+        if (!el || el.tagName !== 'P') {
+            return false;
+        }
+        const text = (el.textContent || '').replace(/\u00a0/g, ' ').trim();
+        return !text;
+    },
+
+    isTaskList(el) {
+        return !!(el && el.getAttribute('data-type') === 'taskList');
+    },
+
+    isCallout(el) {
+        return !!(el && el.nodeType === Node.ELEMENT_NODE && el.hasAttribute('data-callout'));
+    },
+
+    isDetails(el) {
+        if (!el || el.nodeType !== Node.ELEMENT_NODE) {
+            return false;
+        }
+        if (el.tagName === 'DETAILS') {
+            return true;
+        }
+        const type = el.getAttribute('data-type');
+        return type === 'details' || type === 'toggle';
+    },
+
+    wrapDelim(delim, inner) {
+        if (!inner) {
+            return '';
+        }
+        return delim + inner + delim;
+    },
+
+    wrapInlineCode(text) {
+        const t = String(text || '').replace(/\n/g, ' ');
+        let ticks = '`';
+        const runs = t.match(/`+/g);
+        if (runs) {
+            let max = 1;
+            for (const run of runs) {
+                if (run.length >= max) {
+                    max = run.length + 1;
+                }
+            }
+            ticks = '`'.repeat(max);
+        }
+        const pad = t.startsWith(' ') || t.endsWith(' ') || t.startsWith('`') || t.endsWith('`') ? ' ' : '';
+        return ticks + pad + t + pad + ticks;
+    },
+
+    convertInline(el) {
+        if (!el) {
+            return '';
+        }
+        let out = '';
+        for (const child of el.childNodes) {
+            if (child.nodeType === Node.TEXT_NODE) {
+                out += (child.textContent || '').replace(/\u00a0/g, ' ').replace(/\s+/g, ' ');
+                continue;
+            }
+            if (child.nodeType !== Node.ELEMENT_NODE) {
+                continue;
+            }
+            const tag = child.tagName.toLowerCase();
+            if (tag === 'br') {
+                if (child.classList.contains('ProseMirror-trailingBreak')) {
+                    continue;
+                }
+                out += '  \n';
+                continue;
+            }
+            if (tag === 'strong' || tag === 'b') {
+                out += this.wrapDelim('**', this.convertInline(child));
+                continue;
+            }
+            if (tag === 'em' || tag === 'i') {
+                out += this.wrapDelim('*', this.convertInline(child));
+                continue;
+            }
+            if (tag === 's' || tag === 'del' || tag === 'strike') {
+                out += this.wrapDelim('~~', this.convertInline(child));
+                continue;
+            }
+            if (tag === 'code' && !child.closest('pre')) {
+                out += this.wrapInlineCode(child.textContent || '');
+                continue;
+            }
+            if (tag === 'a') {
+                const href = (child.getAttribute('href') || '').trim();
+                const label = this.convertInline(child);
+                if (!href) {
+                    out += label;
+                } else {
+                    out += '[' + label + '](' + href + ')';
+                }
+                continue;
+            }
+            if (tag === 'img') {
+                const src = (child.getAttribute('src') || '').trim();
+                const alt = (child.getAttribute('alt') || '').replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+                if (src) {
+                    out += '![' + alt + '](' + src + ')';
+                }
+                continue;
+            }
+            // u, mark, span, and unknown inline wrappers: flatten (drop color/highlight/underline)
+            out += this.convertInline(child);
+        }
+        return out;
+    },
+
+    convertBlocks(parent) {
+        const parts = [];
+        this.forElementChildren(parent, (child) => {
+            parts.push(this.convertBlock(child));
+        });
+        let out = '';
+        for (let i = 0; i < parts.length; i++) {
+            if (i > 0) {
+                out += '\n\n';
+            }
+            out += parts[i];
+        }
+        return out;
+    },
+
+    convertBlockquote(el) {
+        const inner = this.convertBlocks(el).replace(/\n+$/, '');
+        if (!inner) {
+            return '>';
+        }
+        return inner
+            .split('\n')
+            .map((line) => (line === '' ? '>' : '> ' + line))
+            .join('\n');
+    },
+
+    convertPre(el) {
+        const code = el.querySelector('code') || el;
+        let lang = '';
+        const cls = code.getAttribute('class') || '';
+        const langMatch = cls.match(/language-([A-Za-z0-9_+-]+)/);
+        if (langMatch) {
+            lang = langMatch[1];
+        }
+        let text = code.textContent || '';
+        if (text.endsWith('\n')) {
+            text = text.slice(0, -1);
+        }
+        return '```' + lang + '\n' + text + '\n```';
+    },
+
+    convertTable(el) {
+        const rows = Array.from(el.querySelectorAll('tr'));
+        if (rows.length === 0) {
+            return '';
+        }
+        const cellText = (cell) =>
+            this.convertInline(cell).replace(/\|/g, '\\|').replace(/\n/g, ' ').trim();
+        const matrix = rows.map((tr) =>
+            Array.from(tr.children)
+                .filter((c) => c.tagName === 'TH' || c.tagName === 'TD')
+                .map(cellText)
+        );
+        const cols = matrix.reduce((max, row) => Math.max(max, row.length), 0);
+        if (cols === 0) {
+            return '';
+        }
+        const pad = (row) => {
+            const next = row.slice();
+            while (next.length < cols) {
+                next.push('');
+            }
+            return next;
+        };
+        const lines = [];
+        const header = pad(matrix[0]);
+        lines.push('| ' + header.join(' | ') + ' |');
+        lines.push('| ' + header.map(() => '---').join(' | ') + ' |');
+        for (let i = 1; i < matrix.length; i++) {
+            lines.push('| ' + pad(matrix[i]).join(' | ') + ' |');
+        }
+        return lines.join('\n');
+    },
+
+    convertDetails(el) {
+        const summary =
+            el.querySelector(':scope > summary, :scope > [data-type="detailsSummary"]') ||
+            el.querySelector('summary, [data-type="detailsSummary"]');
+        const content =
+            el.querySelector(':scope > [data-type="detailsContent"]') ||
+            el.querySelector('[data-type="detailsContent"]');
+        const title = summary ? this.convertInline(summary).trim() : '';
+        const bodyParent = content || el;
+        const bodyParts = [];
+        this.forElementChildren(bodyParent, (child) => {
+            if (child === summary || (summary && summary.contains(child))) {
+                return;
+            }
+            if (child.tagName === 'SUMMARY' || child.getAttribute('data-type') === 'detailsSummary') {
+                return;
+            }
+            bodyParts.push(this.convertBlock(child));
+        });
+        let body = '';
+        for (let i = 0; i < bodyParts.length; i++) {
+            if (i > 0) {
+                body += '\n\n';
+            }
+            body += bodyParts[i];
+        }
+        if (title && body) {
+            return '**' + title + '**\n\n' + body;
+        }
+        if (title) {
+            return '**' + title + '**';
+        }
+        return body;
+    },
+
+    convertList(el, ordered, indent) {
+        const pad = ' '.repeat(indent || 0);
+        const items = [];
+        let n = 1;
+        const task = this.isTaskList(el);
+        this.forElementChildren(el, (li) => {
+            if (li.tagName !== 'LI') {
+                return;
+            }
+            let marker;
+            if (task || li.getAttribute('data-type') === 'taskItem') {
+                const checkedAttr = li.getAttribute('data-checked');
+                const checked =
+                    checkedAttr === 'true' ||
+                    !!(li.querySelector && li.querySelector('input[type="checkbox"]:checked'));
+                marker = checked ? '- [x]' : '- [ ]';
+            } else if (ordered) {
+                marker = String(n) + '.';
+                n += 1;
+            } else {
+                marker = '-';
+            }
+            const hang = pad + ' '.repeat(marker.length + 1);
+            const blocks = [];
+            const pushChild = (child) => {
+                const tag = child.tagName.toLowerCase();
+                if (tag === 'label' || tag === 'input') {
+                    return;
+                }
+                if (tag === 'ul' || tag === 'ol') {
+                    blocks.push({ kind: 'list', el: child });
+                    return;
+                }
+                const type = child.getAttribute('data-type') || '';
+                const flattenWrapper =
+                    tag === 'div' &&
+                    !this.isCallout(child) &&
+                    !this.isDetails(child) &&
+                    type !== 'codeBlock';
+                if (flattenWrapper) {
+                    this.forElementChildren(child, pushChild);
+                    return;
+                }
+                blocks.push({ kind: 'block', el: child });
+            };
+            this.forElementChildren(li, pushChild);
+
+            const lines = [];
+            let usedMarker = false;
+            const appendIndented = (md, firstLineUsesMarker) => {
+                const split = String(md).split('\n');
+                if (firstLineUsesMarker) {
+                    lines.push(pad + marker + (split[0] ? ' ' + split[0] : ''));
+                    for (let i = 1; i < split.length; i++) {
+                        lines.push(split[i] === '' ? hang.replace(/\s+$/, '') : hang + split[i]);
+                    }
+                    usedMarker = true;
+                    return;
+                }
+                for (const line of split) {
+                    lines.push(line === '' ? hang.replace(/\s+$/, '') : hang + line);
+                }
+            };
+            for (const block of blocks) {
+                if (block.kind === 'list') {
+                    const nestedOrdered = block.el.tagName === 'OL';
+                    const nested = this.convertList(block.el, nestedOrdered, (indent || 0) + 4);
+                    if (!usedMarker) {
+                        lines.push(pad + marker);
+                        usedMarker = true;
+                    }
+                    if (nested) {
+                        lines.push(nested);
+                    }
+                    continue;
+                }
+                const md = this.convertBlock(block.el);
+                if (!usedMarker) {
+                    appendIndented(md, true);
+                } else {
+                    appendIndented(md, false);
+                }
+            }
+            if (!usedMarker) {
+                const fallback = this.convertInline(li).trim();
+                lines.push(pad + marker + (fallback ? ' ' + fallback : ''));
+            }
+            items.push(lines.join('\n'));
+        });
+        return items.join('\n');
+    },
+
+    convertBlock(el) {
+        if (!el || el.nodeType !== Node.ELEMENT_NODE) {
+            return '';
+        }
+        const tag = el.tagName.toLowerCase();
+        const type = el.getAttribute('data-type') || '';
+
+        if (tag === 'h1') {
+            return '# ' + this.convertInline(el).trim();
+        }
+        if (tag === 'h2') {
+            return '## ' + this.convertInline(el).trim();
+        }
+        if (tag === 'h3') {
+            return '### ' + this.convertInline(el).trim();
+        }
+        if (tag === 'h4') {
+            return '#### ' + this.convertInline(el).trim();
+        }
+        if (tag === 'h5') {
+            return '##### ' + this.convertInline(el).trim();
+        }
+        if (tag === 'h6') {
+            return '###### ' + this.convertInline(el).trim();
+        }
+        if (tag === 'p') {
+            if (this.isEmptyParagraph(el)) {
+                return '';
+            }
+            return this.convertInline(el).trim();
+        }
+        if (tag === 'ul') {
+            return this.convertList(el, false, 0);
+        }
+        if (tag === 'ol') {
+            return this.convertList(el, true, 0);
+        }
+        if (tag === 'blockquote' || this.isCallout(el)) {
+            return this.convertBlockquote(el);
+        }
+        if (tag === 'hr') {
+            return '---';
+        }
+        if (tag === 'table') {
+            return this.convertTable(el);
+        }
+        if (tag === 'pre' || type === 'codeBlock') {
+            const pre = tag === 'pre' ? el : el.querySelector('pre') || el;
+            return this.convertPre(pre);
+        }
+        if (this.isDetails(el)) {
+            return this.convertDetails(el);
+        }
+        if (tag === 'img') {
+            return this.convertInline(el).trim();
+        }
+        if (tag === 'br') {
+            return '';
+        }
+        const nested = this.convertBlocks(el);
+        if (nested) {
+            return nested;
+        }
+        return this.convertInline(el).trim();
+    },
+
+    editorToMarkdown(editor) {
+        const body = this.convertBlocks(editor).replace(/\n+$/, '');
+        return body ? body + '\n' : '';
+    },
+
+    onMutation(state) {
+        const editor = this.findEditor();
+        const toolbar = this.findToolbar(editor);
+        if (!editor || !toolbar) {
+            if (state.activationLogged) {
+                Logger.debug('export control removed (editor closed)');
+                state.activationLogged = false;
+            }
+            return;
+        }
+        const injected = this.injectButton(toolbar);
+        if (injected && !state.activationLogged) {
+            Logger.log('export control added');
+            state.activationLogged = true;
+        } else if (!state.activationLogged && toolbar.querySelector(`[${BTN_MARKER}="1"]`)) {
+            Logger.log('export control added');
+            state.activationLogged = true;
+        }
+    },
+
+    destroy(state) {
+        const btn = document.querySelector(`[${BTN_MARKER}="1"]`);
+        if (btn) {
+            btn.remove();
+        }
+        if (state) {
+            state.activationLogged = false;
+        }
+    }
+};

--- a/plugins/archetypes/guidelines/main/theme-presets.js
+++ b/plugins/archetypes/guidelines/main/theme-presets.js
@@ -4,8 +4,8 @@
 
 const EDITOR_SEL = '[data-guidelines-editor="true"]';
 const WRAP_MARKER = 'data-fleet-guidelines-themes';
-const DATALIST_ID = 'fleet-guidelines-theme-list';
 const EXPORT_MARKER = 'data-fleet-guidelines-export';
+const MENU_MARKER = 'data-fleet-guidelines-theme-menu';
 
 const PRESETS = [
     { name: 'Title', heading: 1, color: '#db2777', underline: true },
@@ -30,7 +30,7 @@ const plugin = {
     id: 'guidelinesThemePresets',
     name: 'Guideline Theme Presets',
     description: 'Apply named text themes from the edit toolbar',
-    _version: '1.2',
+    _version: '1.3',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -38,7 +38,10 @@ const plugin = {
         savedSel: null,
         onSel: null,
         boundEditor: null,
-        tiptap: null
+        tiptap: null,
+        menuEl: null,
+        onDocPointer: null,
+        onMenuKey: null
     },
 
     findEditor() {
@@ -778,7 +781,7 @@ const plugin = {
         return false;
     },
 
-    applyAfterClick(editorEl, toolbar, preset, input) {
+    applyAfterClick(state, editorEl, toolbar, preset, input) {
         const api0 = this.findEditorApi(editorEl);
         let clicked = false;
         if (preset.heading) {
@@ -787,6 +790,7 @@ const plugin = {
                 if (!this.clickToolbar(toolbar, 'Heading ' + preset.heading)) {
                     this.flash(input, false);
                     Logger.warn('theme apply failed — marks not set');
+                    this.closeMenu(state);
                     return;
                 }
                 clicked = true;
@@ -798,6 +802,7 @@ const plugin = {
                 if (!this.clickToolbar(toolbar, 'Toggle Block')) {
                     this.flash(input, false);
                     Logger.warn('theme apply failed — marks not set');
+                    this.closeMenu(state);
                     return;
                 }
                 clicked = true;
@@ -814,6 +819,7 @@ const plugin = {
                 this.flash(input, false);
                 Logger.warn('theme apply failed — marks not set');
             }
+            this.closeMenu(state);
         };
         if (clicked) {
             window.requestAnimationFrame(finish);
@@ -840,6 +846,7 @@ const plugin = {
         if (!editorEl || !preset) {
             this.flash(input, false);
             Logger.warn('theme apply failed — editor not found');
+            this.closeMenu(state);
             return;
         }
         const api = this.findEditorApi(editorEl);
@@ -867,22 +874,129 @@ const plugin = {
                 ok = this.applyViaPm(view, preset);
             }
             if (!ok && toolbar && (preset.heading || preset.toggle)) {
-                this.applyAfterClick(editorEl, toolbar, preset, input);
+                this.applyAfterClick(state, editorEl, toolbar, preset, input);
                 return;
             }
         } catch (err) {
             this.flash(input, false);
             Logger.error('theme apply threw', err);
+            this.closeMenu(state);
             return;
         }
         if (!ok) {
             this.flash(input, false);
             Logger.warn('theme apply failed — no editor view');
+            this.closeMenu(state);
             return;
         }
         this.flash(input, true);
         Logger.log('applied ' + preset.name);
         input.value = preset.name;
+        this.closeMenu(state);
+    },
+
+    keepEditorSelection(state, editorEl) {
+        const api = this.findEditorApi(editorEl);
+        if (api.view && state.savedSel && state.savedSel.kind === 'pm') {
+            this.restorePmSelection(api.view, state.savedSel);
+            return;
+        }
+        if (state.savedSel && state.savedSel.kind === 'dom' && state.savedSel.range) {
+            const sel = window.getSelection();
+            if (sel) {
+                sel.removeAllRanges();
+                sel.addRange(state.savedSel.range);
+            }
+        }
+        if (editorEl) {
+            editorEl.focus();
+        }
+    },
+
+    closeMenu(state) {
+        if (!state) {
+            return;
+        }
+        if (state.menuEl && state.menuEl.parentNode) {
+            state.menuEl.remove();
+        }
+        state.menuEl = null;
+        if (state.onDocPointer) {
+            document.removeEventListener('pointerdown', state.onDocPointer, true);
+            state.onDocPointer = null;
+        }
+        if (state.onMenuKey) {
+            document.removeEventListener('keydown', state.onMenuKey, true);
+            state.onMenuKey = null;
+        }
+        const wrap = document.querySelector(`[${WRAP_MARKER}="1"]`);
+        const input = wrap ? wrap.querySelector('input') : null;
+        if (input) {
+            input.setAttribute('aria-expanded', 'false');
+        }
+    },
+
+    openMenu(state, wrap, input, editorEl) {
+        this.closeMenu(state);
+        const ui = Context.uiLib;
+        if (ui && typeof ui.ensurePanelStyles === 'function') {
+            ui.ensurePanelStyles(`[${WRAP_MARKER}="1"]`);
+        }
+        const pc = (ui && ui.PANEL_CLASSES) || {};
+        const menu = document.createElement('div');
+        menu.setAttribute(MENU_MARKER, '1');
+        menu.className = pc.root || '';
+        menu.setAttribute('role', 'listbox');
+        menu.style.cssText =
+            'position:absolute;top:100%;left:0;z-index:50;min-width:100%;max-height:16rem;overflow-y:auto;margin-top:2px;';
+        const current = String(input.value || '').trim().toLowerCase();
+        for (const preset of PRESETS) {
+            const opt = document.createElement('button');
+            opt.type = 'button';
+            opt.setAttribute('role', 'option');
+            opt.setAttribute('aria-selected', preset.name.toLowerCase() === current ? 'true' : 'false');
+            opt.className = pc.ghostBtn || '';
+            opt.textContent = preset.name;
+            opt.style.cssText = 'display:block;width:100%;text-align:left;box-sizing:border-box;';
+            opt.addEventListener('pointerdown', (evt) => {
+                evt.preventDefault();
+                this.captureSelection(state, editorEl);
+            });
+            opt.addEventListener('click', (evt) => {
+                evt.preventDefault();
+                this.keepEditorSelection(state, editorEl);
+                this.applyPreset(state, preset, input);
+            });
+            menu.appendChild(opt);
+        }
+        wrap.appendChild(menu);
+        state.menuEl = menu;
+        input.setAttribute('aria-expanded', 'true');
+        state.onDocPointer = (evt) => {
+            if (wrap.contains(evt.target)) {
+                return;
+            }
+            this.closeMenu(state);
+        };
+        document.addEventListener('pointerdown', state.onDocPointer, true);
+        state.onMenuKey = (evt) => {
+            if (evt.key !== 'Escape') {
+                return;
+            }
+            this.closeMenu(state);
+            this.keepEditorSelection(state, editorEl);
+        };
+        document.addEventListener('keydown', state.onMenuKey, true);
+        this.keepEditorSelection(state, editorEl);
+    },
+
+    toggleMenu(state, wrap, input, editorEl) {
+        if (state.menuEl) {
+            this.closeMenu(state);
+            this.keepEditorSelection(state, editorEl);
+            return;
+        }
+        this.openMenu(state, wrap, input, editorEl);
     },
 
     injectPicker(state, toolbar, editor) {
@@ -891,29 +1005,30 @@ const plugin = {
         }
         const wrap = document.createElement('span');
         wrap.setAttribute(WRAP_MARKER, '1');
-        wrap.style.cssText = 'display:inline-flex;align-items:center;margin-left:4px;';
+        wrap.style.cssText = 'display:inline-flex;align-items:center;margin-left:4px;position:relative;';
 
         const input = document.createElement('input');
         input.type = 'text';
-        input.setAttribute('list', DATALIST_ID);
         input.placeholder = 'Theme';
         input.title = 'Theme';
         input.setAttribute('aria-label', 'Theme');
+        input.setAttribute('role', 'combobox');
+        input.setAttribute('aria-expanded', 'false');
+        input.setAttribute('aria-haspopup', 'listbox');
         input.autocomplete = 'off';
         input.className =
             'h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground';
         input.style.width = '7.5rem';
 
-        const list = document.createElement('datalist');
-        list.id = DATALIST_ID;
-        for (const preset of PRESETS) {
-            const opt = document.createElement('option');
-            opt.value = preset.name;
-            list.appendChild(opt);
-        }
-
         const saveSel = () => this.captureSelection(state, editor);
-        input.addEventListener('pointerdown', saveSel, true);
+        input.addEventListener('pointerdown', (evt) => {
+            if (evt.button !== 0) {
+                return;
+            }
+            saveSel();
+            evt.preventDefault();
+            this.toggleMenu(state, wrap, input, editor);
+        }, true);
         input.addEventListener('focus', saveSel);
 
         const tryApply = () => {
@@ -925,6 +1040,12 @@ const plugin = {
         };
         input.addEventListener('change', tryApply);
         input.addEventListener('keydown', (evt) => {
+            if (evt.key === 'ArrowDown' && !state.menuEl) {
+                evt.preventDefault();
+                saveSel();
+                this.openMenu(state, wrap, input, editor);
+                return;
+            }
             if (evt.key !== 'Enter') {
                 return;
             }
@@ -938,7 +1059,7 @@ const plugin = {
             this.applyPreset(state, preset, input);
         });
 
-        wrap.append(input, list);
+        wrap.appendChild(input);
         this.bindCaret(state, editor, input);
         const exportBtn = toolbar.querySelector(`[${EXPORT_MARKER}="1"]`);
         if (exportBtn) {
@@ -964,6 +1085,7 @@ const plugin = {
                 Logger.debug('theme presets removed (editor closed)');
                 state.activationLogged = false;
             }
+            this.closeMenu(state);
             this.unbindCaret(state);
             return;
         }
@@ -980,6 +1102,7 @@ const plugin = {
     },
 
     destroy(state) {
+        this.closeMenu(state);
         this.unbindCaret(state);
         const wrap = document.querySelector(`[${WRAP_MARKER}="1"]`);
         if (wrap) {

--- a/plugins/archetypes/guidelines/main/theme-presets.js
+++ b/plugins/archetypes/guidelines/main/theme-presets.js
@@ -1,0 +1,669 @@
+// ============= theme-presets.js =============
+// Archetype: guidelines (work/guidelines).
+// Preset text themes on the TipTap edit toolbar (after Redo, before export).
+
+const EDITOR_SEL = '[data-guidelines-editor="true"]';
+const WRAP_MARKER = 'data-fleet-guidelines-themes';
+const DATALIST_ID = 'fleet-guidelines-theme-list';
+const EXPORT_MARKER = 'data-fleet-guidelines-export';
+
+const PRESETS = [
+    { name: 'Title', heading: 1, color: 'rgb(219, 39, 119)', underline: true },
+    { name: 'Section', heading: 2, color: 'rgb(107, 114, 128)' },
+    { name: 'Subsection', heading: 3, color: 'rgb(56, 125, 201)', bold: true },
+    { name: 'FAQ', toggle: true, color: 'rgb(159, 118, 90)' },
+    { name: 'Step', color: 'rgb(56, 125, 201)', bold: true },
+    { name: 'Allowed', color: 'rgb(80, 148, 110)' },
+    { name: 'Forbidden', color: 'rgb(207, 81, 72)' },
+    { name: 'Term', color: 'rgb(203, 148, 52)', bold: true },
+    { name: 'Qualifier', color: 'rgb(203, 148, 52)', italic: true },
+    { name: 'Caution', color: 'rgb(217, 119, 6)' },
+    { name: 'Link', color: 'rgb(13, 148, 136)' },
+    { name: 'Ban', highlight: '#fbcfe8' },
+    { name: 'Must', highlight: '#fef08a' },
+    { name: 'Ok', highlight: '#bbf7d0' }
+];
+
+const THEME_MARKS = ['textStyle', 'underline', 'bold', 'italic', 'highlight'];
+
+const plugin = {
+    id: 'guidelinesThemePresets',
+    name: 'Guideline Theme Presets',
+    description: 'Apply named text themes from the edit toolbar',
+    _version: '1.0',
+    enabledByDefault: true,
+    phase: 'mutation',
+    initialState: {
+        activationLogged: false,
+        savedSel: null
+    },
+
+    findEditor() {
+        return document.querySelector(EDITOR_SEL);
+    },
+
+    findToolbar(editor) {
+        if (!editor) {
+            return null;
+        }
+        const shell = editor.closest('div.rounded-md.border') || editor.parentElement;
+        if (!shell) {
+            return null;
+        }
+        const candidates = shell.querySelectorAll('div');
+        for (const el of candidates) {
+            const cl = el.classList;
+            if (
+                cl.contains('sticky') &&
+                cl.contains('top-0') &&
+                cl.contains('z-10') &&
+                cl.contains('flex') &&
+                cl.contains('flex-wrap')
+            ) {
+                return el;
+            }
+        }
+        return null;
+    },
+
+    findPreset(name) {
+        const key = String(name || '').trim().toLowerCase();
+        if (!key) {
+            return null;
+        }
+        for (const preset of PRESETS) {
+            if (preset.name.toLowerCase() === key) {
+                return preset;
+            }
+        }
+        return null;
+    },
+
+    findPmView(editor) {
+        if (!editor) {
+            return null;
+        }
+        const fromDesc = (el) => {
+            if (!el || !el.pmViewDesc) {
+                return null;
+            }
+            let desc = el.pmViewDesc;
+            while (desc.parent) {
+                desc = desc.parent;
+            }
+            const view = desc.view || desc.editorView || null;
+            if (view && view.state && view.state.schema) {
+                return view;
+            }
+            return null;
+        };
+        let view = fromDesc(editor);
+        if (view) {
+            return view;
+        }
+        let node = editor.parentElement;
+        for (let i = 0; i < 6 && node; i++) {
+            view = fromDesc(node);
+            if (view) {
+                return view;
+            }
+            node = node.parentElement;
+        }
+        return this.findViewViaFiber(editor);
+    },
+
+    findViewViaFiber(el) {
+        if (!el) {
+            return null;
+        }
+        let fiberKey = null;
+        for (const key of Object.keys(el)) {
+            if (key.startsWith('__reactFiber$') || key.startsWith('__reactInternalInstance$')) {
+                fiberKey = key;
+                break;
+            }
+        }
+        if (!fiberKey) {
+            return null;
+        }
+        let fiber = el[fiberKey];
+        for (let i = 0; i < 50 && fiber; i++) {
+            const props = fiber.memoizedProps || fiber.pendingProps;
+            const fromProps = this.viewFromUnknown(props && props.editor) || this.viewFromUnknown(props);
+            if (fromProps) {
+                return fromProps;
+            }
+            let hook = fiber.memoizedState;
+            for (let j = 0; j < 30 && hook; j++) {
+                const fromHook = this.viewFromUnknown(hook.memoizedState);
+                if (fromHook) {
+                    return fromHook;
+                }
+                hook = hook.next;
+            }
+            fiber = fiber.return;
+        }
+        return null;
+    },
+
+    viewFromUnknown(obj) {
+        if (!obj || typeof obj !== 'object') {
+            return null;
+        }
+        if (obj.state && obj.state.schema && typeof obj.dispatch === 'function') {
+            return obj;
+        }
+        if (obj.view && obj.view.state && obj.view.state.schema) {
+            return obj.view;
+        }
+        if (obj.editor && obj.editor.view && obj.editor.view.state) {
+            return obj.editor.view;
+        }
+        return null;
+    },
+
+    captureSelection(state, editor) {
+        const view = this.findPmView(editor);
+        if (view && view.state && view.state.selection) {
+            const sel = view.state.selection;
+            state.savedSel = { from: sel.from, to: sel.to, empty: sel.empty, kind: 'pm' };
+            return;
+        }
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) {
+            state.savedSel = null;
+            return;
+        }
+        try {
+            state.savedSel = { kind: 'dom', range: sel.getRangeAt(0).cloneRange() };
+        } catch (err) {
+            state.savedSel = null;
+        }
+    },
+
+    restorePmSelection(view, saved) {
+        if (!view || !saved || saved.kind !== 'pm') {
+            return;
+        }
+        const max = view.state.doc.content.size;
+        const from = Math.max(0, Math.min(saved.from, max));
+        const to = Math.max(0, Math.min(saved.to, max));
+        try {
+            const Ctor = view.state.selection.constructor;
+            if (typeof Ctor.create !== 'function') {
+                view.focus();
+                return;
+            }
+            const next = Ctor.create(view.state.doc, from, to);
+            view.dispatch(view.state.tr.setSelection(next));
+        } catch (err) {
+            Logger.debug('could not restore selection');
+        }
+        view.focus();
+    },
+
+    blockRange(view) {
+        const sel = view.state.selection;
+        if (!sel.empty) {
+            return { from: sel.from, to: sel.to };
+        }
+        const $from = sel.$from;
+        const start = $from.start();
+        const end = $from.end();
+        if (start < end) {
+            return { from: start, to: end };
+        }
+        return { from: sel.from, to: sel.to, stored: true };
+    },
+
+    headingLevel(view) {
+        const $from = view.state.selection.$from;
+        for (let d = $from.depth; d > 0; d--) {
+            const node = $from.node(d);
+            if (node.type && node.type.name === 'heading') {
+                return node.attrs.level || 1;
+            }
+        }
+        return 0;
+    },
+
+    inDetails(view) {
+        const $from = view.state.selection.$from;
+        for (let d = $from.depth; d > 0; d--) {
+            const name = $from.node(d).type && $from.node(d).type.name;
+            if (name === 'details' || name === 'detailsSummary' || name === 'toggle') {
+                return true;
+            }
+        }
+        return false;
+    },
+
+    clickToolbar(toolbar, title) {
+        if (!toolbar) {
+            return false;
+        }
+        const buttons = toolbar.querySelectorAll('button[title]');
+        for (const btn of buttons) {
+            if (btn.getAttribute('title') === title) {
+                btn.click();
+                return true;
+            }
+        }
+        return false;
+    },
+
+    schemaMark(schema, name) {
+        return schema && schema.marks && schema.marks[name] ? schema.marks[name] : null;
+    },
+
+    clearThemeMarks(tr, from, to, schema) {
+        for (const name of THEME_MARKS) {
+            const mt = this.schemaMark(schema, name);
+            if (mt) {
+                tr = tr.removeMark(from, to, mt);
+            }
+        }
+        return tr;
+    },
+
+    addPresetMarks(tr, from, to, schema, preset, stored) {
+        const marks = [];
+        const textStyle = this.schemaMark(schema, 'textStyle');
+        const underline = this.schemaMark(schema, 'underline');
+        const bold = this.schemaMark(schema, 'bold');
+        const italic = this.schemaMark(schema, 'italic');
+        const highlight = this.schemaMark(schema, 'highlight');
+        if (preset.color && textStyle) {
+            marks.push(textStyle.create({ color: preset.color }));
+        }
+        if (preset.underline && underline) {
+            marks.push(underline.create());
+        }
+        if (preset.bold && bold) {
+            marks.push(bold.create());
+        }
+        if (preset.italic && italic) {
+            marks.push(italic.create());
+        }
+        if (preset.highlight && highlight) {
+            marks.push(highlight.create({ color: preset.highlight }));
+        }
+        if (stored) {
+            return tr.setStoredMarks(marks);
+        }
+        for (const mark of marks) {
+            tr = tr.addMark(from, to, mark);
+        }
+        return tr;
+    },
+
+    applyViaPm(view, toolbar, preset) {
+        if (!view || !view.state || !view.dispatch) {
+            return false;
+        }
+        const schema = view.state.schema;
+        if (preset.heading) {
+            const current = this.headingLevel(view);
+            if (current !== preset.heading) {
+                const heading = schema.nodes && schema.nodes.heading;
+                if (heading) {
+                    const range = this.blockRange(view);
+                    try {
+                        view.dispatch(
+                            view.state.tr.setBlockType(range.from, range.to, heading, {
+                                level: preset.heading
+                            })
+                        );
+                    } catch (err) {
+                        this.clickToolbar(toolbar, 'Heading ' + preset.heading);
+                    }
+                } else {
+                    this.clickToolbar(toolbar, 'Heading ' + preset.heading);
+                }
+            }
+        }
+        if (preset.toggle && !this.inDetails(view)) {
+            this.clickToolbar(toolbar, 'Toggle Block');
+        }
+        const range = this.blockRange(view);
+        let tr = view.state.tr;
+        if (!range.stored) {
+            tr = this.clearThemeMarks(tr, range.from, range.to, schema);
+        }
+        tr = this.addPresetMarks(tr, range.from, range.to, schema, preset, !!range.stored);
+        view.dispatch(tr);
+        view.focus();
+        return true;
+    },
+
+    closestBlock(node, editor) {
+        let el = node;
+        if (el && el.nodeType !== Node.ELEMENT_NODE) {
+            el = el.parentElement;
+        }
+        if (!el) {
+            return null;
+        }
+        const found = el.closest('h1, h2, h3, h4, h5, h6, p, summary, li');
+        if (found && editor.contains(found)) {
+            return found;
+        }
+        return editor.contains(el) ? el : null;
+    },
+
+    targetRange(editor, saved) {
+        if (saved && saved.kind === 'dom' && saved.range) {
+            const range = saved.range;
+            if (range.collapsed) {
+                const block = this.closestBlock(range.startContainer, editor);
+                if (block) {
+                    const next = document.createRange();
+                    next.selectNodeContents(block);
+                    return { range: next, block };
+                }
+            }
+            return { range, block: this.closestBlock(range.commonAncestorContainer, editor) };
+        }
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) {
+            return null;
+        }
+        const range = sel.getRangeAt(0);
+        if (!editor.contains(range.commonAncestorContainer) && range.commonAncestorContainer !== editor) {
+            return null;
+        }
+        if (range.collapsed) {
+            const block = this.closestBlock(range.startContainer, editor);
+            if (!block) {
+                return null;
+            }
+            const next = document.createRange();
+            next.selectNodeContents(block);
+            return { range: next, block };
+        }
+        return { range, block: this.closestBlock(range.commonAncestorContainer, editor) };
+    },
+
+    refreshBlock(editor, fallback) {
+        const sel = window.getSelection();
+        if (sel && sel.rangeCount > 0) {
+            const block = this.closestBlock(sel.getRangeAt(0).startContainer, editor);
+            if (block) {
+                return block;
+            }
+        }
+        if (fallback && fallback.parentNode) {
+            return fallback;
+        }
+        return fallback;
+    },
+
+    replaceTag(el, tagName) {
+        if (!el || el.tagName.toLowerCase() === tagName) {
+            return el;
+        }
+        const next = document.createElement(tagName);
+        while (el.firstChild) {
+            next.appendChild(el.firstChild);
+        }
+        if (el.parentNode) {
+            el.parentNode.replaceChild(next, el);
+        }
+        return next;
+    },
+
+    wrapRange(range, tagName, attrs) {
+        const el = document.createElement(tagName);
+        if (attrs) {
+            for (const key of Object.keys(attrs)) {
+                el.setAttribute(key, attrs[key]);
+            }
+        }
+        try {
+            range.surroundContents(el);
+        } catch (err) {
+            const frag = range.extractContents();
+            el.appendChild(frag);
+            range.insertNode(el);
+        }
+        return el;
+    },
+
+    applyViaDom(editor, toolbar, preset, saved) {
+        const target = this.targetRange(editor, saved);
+        if (!target) {
+            return false;
+        }
+        let block = target.block;
+        let range = target.range;
+        if (preset.heading && block) {
+            const want = 'H' + preset.heading;
+            if (block.tagName !== want) {
+                this.clickToolbar(toolbar, 'Heading ' + preset.heading);
+                block = this.refreshBlock(editor, block);
+                if (block && block.parentNode && block.tagName !== want) {
+                    block = this.replaceTag(block, 'h' + preset.heading);
+                }
+                if (block) {
+                    range = document.createRange();
+                    range.selectNodeContents(block);
+                }
+            }
+        }
+        if (preset.toggle && block && block.tagName !== 'SUMMARY' && !block.closest('details')) {
+            this.clickToolbar(toolbar, 'Toggle Block');
+            const after = this.refreshBlock(editor, block);
+            if (after && (after.tagName === 'SUMMARY' || after.closest('details'))) {
+                block = after.tagName === 'SUMMARY' ? after : after.closest('details').querySelector('summary') || after;
+                range = document.createRange();
+                range.selectNodeContents(block);
+            } else {
+                const details = document.createElement('details');
+                const summary = document.createElement('summary');
+                while (block.firstChild) {
+                    summary.appendChild(block.firstChild);
+                }
+                details.appendChild(summary);
+                const content = document.createElement('div');
+                content.setAttribute('data-details-content', '');
+                const p = document.createElement('p');
+                p.appendChild(document.createElement('br'));
+                content.appendChild(p);
+                details.appendChild(content);
+                if (block.parentNode) {
+                    block.parentNode.replaceChild(details, block);
+                }
+                block = summary;
+                range = document.createRange();
+                range.selectNodeContents(summary);
+            }
+        }
+        if (preset.highlight) {
+            this.wrapRange(range, 'mark', {
+                'data-color': preset.highlight,
+                style: 'background-color: ' + preset.highlight + '; color: inherit;'
+            });
+            return true;
+        }
+        let inner = range;
+        if (preset.underline) {
+            this.wrapRange(inner, 'u', null);
+            inner = document.createRange();
+            if (block) {
+                inner.selectNodeContents(block);
+            }
+        }
+        if (preset.bold) {
+            this.wrapRange(inner, 'strong', null);
+            inner = document.createRange();
+            if (block) {
+                inner.selectNodeContents(block);
+            }
+        }
+        if (preset.italic) {
+            this.wrapRange(inner, 'em', null);
+            inner = document.createRange();
+            if (block) {
+                inner.selectNodeContents(block);
+            }
+        }
+        if (preset.color) {
+            this.wrapRange(inner, 'span', { style: 'color: ' + preset.color });
+        }
+        return true;
+    },
+
+    flash(el, ok) {
+        const fb = Context.buttonFeedback;
+        if (!el || !fb) {
+            return;
+        }
+        if (ok && typeof fb.flashSuccess === 'function') {
+            fb.flashSuccess(el);
+        } else if (!ok && typeof fb.flashFailure === 'function') {
+            fb.flashFailure(el);
+        }
+    },
+
+    applyPreset(state, preset, input) {
+        const editor = this.findEditor();
+        const toolbar = this.findToolbar(editor);
+        if (!editor || !preset) {
+            this.flash(input, false);
+            Logger.warn('theme apply failed — editor not found');
+            return;
+        }
+        const view = this.findPmView(editor);
+        if (view && state.savedSel && state.savedSel.kind === 'pm') {
+            this.restorePmSelection(view, state.savedSel);
+        } else if (state.savedSel && state.savedSel.kind === 'dom' && state.savedSel.range) {
+            const sel = window.getSelection();
+            if (sel) {
+                sel.removeAllRanges();
+                sel.addRange(state.savedSel.range);
+            }
+            editor.focus();
+        } else {
+            editor.focus();
+        }
+        let ok = false;
+        try {
+            if (view) {
+                ok = this.applyViaPm(view, toolbar, preset);
+            }
+            if (!ok) {
+                ok = this.applyViaDom(editor, toolbar, preset, state.savedSel);
+            }
+        } catch (err) {
+            this.flash(input, false);
+            Logger.error('theme apply threw', err);
+            return;
+        }
+        if (!ok) {
+            this.flash(input, false);
+            Logger.warn('theme apply failed — no selection target');
+            return;
+        }
+        this.flash(input, true);
+        Logger.log('applied ' + preset.name);
+        input.value = '';
+    },
+
+    injectPicker(state, toolbar, editor) {
+        if (!toolbar || toolbar.querySelector(`[${WRAP_MARKER}="1"]`)) {
+            return false;
+        }
+        const wrap = document.createElement('span');
+        wrap.setAttribute(WRAP_MARKER, '1');
+        wrap.style.cssText = 'display:inline-flex;align-items:center;margin-left:4px;';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.setAttribute('list', DATALIST_ID);
+        input.placeholder = 'Theme';
+        input.title = 'Theme';
+        input.setAttribute('aria-label', 'Theme');
+        input.autocomplete = 'off';
+        input.className =
+            'h-8 rounded-md border border-input bg-background px-2 text-xs text-foreground';
+        input.style.width = '7.5rem';
+
+        const list = document.createElement('datalist');
+        list.id = DATALIST_ID;
+        for (const preset of PRESETS) {
+            const opt = document.createElement('option');
+            opt.value = preset.name;
+            list.appendChild(opt);
+        }
+
+        const saveSel = () => this.captureSelection(state, editor);
+        input.addEventListener('pointerdown', saveSel, true);
+        input.addEventListener('focus', saveSel);
+
+        const tryApply = () => {
+            const preset = this.findPreset(input.value);
+            if (!preset) {
+                return;
+            }
+            this.applyPreset(state, preset, input);
+        };
+        input.addEventListener('change', tryApply);
+        input.addEventListener('keydown', (evt) => {
+            if (evt.key !== 'Enter') {
+                return;
+            }
+            evt.preventDefault();
+            const preset = this.findPreset(input.value);
+            if (!preset) {
+                this.flash(input, false);
+                Logger.warn('unknown theme');
+                return;
+            }
+            this.applyPreset(state, preset, input);
+        });
+
+        wrap.append(input, list);
+        const exportBtn = toolbar.querySelector(`[${EXPORT_MARKER}="1"]`);
+        if (exportBtn) {
+            toolbar.insertBefore(wrap, exportBtn);
+        } else {
+            const redo = toolbar.querySelector('button[title="Redo"]');
+            if (redo && redo.nextSibling) {
+                toolbar.insertBefore(wrap, redo.nextSibling);
+            } else if (redo) {
+                redo.after(wrap);
+            } else {
+                toolbar.appendChild(wrap);
+            }
+        }
+        return true;
+    },
+
+    onMutation(state) {
+        const editor = this.findEditor();
+        const toolbar = this.findToolbar(editor);
+        if (!editor || !toolbar) {
+            if (state.activationLogged) {
+                Logger.debug('theme presets removed (editor closed)');
+                state.activationLogged = false;
+            }
+            return;
+        }
+        const injected = this.injectPicker(state, toolbar, editor);
+        if ((injected || toolbar.querySelector(`[${WRAP_MARKER}="1"]`)) && !state.activationLogged) {
+            Logger.log('theme presets added');
+            state.activationLogged = true;
+        }
+    },
+
+    destroy(state) {
+        const wrap = document.querySelector(`[${WRAP_MARKER}="1"]`);
+        if (wrap) {
+            wrap.remove();
+        }
+        if (state) {
+            state.activationLogged = false;
+            state.savedSel = null;
+        }
+    }
+};

--- a/plugins/archetypes/guidelines/main/theme-presets.js
+++ b/plugins/archetypes/guidelines/main/theme-presets.js
@@ -8,29 +8,29 @@ const DATALIST_ID = 'fleet-guidelines-theme-list';
 const EXPORT_MARKER = 'data-fleet-guidelines-export';
 
 const PRESETS = [
-    { name: 'Title', heading: 1, color: 'rgb(219, 39, 119)', underline: true },
-    { name: 'Section', heading: 2, color: 'rgb(107, 114, 128)' },
-    { name: 'Subsection', heading: 3, color: 'rgb(56, 125, 201)', bold: true },
-    { name: 'FAQ', toggle: true, color: 'rgb(159, 118, 90)' },
-    { name: 'Step', color: 'rgb(56, 125, 201)', bold: true },
-    { name: 'Allowed', color: 'rgb(80, 148, 110)' },
-    { name: 'Forbidden', color: 'rgb(207, 81, 72)' },
-    { name: 'Term', color: 'rgb(203, 148, 52)', bold: true },
-    { name: 'Qualifier', color: 'rgb(203, 148, 52)', italic: true },
-    { name: 'Caution', color: 'rgb(217, 119, 6)' },
-    { name: 'Link', color: 'rgb(13, 148, 136)' },
+    { name: 'Title', heading: 1, color: '#db2777', underline: true },
+    { name: 'Section', heading: 2, color: '#6b7280' },
+    { name: 'Subsection', heading: 3, color: '#387dc9', bold: true },
+    { name: 'FAQ', toggle: true, color: '#9f765a' },
+    { name: 'Step', color: '#387dc9', bold: true },
+    { name: 'Allowed', color: '#50946e' },
+    { name: 'Forbidden', color: '#cf5148' },
+    { name: 'Term', color: '#cb9434', bold: true },
+    { name: 'Qualifier', color: '#cb9434', italic: true },
+    { name: 'Caution', color: '#d97706' },
+    { name: 'Link', color: '#0d9488' },
     { name: 'Ban', highlight: '#fbcfe8' },
     { name: 'Must', highlight: '#fef08a' },
     { name: 'Ok', highlight: '#bbf7d0' }
 ];
 
-const THEME_MARKS = ['textStyle', 'underline', 'bold', 'italic', 'highlight'];
+const THEME_MARKS = ['textStyle', 'color', 'underline', 'bold', 'italic', 'highlight'];
 
 const plugin = {
     id: 'guidelinesThemePresets',
     name: 'Guideline Theme Presets',
     description: 'Apply named text themes from the edit toolbar',
-    _version: '1.0',
+    _version: '1.1',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -79,40 +79,59 @@ const plugin = {
         return null;
     },
 
-    findPmView(editor) {
-        if (!editor) {
-            return null;
-        }
-        const fromDesc = (el) => {
-            if (!el || !el.pmViewDesc) {
-                return null;
-            }
-            let desc = el.pmViewDesc;
-            while (desc.parent) {
-                desc = desc.parent;
-            }
-            const view = desc.view || desc.editorView || null;
-            if (view && view.state && view.state.schema) {
-                return view;
-            }
-            return null;
-        };
-        let view = fromDesc(editor);
-        if (view) {
-            return view;
-        }
-        let node = editor.parentElement;
-        for (let i = 0; i < 6 && node; i++) {
-            view = fromDesc(node);
-            if (view) {
-                return view;
-            }
-            node = node.parentElement;
-        }
-        return this.findViewViaFiber(editor);
+    isTiptapEditor(obj) {
+        return !!(
+            obj &&
+            typeof obj === 'object' &&
+            typeof obj.chain === 'function' &&
+            obj.view &&
+            obj.view.state &&
+            obj.view.state.schema
+        );
     },
 
-    findViewViaFiber(el) {
+    isPmView(obj) {
+        return !!(obj && obj.state && obj.state.schema && typeof obj.dispatch === 'function');
+    },
+
+    viewFromUnknown(obj) {
+        if (!obj || typeof obj !== 'object') {
+            return null;
+        }
+        if (this.isTiptapEditor(obj)) {
+            return { editor: obj, view: obj.view };
+        }
+        if (this.isTiptapEditor(obj.editor)) {
+            return { editor: obj.editor, view: obj.editor.view };
+        }
+        if (this.isPmView(obj)) {
+            const editor = this.isTiptapEditor(obj.editor) ? obj.editor : null;
+            return { editor, view: obj };
+        }
+        if (this.isPmView(obj.view)) {
+            const editor = this.isTiptapEditor(obj.view.editor) ? obj.view.editor : null;
+            return { editor, view: obj.view };
+        }
+        return null;
+    },
+
+    fromDesc(el) {
+        if (!el || !el.pmViewDesc) {
+            return null;
+        }
+        let desc = el.pmViewDesc;
+        while (desc.parent) {
+            desc = desc.parent;
+        }
+        const view = desc.view || desc.editorView || null;
+        if (!this.isPmView(view)) {
+            return null;
+        }
+        const editor = this.isTiptapEditor(view.editor) ? view.editor : null;
+        return { editor, view };
+    },
+
+    fiberSearch(el) {
         if (!el) {
             return null;
         }
@@ -127,14 +146,15 @@ const plugin = {
             return null;
         }
         let fiber = el[fiberKey];
-        for (let i = 0; i < 50 && fiber; i++) {
+        for (let i = 0; i < 60 && fiber; i++) {
             const props = fiber.memoizedProps || fiber.pendingProps;
-            const fromProps = this.viewFromUnknown(props && props.editor) || this.viewFromUnknown(props);
+            const fromProps =
+                this.viewFromUnknown(props && props.editor) || this.viewFromUnknown(props);
             if (fromProps) {
                 return fromProps;
             }
             let hook = fiber.memoizedState;
-            for (let j = 0; j < 30 && hook; j++) {
+            for (let j = 0; j < 40 && hook; j++) {
                 const fromHook = this.viewFromUnknown(hook.memoizedState);
                 if (fromHook) {
                     return fromHook;
@@ -146,26 +166,35 @@ const plugin = {
         return null;
     },
 
-    viewFromUnknown(obj) {
-        if (!obj || typeof obj !== 'object') {
-            return null;
+    findEditorApi(dom) {
+        if (!dom) {
+            return { editor: null, view: null };
         }
-        if (obj.state && obj.state.schema && typeof obj.dispatch === 'function') {
-            return obj;
+        let found = this.fromDesc(dom);
+        if (found) {
+            if (!found.editor) {
+                const viaFiber = this.fiberSearch(dom);
+                if (viaFiber && viaFiber.editor) {
+                    found.editor = viaFiber.editor;
+                }
+            }
+            return found;
         }
-        if (obj.view && obj.view.state && obj.view.state.schema) {
-            return obj.view;
+        let node = dom;
+        for (let i = 0; i < 12 && node; i++) {
+            found = this.fromDesc(node) || this.fiberSearch(node);
+            if (found) {
+                return found;
+            }
+            node = node.parentElement;
         }
-        if (obj.editor && obj.editor.view && obj.editor.view.state) {
-            return obj.editor.view;
-        }
-        return null;
+        return { editor: null, view: null };
     },
 
-    captureSelection(state, editor) {
-        const view = this.findPmView(editor);
-        if (view && view.state && view.state.selection) {
-            const sel = view.state.selection;
+    captureSelection(state, editorEl) {
+        const api = this.findEditorApi(editorEl);
+        if (api.view && api.view.state && api.view.state.selection) {
+            const sel = api.view.state.selection;
             state.savedSel = { from: sel.from, to: sel.to, empty: sel.empty, kind: 'pm' };
             return;
         }
@@ -202,7 +231,7 @@ const plugin = {
         view.focus();
     },
 
-    blockRange(view) {
+    expandToBlock(view) {
         const sel = view.state.selection;
         if (!sel.empty) {
             return { from: sel.from, to: sel.to };
@@ -214,6 +243,17 @@ const plugin = {
             return { from: start, to: end };
         }
         return { from: sel.from, to: sel.to, stored: true };
+    },
+
+    pmBlockRange(view) {
+        const sel = view.state.selection;
+        if (typeof sel.$from.blockRange === 'function') {
+            const br = sel.$from.blockRange(sel.$to);
+            if (br) {
+                return br;
+            }
+        }
+        return null;
     },
 
     headingLevel(view) {
@@ -238,6 +278,27 @@ const plugin = {
         return false;
     },
 
+    selectSummaryContent(view) {
+        const $from = view.state.selection.$from;
+        for (let d = $from.depth; d > 0; d--) {
+            const name = $from.node(d).type && $from.node(d).type.name;
+            if (name === 'detailsSummary') {
+                const from = $from.start(d);
+                const to = $from.end(d);
+                try {
+                    const Ctor = view.state.selection.constructor;
+                    view.dispatch(
+                        view.state.tr.setSelection(Ctor.create(view.state.doc, from, to))
+                    );
+                } catch (err) {
+                    return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    },
+
     clickToolbar(toolbar, title) {
         if (!toolbar) {
             return false;
@@ -252,23 +313,149 @@ const plugin = {
         return false;
     },
 
+    hasCmd(editor, name) {
+        return !!(editor && editor.commands && typeof editor.commands[name] === 'function');
+    },
+
+    queueCmd(chain, editor, name, arg) {
+        if (!this.hasCmd(editor, name) || typeof chain[name] !== 'function') {
+            return chain;
+        }
+        if (arg === undefined) {
+            return chain[name]();
+        }
+        return chain[name](arg);
+    },
+
+    tiptapCanApply(editor, preset) {
+        if (!this.isTiptapEditor(editor)) {
+            return false;
+        }
+        if (preset.heading && !this.hasCmd(editor, 'setHeading')) {
+            return false;
+        }
+        if (preset.toggle && !this.hasCmd(editor, 'setDetails') && !this.inDetails(editor.view)) {
+            return false;
+        }
+        if (preset.color && !this.hasCmd(editor, 'setColor')) {
+            return false;
+        }
+        if (preset.underline && !this.hasCmd(editor, 'setUnderline')) {
+            return false;
+        }
+        if (preset.bold && !this.hasCmd(editor, 'setBold')) {
+            return false;
+        }
+        if (preset.italic && !this.hasCmd(editor, 'setItalic')) {
+            return false;
+        }
+        if (preset.highlight && !this.hasCmd(editor, 'setHighlight')) {
+            return false;
+        }
+        return true;
+    },
+
+    applyViaTiptap(editor, preset, saved) {
+        if (!this.tiptapCanApply(editor, preset)) {
+            return false;
+        }
+        if (saved && saved.kind === 'pm') {
+            this.restorePmSelection(editor.view, saved);
+        } else {
+            editor.view.focus();
+        }
+        const range = this.expandToBlock(editor.view);
+        let chain = editor.chain().focus();
+        if (!range.stored) {
+            chain = this.queueCmd(chain, editor, 'setTextSelection', {
+                from: range.from,
+                to: range.to
+            });
+        }
+        if (preset.heading) {
+            chain = this.queueCmd(chain, editor, 'setHeading', { level: preset.heading });
+        }
+        if (preset.toggle && !this.inDetails(editor.view)) {
+            chain = this.queueCmd(chain, editor, 'setDetails');
+        }
+        chain = this.queueCmd(chain, editor, 'unsetHighlight');
+        chain = this.queueCmd(chain, editor, 'unsetColor');
+        chain = this.queueCmd(chain, editor, 'unsetUnderline');
+        chain = this.queueCmd(chain, editor, 'unsetBold');
+        chain = this.queueCmd(chain, editor, 'unsetItalic');
+        if (preset.color) {
+            chain = this.queueCmd(chain, editor, 'setColor', preset.color);
+        }
+        if (preset.underline) {
+            chain = this.queueCmd(chain, editor, 'setUnderline');
+        }
+        if (preset.bold) {
+            chain = this.queueCmd(chain, editor, 'setBold');
+        }
+        if (preset.italic) {
+            chain = this.queueCmd(chain, editor, 'setItalic');
+        }
+        if (preset.highlight) {
+            chain = this.queueCmd(chain, editor, 'setHighlight', { color: preset.highlight });
+        }
+        const ok = chain.run();
+        if (!ok) {
+            return false;
+        }
+        if (preset.toggle) {
+            this.selectSummaryContent(editor.view);
+            if (preset.color && this.hasCmd(editor, 'setColor')) {
+                editor.chain().focus().setColor(preset.color).run();
+            }
+        }
+        return true;
+    },
+
     schemaMark(schema, name) {
         return schema && schema.marks && schema.marks[name] ? schema.marks[name] : null;
     },
 
-    clearThemeMarks(tr, from, to, schema) {
-        for (const name of THEME_MARKS) {
-            const mt = this.schemaMark(schema, name);
-            if (mt) {
-                tr = tr.removeMark(from, to, mt);
-            }
-        }
-        return tr;
+    colorMarkType(schema) {
+        return this.schemaMark(schema, 'textStyle') || this.schemaMark(schema, 'color');
     },
 
-    addPresetMarks(tr, from, to, schema, preset, stored) {
+    pmCanApply(view, preset) {
+        if (!this.isPmView(view)) {
+            return false;
+        }
+        const schema = view.state.schema;
+        if (preset.heading && !(schema.nodes && schema.nodes.heading)) {
+            return false;
+        }
+        if (preset.color && !this.colorMarkType(schema)) {
+            return false;
+        }
+        if (preset.underline && !this.schemaMark(schema, 'underline')) {
+            return false;
+        }
+        if (preset.bold && !this.schemaMark(schema, 'bold')) {
+            return false;
+        }
+        if (preset.italic && !this.schemaMark(schema, 'italic')) {
+            return false;
+        }
+        if (preset.highlight && !this.schemaMark(schema, 'highlight')) {
+            return false;
+        }
+        return true;
+    },
+
+    applyMarksPm(tr, from, to, schema, preset, stored) {
+        if (!stored) {
+            for (const name of THEME_MARKS) {
+                const mt = this.schemaMark(schema, name);
+                if (mt) {
+                    tr = tr.removeMark(from, to, mt);
+                }
+            }
+        }
         const marks = [];
-        const textStyle = this.schemaMark(schema, 'textStyle');
+        const textStyle = this.colorMarkType(schema);
         const underline = this.schemaMark(schema, 'underline');
         const bold = this.schemaMark(schema, 'bold');
         const italic = this.schemaMark(schema, 'italic');
@@ -297,220 +484,104 @@ const plugin = {
         return tr;
     },
 
-    applyViaPm(view, toolbar, preset) {
-        if (!view || !view.state || !view.dispatch) {
+    applyViaPm(view, preset) {
+        if (!this.pmCanApply(view, preset)) {
             return false;
         }
+        if (preset.toggle) {
+            if (!this.inDetails(view)) {
+                return false;
+            }
+            this.selectSummaryContent(view);
+        }
         const schema = view.state.schema;
-        if (preset.heading) {
+        let tr = view.state.tr;
+        if (preset.heading && schema.nodes && schema.nodes.heading) {
             const current = this.headingLevel(view);
             if (current !== preset.heading) {
-                const heading = schema.nodes && schema.nodes.heading;
-                if (heading) {
-                    const range = this.blockRange(view);
-                    try {
-                        view.dispatch(
-                            view.state.tr.setBlockType(range.from, range.to, heading, {
-                                level: preset.heading
-                            })
-                        );
-                    } catch (err) {
-                        this.clickToolbar(toolbar, 'Heading ' + preset.heading);
-                    }
-                } else {
-                    this.clickToolbar(toolbar, 'Heading ' + preset.heading);
+                const br = this.pmBlockRange(view);
+                if (!br) {
+                    return false;
+                }
+                try {
+                    tr = tr.setBlockType(br.start, br.end, schema.nodes.heading, {
+                        level: preset.heading
+                    });
+                } catch (err) {
+                    Logger.debug('setBlockType failed');
+                    return false;
                 }
             }
         }
-        if (preset.toggle && !this.inDetails(view)) {
-            this.clickToolbar(toolbar, 'Toggle Block');
-        }
-        const range = this.blockRange(view);
-        let tr = view.state.tr;
-        if (!range.stored) {
-            tr = this.clearThemeMarks(tr, range.from, range.to, schema);
-        }
-        tr = this.addPresetMarks(tr, range.from, range.to, schema, preset, !!range.stored);
+        const sel = tr.selection;
+        const $from = sel.$from;
+        const from = sel.empty ? $from.start() : sel.from;
+        const to = sel.empty ? $from.end() : sel.to;
+        const stored = from >= to;
+        tr = this.applyMarksPm(tr, from, to, schema, preset, stored);
         view.dispatch(tr);
         view.focus();
         return true;
     },
 
-    closestBlock(node, editor) {
-        let el = node;
-        if (el && el.nodeType !== Node.ELEMENT_NODE) {
-            el = el.parentElement;
+    applyMarksOnly(api, preset) {
+        if (preset.toggle && api.view) {
+            this.selectSummaryContent(api.view);
         }
-        if (!el) {
-            return null;
+        const markPreset = Object.assign({}, preset);
+        delete markPreset.heading;
+        delete markPreset.toggle;
+        if (api.editor && this.tiptapCanApply(api.editor, markPreset)) {
+            return this.applyViaTiptap(api.editor, markPreset, null);
         }
-        const found = el.closest('h1, h2, h3, h4, h5, h6, p, summary, li');
-        if (found && editor.contains(found)) {
-            return found;
+        if (api.view && this.pmCanApply(api.view, markPreset)) {
+            return this.applyViaPm(api.view, markPreset);
         }
-        return editor.contains(el) ? el : null;
+        return false;
     },
 
-    targetRange(editor, saved) {
-        if (saved && saved.kind === 'dom' && saved.range) {
-            const range = saved.range;
-            if (range.collapsed) {
-                const block = this.closestBlock(range.startContainer, editor);
-                if (block) {
-                    const next = document.createRange();
-                    next.selectNodeContents(block);
-                    return { range: next, block };
+    applyAfterClick(editorEl, toolbar, preset, input) {
+        const api0 = this.findEditorApi(editorEl);
+        let clicked = false;
+        if (preset.heading) {
+            const already = api0.view && this.headingLevel(api0.view) === preset.heading;
+            if (!already) {
+                if (!this.clickToolbar(toolbar, 'Heading ' + preset.heading)) {
+                    this.flash(input, false);
+                    Logger.warn('theme apply failed — marks not set');
+                    return;
                 }
-            }
-            return { range, block: this.closestBlock(range.commonAncestorContainer, editor) };
-        }
-        const sel = window.getSelection();
-        if (!sel || sel.rangeCount === 0) {
-            return null;
-        }
-        const range = sel.getRangeAt(0);
-        if (!editor.contains(range.commonAncestorContainer) && range.commonAncestorContainer !== editor) {
-            return null;
-        }
-        if (range.collapsed) {
-            const block = this.closestBlock(range.startContainer, editor);
-            if (!block) {
-                return null;
-            }
-            const next = document.createRange();
-            next.selectNodeContents(block);
-            return { range: next, block };
-        }
-        return { range, block: this.closestBlock(range.commonAncestorContainer, editor) };
-    },
-
-    refreshBlock(editor, fallback) {
-        const sel = window.getSelection();
-        if (sel && sel.rangeCount > 0) {
-            const block = this.closestBlock(sel.getRangeAt(0).startContainer, editor);
-            if (block) {
-                return block;
+                clicked = true;
             }
         }
-        if (fallback && fallback.parentNode) {
-            return fallback;
-        }
-        return fallback;
-    },
-
-    replaceTag(el, tagName) {
-        if (!el || el.tagName.toLowerCase() === tagName) {
-            return el;
-        }
-        const next = document.createElement(tagName);
-        while (el.firstChild) {
-            next.appendChild(el.firstChild);
-        }
-        if (el.parentNode) {
-            el.parentNode.replaceChild(next, el);
-        }
-        return next;
-    },
-
-    wrapRange(range, tagName, attrs) {
-        const el = document.createElement(tagName);
-        if (attrs) {
-            for (const key of Object.keys(attrs)) {
-                el.setAttribute(key, attrs[key]);
-            }
-        }
-        try {
-            range.surroundContents(el);
-        } catch (err) {
-            const frag = range.extractContents();
-            el.appendChild(frag);
-            range.insertNode(el);
-        }
-        return el;
-    },
-
-    applyViaDom(editor, toolbar, preset, saved) {
-        const target = this.targetRange(editor, saved);
-        if (!target) {
-            return false;
-        }
-        let block = target.block;
-        let range = target.range;
-        if (preset.heading && block) {
-            const want = 'H' + preset.heading;
-            if (block.tagName !== want) {
-                this.clickToolbar(toolbar, 'Heading ' + preset.heading);
-                block = this.refreshBlock(editor, block);
-                if (block && block.parentNode && block.tagName !== want) {
-                    block = this.replaceTag(block, 'h' + preset.heading);
+        if (preset.toggle) {
+            const already = api0.view && this.inDetails(api0.view);
+            if (!already) {
+                if (!this.clickToolbar(toolbar, 'Toggle Block')) {
+                    this.flash(input, false);
+                    Logger.warn('theme apply failed — marks not set');
+                    return;
                 }
-                if (block) {
-                    range = document.createRange();
-                    range.selectNodeContents(block);
-                }
+                clicked = true;
             }
         }
-        if (preset.toggle && block && block.tagName !== 'SUMMARY' && !block.closest('details')) {
-            this.clickToolbar(toolbar, 'Toggle Block');
-            const after = this.refreshBlock(editor, block);
-            if (after && (after.tagName === 'SUMMARY' || after.closest('details'))) {
-                block = after.tagName === 'SUMMARY' ? after : after.closest('details').querySelector('summary') || after;
-                range = document.createRange();
-                range.selectNodeContents(block);
+        const finish = () => {
+            const api = this.findEditorApi(editorEl);
+            const marked = this.applyMarksOnly(api, preset);
+            if (marked) {
+                this.flash(input, true);
+                Logger.log('applied ' + preset.name);
+                input.value = '';
             } else {
-                const details = document.createElement('details');
-                const summary = document.createElement('summary');
-                while (block.firstChild) {
-                    summary.appendChild(block.firstChild);
-                }
-                details.appendChild(summary);
-                const content = document.createElement('div');
-                content.setAttribute('data-details-content', '');
-                const p = document.createElement('p');
-                p.appendChild(document.createElement('br'));
-                content.appendChild(p);
-                details.appendChild(content);
-                if (block.parentNode) {
-                    block.parentNode.replaceChild(details, block);
-                }
-                block = summary;
-                range = document.createRange();
-                range.selectNodeContents(summary);
+                this.flash(input, false);
+                Logger.warn('theme apply failed — marks not set');
             }
+        };
+        if (clicked) {
+            window.requestAnimationFrame(finish);
+        } else {
+            finish();
         }
-        if (preset.highlight) {
-            this.wrapRange(range, 'mark', {
-                'data-color': preset.highlight,
-                style: 'background-color: ' + preset.highlight + '; color: inherit;'
-            });
-            return true;
-        }
-        let inner = range;
-        if (preset.underline) {
-            this.wrapRange(inner, 'u', null);
-            inner = document.createRange();
-            if (block) {
-                inner.selectNodeContents(block);
-            }
-        }
-        if (preset.bold) {
-            this.wrapRange(inner, 'strong', null);
-            inner = document.createRange();
-            if (block) {
-                inner.selectNodeContents(block);
-            }
-        }
-        if (preset.italic) {
-            this.wrapRange(inner, 'em', null);
-            inner = document.createRange();
-            if (block) {
-                inner.selectNodeContents(block);
-            }
-        }
-        if (preset.color) {
-            this.wrapRange(inner, 'span', { style: 'color: ' + preset.color });
-        }
-        return true;
     },
 
     flash(el, ok) {
@@ -526,14 +597,16 @@ const plugin = {
     },
 
     applyPreset(state, preset, input) {
-        const editor = this.findEditor();
-        const toolbar = this.findToolbar(editor);
-        if (!editor || !preset) {
+        const editorEl = this.findEditor();
+        const toolbar = this.findToolbar(editorEl);
+        if (!editorEl || !preset) {
             this.flash(input, false);
             Logger.warn('theme apply failed — editor not found');
             return;
         }
-        const view = this.findPmView(editor);
+        const api = this.findEditorApi(editorEl);
+        const view = api.view;
+        const tiptap = api.editor;
         if (view && state.savedSel && state.savedSel.kind === 'pm') {
             this.restorePmSelection(view, state.savedSel);
         } else if (state.savedSel && state.savedSel.kind === 'dom' && state.savedSel.range) {
@@ -542,17 +615,22 @@ const plugin = {
                 sel.removeAllRanges();
                 sel.addRange(state.savedSel.range);
             }
-            editor.focus();
+            editorEl.focus();
         } else {
-            editor.focus();
+            editorEl.focus();
         }
+
         let ok = false;
         try {
-            if (view) {
-                ok = this.applyViaPm(view, toolbar, preset);
+            if (tiptap) {
+                ok = this.applyViaTiptap(tiptap, preset, state.savedSel);
             }
-            if (!ok) {
-                ok = this.applyViaDom(editor, toolbar, preset, state.savedSel);
+            if (!ok && view) {
+                ok = this.applyViaPm(view, preset);
+            }
+            if (!ok && toolbar && (preset.heading || preset.toggle)) {
+                this.applyAfterClick(editorEl, toolbar, preset, input);
+                return;
             }
         } catch (err) {
             this.flash(input, false);
@@ -561,7 +639,7 @@ const plugin = {
         }
         if (!ok) {
             this.flash(input, false);
-            Logger.warn('theme apply failed — no selection target');
+            Logger.warn('theme apply failed — no editor view');
             return;
         }
         this.flash(input, true);

--- a/plugins/archetypes/guidelines/main/theme-presets.js
+++ b/plugins/archetypes/guidelines/main/theme-presets.js
@@ -30,12 +30,15 @@ const plugin = {
     id: 'guidelinesThemePresets',
     name: 'Guideline Theme Presets',
     description: 'Apply named text themes from the edit toolbar',
-    _version: '1.1',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
         activationLogged: false,
-        savedSel: null
+        savedSel: null,
+        onSel: null,
+        boundEditor: null,
+        tiptap: null
     },
 
     findEditor() {
@@ -77,6 +80,241 @@ const plugin = {
             }
         }
         return null;
+    },
+
+    rgbToHex(r, g, b) {
+        const to = (n) => {
+            const v = Math.max(0, Math.min(255, Number(n) || 0));
+            return v.toString(16).padStart(2, '0');
+        };
+        return '#' + to(r) + to(g) + to(b);
+    },
+
+    normalizeColor(value) {
+        if (!value) {
+            return '';
+        }
+        const s = String(value).trim().toLowerCase();
+        const rgb = s.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+        if (rgb) {
+            return this.rgbToHex(rgb[1], rgb[2], rgb[3]);
+        }
+        if (s.charAt(0) === '#') {
+            if (s.length === 4) {
+                return '#' + s[1] + s[1] + s[2] + s[2] + s[3] + s[3];
+            }
+            if (s.length >= 7) {
+                return s.slice(0, 7);
+            }
+        }
+        return '';
+    },
+
+    colorsEqual(a, b) {
+        const left = this.normalizeColor(a);
+        const right = this.normalizeColor(b);
+        return !!(left && right && left === right);
+    },
+
+    markByName(marks, name) {
+        if (!marks || !marks.length) {
+            return null;
+        }
+        for (const mark of marks) {
+            if (mark && mark.type && mark.type.name === name) {
+                return mark;
+            }
+        }
+        return null;
+    },
+
+    snapshotFromView(view) {
+        if (!this.isPmView(view)) {
+            return null;
+        }
+        const sel = view.state.selection;
+        const $from = sel.$from;
+        const marks = sel.empty
+            ? (view.state.storedMarks || $from.marks())
+            : $from.marks();
+        const textStyle = this.markByName(marks, 'textStyle') || this.markByName(marks, 'color');
+        const highlight = this.markByName(marks, 'highlight');
+        return {
+            heading: this.headingLevel(view),
+            toggle: this.inDetails(view),
+            color: textStyle && textStyle.attrs ? textStyle.attrs.color || '' : '',
+            highlight: highlight && highlight.attrs
+                ? highlight.attrs.color || highlight.attrs.backgroundColor || ''
+                : '',
+            underline: !!this.markByName(marks, 'underline'),
+            bold: !!this.markByName(marks, 'bold'),
+            italic: !!this.markByName(marks, 'italic')
+        };
+    },
+
+    snapshotFromDom(editorEl) {
+        const sel = window.getSelection();
+        if (!sel || !sel.anchorNode) {
+            return null;
+        }
+        let el = sel.anchorNode;
+        if (el.nodeType !== Node.ELEMENT_NODE) {
+            el = el.parentElement;
+        }
+        if (!el || !editorEl.contains(el)) {
+            return null;
+        }
+        const headingEl = el.closest('h1, h2, h3, h4, h5, h6');
+        const heading = headingEl ? parseInt(headingEl.tagName.charAt(1), 10) || 0 : 0;
+        const mark = el.closest('mark');
+        let color = '';
+        let node = el;
+        while (node && editorEl.contains(node)) {
+            if (node.style && node.style.color) {
+                color = node.style.color;
+                break;
+            }
+            node = node.parentElement;
+        }
+        return {
+            heading,
+            toggle: !!el.closest('details'),
+            color,
+            highlight: mark
+                ? mark.getAttribute('data-color') || (mark.style && mark.style.backgroundColor) || ''
+                : '',
+            underline: !!(el.closest('u') || /underline/.test(
+                (el.style && el.style.textDecoration) || ''
+            )),
+            bold: !!el.closest('strong, b'),
+            italic: !!el.closest('em, i')
+        };
+    },
+
+    snapshotAtCaret(editorEl) {
+        const api = this.findEditorApi(editorEl);
+        return this.snapshotFromView(api.view) || this.snapshotFromDom(editorEl);
+    },
+
+    scorePreset(preset, snap) {
+        if (!preset || !snap) {
+            return -1;
+        }
+        if (preset.heading && snap.heading !== preset.heading) {
+            return -1;
+        }
+        if (preset.toggle && !snap.toggle) {
+            return -1;
+        }
+        if (preset.color && !this.colorsEqual(snap.color, preset.color)) {
+            return -1;
+        }
+        if (preset.highlight && !this.colorsEqual(snap.highlight, preset.highlight)) {
+            return -1;
+        }
+        if (preset.underline && !snap.underline) {
+            return -1;
+        }
+        if (preset.bold && !snap.bold) {
+            return -1;
+        }
+        if (preset.italic && !snap.italic) {
+            return -1;
+        }
+        let score = 0;
+        if (preset.heading) {
+            score += 10;
+        }
+        if (preset.toggle) {
+            score += 10;
+        }
+        if (preset.highlight) {
+            score += 8;
+        }
+        if (preset.color) {
+            score += 4;
+        }
+        if (preset.underline) {
+            score += 2;
+        }
+        if (preset.bold) {
+            score += 2;
+        }
+        if (preset.italic) {
+            score += 2;
+        }
+        return score;
+    },
+
+    matchTheme(editorEl) {
+        const snap = this.snapshotAtCaret(editorEl);
+        if (!snap) {
+            return '';
+        }
+        let best = null;
+        let bestScore = 0;
+        for (const preset of PRESETS) {
+            const score = this.scorePreset(preset, snap);
+            if (score > bestScore) {
+                bestScore = score;
+                best = preset;
+            }
+        }
+        return best ? best.name : '';
+    },
+
+    syncThemeDisplay(editorEl, input) {
+        if (!editorEl || !input || input === document.activeElement) {
+            return;
+        }
+        const sel = window.getSelection();
+        if (sel && sel.anchorNode && !editorEl.contains(sel.anchorNode)) {
+            return;
+        }
+        const name = this.matchTheme(editorEl);
+        if (input.value !== name) {
+            input.value = name;
+        }
+    },
+
+    unbindCaret(state) {
+        if (state && state.onSel) {
+            document.removeEventListener('selectionchange', state.onSel);
+            if (state.boundEditor) {
+                state.boundEditor.removeEventListener('keyup', state.onSel);
+                state.boundEditor.removeEventListener('mouseup', state.onSel);
+            }
+            if (state.tiptap && typeof state.tiptap.off === 'function') {
+                state.tiptap.off('selectionUpdate', state.onSel);
+            }
+        }
+        if (state) {
+            state.onSel = null;
+            state.boundEditor = null;
+            state.tiptap = null;
+        }
+    },
+
+    bindCaret(state, editorEl, input) {
+        if (!editorEl || !input) {
+            return;
+        }
+        if (state.boundEditor === editorEl && state.onSel) {
+            return;
+        }
+        this.unbindCaret(state);
+        const onSel = () => this.syncThemeDisplay(editorEl, input);
+        document.addEventListener('selectionchange', onSel);
+        editorEl.addEventListener('keyup', onSel);
+        editorEl.addEventListener('mouseup', onSel);
+        const api = this.findEditorApi(editorEl);
+        if (api.editor && typeof api.editor.on === 'function') {
+            api.editor.on('selectionUpdate', onSel);
+            state.tiptap = api.editor;
+        }
+        state.onSel = onSel;
+        state.boundEditor = editorEl;
+        onSel();
     },
 
     isTiptapEditor(obj) {
@@ -571,7 +809,7 @@ const plugin = {
             if (marked) {
                 this.flash(input, true);
                 Logger.log('applied ' + preset.name);
-                input.value = '';
+                input.value = preset.name;
             } else {
                 this.flash(input, false);
                 Logger.warn('theme apply failed — marks not set');
@@ -644,7 +882,7 @@ const plugin = {
         }
         this.flash(input, true);
         Logger.log('applied ' + preset.name);
-        input.value = '';
+        input.value = preset.name;
     },
 
     injectPicker(state, toolbar, editor) {
@@ -701,6 +939,7 @@ const plugin = {
         });
 
         wrap.append(input, list);
+        this.bindCaret(state, editor, input);
         const exportBtn = toolbar.querySelector(`[${EXPORT_MARKER}="1"]`);
         if (exportBtn) {
             toolbar.insertBefore(wrap, exportBtn);
@@ -725,16 +964,23 @@ const plugin = {
                 Logger.debug('theme presets removed (editor closed)');
                 state.activationLogged = false;
             }
+            this.unbindCaret(state);
             return;
         }
         const injected = this.injectPicker(state, toolbar, editor);
-        if ((injected || toolbar.querySelector(`[${WRAP_MARKER}="1"]`)) && !state.activationLogged) {
+        const wrap = toolbar.querySelector(`[${WRAP_MARKER}="1"]`);
+        const input = wrap ? wrap.querySelector('input') : null;
+        if (input) {
+            this.bindCaret(state, editor, input);
+        }
+        if ((injected || wrap) && !state.activationLogged) {
             Logger.log('theme presets added');
             state.activationLogged = true;
         }
     },
 
     destroy(state) {
+        this.unbindCaret(state);
         const wrap = document.querySelector(`[${WRAP_MARKER}="1"]`);
         if (wrap) {
             wrap.remove();

--- a/plugins/archetypes/qa-comp-use/main/fos-iframe-autoconnect.js
+++ b/plugins/archetypes/qa-comp-use/main/fos-iframe-autoconnect.js
@@ -5,8 +5,8 @@ const plugin = {
     id: 'qaCompUseFosIframeAutoconnect',
     name: 'FOS Viewport Resize',
     description:
-        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again',
-    _version: '1.1',
+        'Resizes the embedded FOS environment to the viewport. Autoconnects the instance and open-in-new-tab URL; reconnects when the tab is focused again unless the environment pane is hidden',
+    _version: '1.2',
     enabledByDefault: true,
     phase: 'mutation',
     initialState: {
@@ -20,7 +20,8 @@ const plugin = {
         visibilityInstalled: false,
         wasHidden: false,
         desktopUnsub: null,
-        reloadTimer: null
+        reloadTimer: null,
+        pendingFocusReconnect: false
     },
 
     onMutation(state) {

--- a/plugins/libs/fos-iframe-autoconnect.js
+++ b/plugins/libs/fos-iframe-autoconnect.js
@@ -30,6 +30,7 @@ const FosIframeAutoconnectApi = {
                 state.patchedLogged = false;
                 state.waitingFosLogged = false;
                 state.waitingIframeLogged = false;
+                state.pendingFocusReconnect = false;
             } else if (!state.waitingIframeLogged) {
                 state.waitingIframeLogged = true;
                 Logger.debug('waiting for env iframe');
@@ -54,6 +55,9 @@ const FosIframeAutoconnectApi = {
         state.waitingFosLogged = false;
         this._patchIframeSrc(state, iframe);
         this._replaceOpenTabButton(state, iframe);
+        if (state.pendingFocusReconnect && !this._isEnvPanelCollapsed(iframe)) {
+            this._reconnectIframe(state);
+        }
     },
 
     _ensureDesktopSubscription(state) {
@@ -195,11 +199,21 @@ const FosIframeAutoconnectApi = {
         }
     },
 
+    _isEnvPanelCollapsed(iframe) {
+        return !!(iframe && iframe.closest('[data-panel][data-fleet-collapsed="true"]'));
+    },
+
     _reconnectIframe(state) {
         const iframe = this._findEnvIframe();
         if (!iframe || !iframe.isConnected) {
             return;
         }
+        if (this._isEnvPanelCollapsed(iframe)) {
+            state.pendingFocusReconnect = true;
+            Logger.debug('skipped FOS iframe reconnect; environment pane collapsed');
+            return;
+        }
+        state.pendingFocusReconnect = false;
         const instanceId = this._instanceIdFromIframe(iframe);
         if (!instanceId || !this._isFosDesktop(instanceId)) {
             return;
@@ -346,8 +360,8 @@ const plugin = {
     id: 'fosIframeAutoconnectLib',
     name: 'FOS Viewport Resize (library)',
     description:
-        'Resizes embedded FOS environments to the viewport. Autoconnects instances and open-in-new-tab URLs; reconnects on tab focus',
-    _version: '1.1',
+        'Resizes embedded FOS environments to the viewport. Autoconnects instances and open-in-new-tab URLs; reconnects on tab focus unless the environment pane is hidden',
+    _version: '1.2',
     phase: 'core',
     enabledByDefault: true,
     initialState: { registered: false },

--- a/plugins/libs/toggle-main-panels.js
+++ b/plugins/libs/toggle-main-panels.js
@@ -1,0 +1,569 @@
+// ============= toggle-main-panels.js (library) =============
+// Hide/Unhide toggles in each main pane header; CSS-only collapse with mutual exclusivity.
+
+const STYLE_ID = 'fleet-toggle-main-panels';
+const TOGGLE_MARKER = 'data-fleet-pane-toggle';
+const SLIVER_MARKER = 'data-fleet-pane-sliver';
+const SLOT_MARKER = 'data-fleet-pane-toggle-slot';
+const COLLAPSED_STRIP_WIDTH = '2.75rem';
+const ENV_IFRAME_HOST = /\.env\.[^.]+(?:\.[^.]+)*\.fleetai\.com$/;
+
+const ToggleMainPanelsApi = {
+    id: 'toggleMainPanels',
+
+    run(state, options) {
+        const opts = options || {};
+        if (opts.pluginId) {
+            this.id = opts.pluginId;
+        }
+
+        this.ensureStyle(state);
+
+        const panels = this.getPanels();
+        if (!panels.left || !panels.right) {
+            if (state.hiddenPane) {
+                state.hiddenPane = null;
+                this.clearCollapsedMarkers(panels);
+            }
+            if (state.activationLogged) {
+                Logger.debug('main panels gone — idle');
+                state.activationLogged = false;
+            }
+            if (!state.missingLogged) {
+                Logger.debug('main panels not found yet');
+                state.missingLogged = true;
+            }
+            return;
+        }
+        state.missingLogged = false;
+
+        const leftToolbar = this.findPanelHeaderToolbar(panels.left, 'left');
+        const rightToolbar = this.findPanelHeaderToolbar(panels.right, 'right');
+        if (!leftToolbar || !rightToolbar) {
+            if (!state.headerMissingLogged) {
+                Logger.debug(
+                    `pane header toolbar not found (left=${!!leftToolbar}, right=${!!rightToolbar})`
+                );
+                state.headerMissingLogged = true;
+            }
+            return;
+        }
+        state.headerMissingLogged = false;
+
+        this.ensureToggleButton(state, 'left', leftToolbar, panels.left);
+        this.ensureToggleButton(state, 'right', rightToolbar, panels.right);
+        this.applyCollapsedState(state, panels);
+        this.relocateToggleButtons(state, panels);
+        this.updateButtonLabels(state);
+
+        if (!state.activationLogged) {
+            Logger.log('Hide/Unhide toggles attached to both main pane headers');
+            state.activationLogged = true;
+        }
+    },
+
+    getPanels() {
+        const qa = this._getQaPanels();
+        if (qa.left && qa.right) {
+            return qa;
+        }
+        return this._getSplitPanels();
+    },
+
+    _getQaPanels() {
+        const taskDetail = document.querySelector('[data-ui="qa-task-detail-panel"]');
+        if (!taskDetail) {
+            return { left: null, right: null, group: null };
+        }
+
+        const left = taskDetail.matches('[data-panel]') ? taskDetail : taskDetail.closest('[data-panel]');
+        if (!left || !left.parentElement) {
+            return { left: null, right: null, group: null };
+        }
+
+        const group =
+            left.closest('[data-ui="qa-task-card"]') ||
+            left.closest('[data-panel-group][data-panel-group-direction="horizontal"]') ||
+            left.parentElement;
+
+        let right = null;
+        for (const child of group.children) {
+            if (child !== left && child.hasAttribute('data-panel')) {
+                right = child;
+                break;
+            }
+        }
+
+        if (!right) {
+            const instanceTab = document.querySelector('[data-ui="qa-instance-tab"]');
+            if (instanceTab && group.contains(instanceTab)) {
+                for (const child of group.children) {
+                    if (child !== left && child.hasAttribute('data-panel') && child.contains(instanceTab)) {
+                        right = child;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return { left, right, group };
+    },
+
+    _getSplitPanels() {
+        const groups = document.querySelectorAll(
+            '[data-panel-group][data-panel-group-direction="horizontal"]'
+        );
+        let fallback = null;
+        for (const group of groups) {
+            const direct = [];
+            for (const child of group.children) {
+                if (child.hasAttribute('data-panel')) {
+                    direct.push(child);
+                }
+            }
+            if (direct.length !== 2) {
+                continue;
+            }
+            const candidate = { left: direct[0], right: direct[1], group };
+            if (this._groupContainsEnvIframe(group)) {
+                return candidate;
+            }
+            if (!fallback) {
+                fallback = candidate;
+            }
+        }
+        return fallback || { left: null, right: null, group: null };
+    },
+
+    _groupContainsEnvIframe(group) {
+        if (!group) {
+            return false;
+        }
+        const frames = group.querySelectorAll('iframe');
+        for (let i = 0; i < frames.length; i++) {
+            const raw = frames[i].src || frames[i].getAttribute('src') || '';
+            if (!raw) {
+                continue;
+            }
+            try {
+                if (ENV_IFRAME_HOST.test(new URL(raw, window.location.href).hostname)) {
+                    return true;
+                }
+            } catch (_e) {
+                /* ignore */
+            }
+        }
+        return false;
+    },
+
+    _hasBorderB(el) {
+        if (!el || !el.classList) {
+            return false;
+        }
+        for (const name of el.classList) {
+            if (name === 'border-b' || name.indexOf('border-b-') === 0) {
+                return true;
+            }
+        }
+        return false;
+    },
+
+    findPanelHeaderToolbar(panel, side) {
+        if (!panel) {
+            return null;
+        }
+
+        let header = null;
+        if (side === 'right') {
+            const tab = panel.querySelector('[data-ui="qa-instance-tab"], [data-ui="qa-verifier-tab"]');
+            header = tab ? tab.closest('div.h-9.border-b') : null;
+        }
+        if (!header) {
+            header = panel.querySelector('div.h-9.border-b');
+        }
+        if (header) {
+            const rows = header.querySelectorAll('div.flex');
+            for (const row of rows) {
+                if (row.classList.contains('items-center') && row.classList.contains('justify-between')) {
+                    return row;
+                }
+            }
+
+            return (
+                header.querySelector('div.flex.items-center.justify-between') ||
+                header.querySelector('div.flex.w-full.items-center.justify-between') ||
+                header.querySelector('div.flex.items-center.justify-between.w-full') ||
+                header.querySelector('div.flex.w-full.items-center') ||
+                header.querySelector('div.flex.items-center') ||
+                header
+            );
+        }
+
+        const candidates = panel.querySelectorAll('div.flex');
+        for (const el of candidates) {
+            if (!el.classList.contains('items-center')) {
+                continue;
+            }
+            if (!this._hasBorderB(el)) {
+                continue;
+            }
+            return el;
+        }
+        return null;
+    },
+
+    findNativeGradingToggle(toolbar) {
+        if (!toolbar) {
+            return null;
+        }
+
+        for (const btn of toolbar.querySelectorAll('button')) {
+            if (btn.hasAttribute(TOGGLE_MARKER)) {
+                continue;
+            }
+            if (btn.closest('[' + SLOT_MARKER + '="true"][data-fleet-plugin="' + this.id + '"]')) {
+                continue;
+            }
+            const text = (btn.textContent || '').replace(/\s+/g, ' ').trim();
+            if (text === 'Hide Grading' || text === 'Show Grading') {
+                return btn;
+            }
+        }
+        return null;
+    },
+
+    ensureToggleSlot(toolbar) {
+        let slot = toolbar.querySelector('[' + SLOT_MARKER + '="true"][data-fleet-plugin="' + this.id + '"]');
+        if (!slot) {
+            slot = document.createElement('div');
+            slot.setAttribute(SLOT_MARKER, 'true');
+            slot.setAttribute('data-fleet-plugin', this.id);
+            toolbar.appendChild(slot);
+        }
+        slot.className = 'flex flex-1 items-center justify-end min-w-0 gap-2';
+        return slot;
+    },
+
+    placeToggleInToolbar(btn, side, toolbar) {
+        if (side === 'left') {
+            if (!btn.classList.contains('ml-auto')) {
+                btn.classList.add('ml-auto');
+            }
+            if (btn.parentElement !== toolbar || btn !== toolbar.lastElementChild) {
+                toolbar.appendChild(btn);
+            }
+            return;
+        }
+
+        btn.classList.remove('ml-auto');
+
+        const slot = this.ensureToggleSlot(toolbar);
+        if (btn.parentElement !== slot) {
+            slot.appendChild(btn);
+        }
+
+        const gradingBtn = this.findNativeGradingToggle(toolbar);
+        if (gradingBtn) {
+            if (slot.nextElementSibling !== gradingBtn) {
+                toolbar.insertBefore(slot, gradingBtn);
+            }
+            return;
+        }
+
+        if (slot.parentElement !== toolbar || slot !== toolbar.lastElementChild) {
+            toolbar.appendChild(slot);
+        }
+    },
+
+    ensureStyle(state) {
+        if (state.styleInjected || document.getElementById(STYLE_ID)) {
+            state.styleInjected = true;
+            return;
+        }
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.setAttribute('data-fleet-plugin', this.id);
+        style.textContent = [
+            '[data-panel][data-fleet-collapsed="true"] {',
+            '  flex: 0 0 ' + COLLAPSED_STRIP_WIDTH + ' !important;',
+            '  min-width: ' + COLLAPSED_STRIP_WIDTH + ' !important;',
+            '  max-width: ' + COLLAPSED_STRIP_WIDTH + ' !important;',
+            '  width: ' + COLLAPSED_STRIP_WIDTH + ' !important;',
+            '  overflow: hidden !important;',
+            '}',
+            '[data-panel][data-fleet-collapsed="true"] > *:not([' + SLIVER_MARKER + '="true"]) {',
+            '  display: none !important;',
+            '}',
+            '[' + SLIVER_MARKER + '="true"] {',
+            '  display: none;',
+            '}',
+            '[data-panel][data-fleet-collapsed="true"] > [' + SLIVER_MARKER + '="true"] {',
+            '  display: flex !important;',
+            '  flex-direction: column !important;',
+            '  align-items: center !important;',
+            '  justify-content: flex-start !important;',
+            '  width: 100% !important;',
+            '  height: 100% !important;',
+            '  min-height: 100% !important;',
+            '  padding: 0.35rem 0.15rem !important;',
+            '  box-sizing: border-box !important;',
+            '  background: var(--background, #fff) !important;',
+            '  border-right: 1px solid var(--border, #e5e5e5) !important;',
+            '}',
+            '[data-panel][data-fleet-collapsed="true"] [' + SLIVER_MARKER + '="true"] [' + TOGGLE_MARKER + '="true"] {',
+            '  writing-mode: vertical-rl !important;',
+            '  text-orientation: mixed !important;',
+            '  white-space: nowrap !important;',
+            '  height: auto !important;',
+            '  min-height: 3.5rem !important;',
+            '  padding: 0.5rem 0.25rem !important;',
+            '}',
+            '[data-panel-group][data-fleet-has-collapsed] > [data-panel]:not([data-fleet-collapsed="true"]) {',
+            '  flex: 1 1 auto !important;',
+            '  min-width: 0 !important;',
+            '  max-width: none !important;',
+            '}',
+            '[data-panel-group][data-fleet-has-collapsed] > [data-resize-handle][data-panel-group-direction="horizontal"] {',
+            '  display: none !important;',
+            '  flex: 0 0 0 !important;',
+            '  width: 0 !important;',
+            '  min-width: 0 !important;',
+            '  overflow: hidden !important;',
+            '  pointer-events: none !important;',
+            '}'
+        ].join('\n');
+        document.head.appendChild(style);
+        CleanupRegistry.registerElement(style);
+        state.styleInjected = true;
+    },
+
+    toggleButtonSelector(side) {
+        return (
+            '[' +
+            TOGGLE_MARKER +
+            '="true"][data-fleet-pane="' +
+            side +
+            '"][data-fleet-plugin="' +
+            this.id +
+            '"]'
+        );
+    },
+
+    findToggleButtons(panel, side) {
+        if (!panel) {
+            return [];
+        }
+        return Array.from(panel.querySelectorAll(this.toggleButtonSelector(side)));
+    },
+
+    findToggleButton(panel, side) {
+        return this.findToggleButtons(panel, side)[0] || null;
+    },
+
+    dedupeToggleButtons(panel, side) {
+        const buttons = this.findToggleButtons(panel, side);
+        if (buttons.length <= 1) {
+            return buttons[0] || null;
+        }
+        const keep = buttons[0];
+        for (let i = 1; i < buttons.length; i++) {
+            buttons[i].remove();
+        }
+        Logger.debug(`removed ${buttons.length - 1} duplicate Hide/Unhide button(s) on ${side}`);
+        return keep;
+    },
+
+    bindToggleButton(btn, side, state) {
+        btn.onclick = (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            this.onToggleClick(side, state);
+        };
+    },
+
+    markPaneHeader(toolbar) {
+        if (!toolbar) {
+            return;
+        }
+        let header = toolbar;
+        if (!this._hasBorderB(toolbar)) {
+            header =
+                toolbar.closest('div.h-9.border-b') ||
+                toolbar.closest('div.border-b') ||
+                toolbar;
+        }
+        header.setAttribute('data-fleet-pane-header', 'true');
+    },
+
+    ensureToggleButton(state, side, toolbar, panel) {
+        this.markPaneHeader(toolbar);
+
+        let btn = this.dedupeToggleButtons(panel || toolbar.closest('[data-panel]'), side);
+        if (btn && btn.getAttribute('data-fleet-plugin') !== this.id) {
+            btn.remove();
+            btn = null;
+        }
+        if (!btn) {
+            btn = document.createElement('button');
+            btn.type = 'button';
+            btn.setAttribute(TOGGLE_MARKER, 'true');
+            btn.setAttribute('data-fleet-pane', side);
+            btn.setAttribute('data-fleet-plugin', this.id);
+            btn.setAttribute('data-slot', 'button');
+            btn.className =
+                'inline-flex items-center justify-center whitespace-nowrap rounded-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 transition-colors hover:bg-accent hover:text-accent-foreground h-7 text-xs pl-2 pr-2 py-1 text-muted-foreground shrink-0';
+        }
+
+        this.bindToggleButton(btn, side, state);
+        btn._fleetToolbar = toolbar;
+
+        const collapsed = state.hiddenPane === side;
+        if (!collapsed) {
+            this.placeToggleInToolbar(btn, side, toolbar);
+        }
+    },
+
+    ensureCollapseSliver(panel) {
+        let sliver = panel.querySelector('[' + SLIVER_MARKER + '="true"][data-fleet-plugin="' + this.id + '"]');
+        if (!sliver) {
+            sliver = document.createElement('div');
+            sliver.setAttribute(SLIVER_MARKER, 'true');
+            sliver.setAttribute('data-fleet-plugin', this.id);
+            panel.insertBefore(sliver, panel.firstChild);
+        }
+        return sliver;
+    },
+
+    relocateToggleButtons(state, panels) {
+        ['left', 'right'].forEach((side) => {
+            const panel = side === 'left' ? panels.left : panels.right;
+            if (!panel) {
+                return;
+            }
+
+            const toolbar = this.findPanelHeaderToolbar(panel, side);
+            const btn = this.dedupeToggleButtons(panel, side);
+            if (!btn) {
+                return;
+            }
+
+            if (toolbar) {
+                btn._fleetToolbar = toolbar;
+            }
+
+            const collapsed = state.hiddenPane === side;
+            const sliver = panel.querySelector('[' + SLIVER_MARKER + '="true"][data-fleet-plugin="' + this.id + '"]');
+
+            if (collapsed) {
+                const targetSliver = this.ensureCollapseSliver(panel);
+                if (btn.parentElement !== targetSliver) {
+                    targetSliver.appendChild(btn);
+                }
+            } else if (toolbar) {
+                this.placeToggleInToolbar(btn, side, toolbar);
+            }
+
+            if (!collapsed && sliver && !sliver.contains(btn)) {
+                sliver.remove();
+            }
+        });
+    },
+
+    onToggleClick(side, state) {
+        const prev = state.hiddenPane;
+        if (state.hiddenPane === side) {
+            state.hiddenPane = null;
+            Logger.log('shown both panes');
+        } else {
+            state.hiddenPane = side;
+            const paneName = side === 'left' ? 'task detail' : 'environment';
+            if (prev && prev !== side) {
+                Logger.log(`hidden ${paneName} pane (replaced ${prev})`);
+            } else {
+                Logger.log(`hidden ${paneName} pane`);
+            }
+        }
+        const panels = this.getPanels();
+        this.applyCollapsedState(state, panels);
+        this.relocateToggleButtons(state, panels);
+        this.dedupeToggleButtons(panels.left, 'left');
+        this.dedupeToggleButtons(panels.right, 'right');
+        this.updateButtonLabels(state);
+    },
+
+    applyCollapsedState(state, panels) {
+        const left = panels.left;
+        const right = panels.right;
+        const group = panels.group;
+
+        if (left) {
+            left.removeAttribute('data-fleet-collapsed');
+        }
+        if (right) {
+            right.removeAttribute('data-fleet-collapsed');
+        }
+
+        if (state.hiddenPane === 'left' && left) {
+            left.setAttribute('data-fleet-collapsed', 'true');
+        } else if (state.hiddenPane === 'right' && right) {
+            right.setAttribute('data-fleet-collapsed', 'true');
+        }
+
+        if (group) {
+            if (state.hiddenPane) {
+                group.setAttribute('data-fleet-has-collapsed', 'true');
+            } else {
+                group.removeAttribute('data-fleet-has-collapsed');
+            }
+        }
+    },
+
+    clearCollapsedMarkers(panels) {
+        if (panels.left) {
+            panels.left.removeAttribute('data-fleet-collapsed');
+        }
+        if (panels.right) {
+            panels.right.removeAttribute('data-fleet-collapsed');
+        }
+        if (panels.group) {
+            panels.group.removeAttribute('data-fleet-has-collapsed');
+        }
+    },
+
+    updateButtonLabels(state) {
+        document.querySelectorAll('[' + TOGGLE_MARKER + '="true"][data-fleet-plugin="' + this.id + '"]').forEach((btn) => {
+            const side = btn.getAttribute('data-fleet-pane');
+            const collapsed = state.hiddenPane === side;
+            const paneName = side === 'left' ? 'task detail' : 'environment';
+            btn.textContent = collapsed ? 'Unhide' : 'Hide Panel';
+            btn.title = collapsed ? 'Show the ' + paneName + ' pane' : 'Hide the ' + paneName + ' pane';
+        });
+    }
+};
+
+const plugin = {
+    id: 'toggleMainPanelsLib',
+    name: 'Toggle Main Panels (library)',
+    description:
+        'Shared Hide/Unhide for the two main panes (task detail or environment); the other pane expands to full width',
+    _version: '1.11',
+    phase: 'core',
+    enabledByDefault: true,
+    initialState: { registered: false },
+
+    init(state) {
+        Context.toggleMainPanels = {
+            run: (s, options) => {
+                const impl = Object.create(ToggleMainPanelsApi);
+                if (options && options.pluginId) {
+                    impl.id = options.pluginId;
+                }
+                return ToggleMainPanelsApi.run.call(impl, s, options);
+            }
+        };
+        if (!state.registered) {
+            Logger.log('module registered (Context.toggleMainPanels)');
+            state.registered = true;
+        }
+    }
+};


### PR DESCRIPTION
## Summary

Adds a Guidelines page with Markdown export and named text theme presets on the editor toolbar, and brings Hide/Unhide for the main computer-use panes to creation and revision. Collapsing the environment pane no longer reloads the FOS iframe when you return to the tab; reconnect runs once the pane is shown again.

## Changes

- New **Guidelines** archetype (`work/guidelines`) for the list and editor.
- **Export Guideline Markdown** places a download control on the TipTap edit toolbar. The file uses the guideline title and keeps headings, lists, tables, links, code, and line breaks; callouts become blockquotes.
- **Guideline Theme Presets** adds a compact Theme field after Redo. Named recipes (Title, Section, Subsection, FAQ, and mark-only styles) apply heading/block type together with color and emphasis. The field shows the matching preset as the caret moves, and the editor selection stays visible while the menu is open.
- **Toggle Main Panels** is now a shared library. QA still finds the task-detail panel; creation and revision use the two-pane split (task/notes vs environment). Hide/Unhide collapses one pane to a sliver and expands the other to full width.
- FOS iframe autoconnect skips reconnect while the environment pane is collapsed, then reconnects when that pane is shown again.

## New plugins

| Plugin | Page | Description |
| --- | --- | --- |
| `export-markdown.js` | Guidelines | Download the open guideline as a Markdown file from the edit toolbar |
| `theme-presets.js` | Guidelines | Apply named text themes from the edit toolbar |
| `toggle-main-panels.js` | Computer Use creation and revision | Hide or unhide either main pane; the other expands to full width (already on QA Computer Use) |
